### PR TITLE
Adds a flag ProductTemplate indicating that product names may need remapping

### DIFF
--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/ProductTemplate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/ProductTemplate.swift
@@ -10,9 +10,11 @@ import Foundation
 struct ProductTemplate: Codable {
   var eventName: String
   var products: [ProductItem]
+  var unlimitedProducts: Bool = true
 
   enum CodingKeys: String, CodingKey {
     case eventName = "event_name"
     case products
+    case unlimitedProducts = "unlimited_products"
   }
 }

--- a/Tests/SuperwallKitTests/Paywall/View Controller/Web View/Templating/TemplateLogicTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/Web View/Templating/TemplateLogicTests.swift
@@ -76,6 +76,7 @@ final class TemplateLogicTests: XCTestCase {
 
     // MARK: Then
     XCTAssertEqual(jsonArray[0]["event_name"], "products")
+    XCTAssertEqual(jsonArray[0]["unlimited_products"], true)
     XCTAssertEqual(jsonArray[0]["products"][0]["productId"].stringValue, products.first!.id)
     XCTAssertEqual(jsonArray[0]["products"][0]["product"].stringValue, products.first!.name)
     XCTAssertEqual(jsonArray[0]["products"].count, 1)
@@ -136,6 +137,7 @@ final class TemplateLogicTests: XCTestCase {
 
     // MARK: Then
     XCTAssertEqual(jsonArray[0]["event_name"], "products")
+    XCTAssertEqual(jsonArray[0]["unlimited_products"], true)
     XCTAssertEqual(jsonArray[0]["products"][0]["productId"].stringValue, productItems.first!.id)
     XCTAssertEqual(jsonArray[0]["products"][0]["product"].stringValue, productItems.first!.name.description)
     XCTAssertEqual(jsonArray[0]["products"].count, 1)
@@ -208,6 +210,7 @@ final class TemplateLogicTests: XCTestCase {
 
     // MARK: Then
     XCTAssertEqual(jsonArray[0]["event_name"], "products")
+    XCTAssertEqual(jsonArray[0]["unlimited_products"], true)
     XCTAssertEqual(jsonArray[0]["products"][0]["productId"].stringValue, products.first!.id)
     XCTAssertEqual(jsonArray[0]["products"][0]["product"].stringValue, products.first!.name)
     XCTAssertEqual(jsonArray[0]["products"][1]["productId"].stringValue, products[1].id)
@@ -286,6 +289,7 @@ final class TemplateLogicTests: XCTestCase {
 
     // MARK: Then
     XCTAssertEqual(jsonArray[0]["event_name"], "products")
+    XCTAssertEqual(jsonArray[0]["unlimited_products"], true)
     XCTAssertEqual(jsonArray[0]["products"][0]["productId"].stringValue, products.first!.id)
     XCTAssertEqual(jsonArray[0]["products"][0]["product"].stringValue, products.first!.name)
     XCTAssertEqual(jsonArray[0]["products"][1]["productId"].stringValue, products[1].id)


### PR DESCRIPTION
## Changes in this pull request

- Adds `unlimited_products` flag on the TemplateProducts message

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
