### PR TITLE
feature/cache-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 3.9.0
+
+- If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 300ms to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
+- When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
+- When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
+
 ## 3.8.0
 
 ### Enhancements

--- a/Examples/SwiftUI/Superwall-SwiftUI/Superwall_SwiftUI-Products.storekit
+++ b/Examples/SwiftUI/Superwall-SwiftUI/Superwall_SwiftUI-Products.storekit
@@ -1,4 +1,14 @@
 {
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
   "identifier" : "88130D01",
   "nonRenewingSubscriptions" : [
 
@@ -97,13 +107,16 @@
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "sw_8999_yr",
           "subscriptionGroupID" : "49A58F4B",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         }
       ]
     }
   ],
   "version" : {
-    "major" : 3,
+    "major" : 4,
     "minor" : 0
   }
 }

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -194,12 +194,6 @@ enum InternalSuperwallEvent {
     func getSuperwallParameters() async -> [String: Any] { [:] }
   }
 
-  struct ConfigRefresh: TrackableSuperwallEvent {
-    let superwallEvent: SuperwallEvent = .configRefresh
-    var audienceFilterParams: [String: Any] = [:]
-    func getSuperwallParameters() async -> [String: Any] { [:] }
-  }
-
   struct ConfigAttributes: TrackableSuperwallEvent {
     let superwallEvent: SuperwallEvent = .configAttributes
     let options: SuperwallOptions
@@ -727,6 +721,41 @@ enum InternalSuperwallEvent {
       }
       params += await paywallInfo.eventParams()
       return params
+    }
+  }
+
+  enum ConfigCacheStatus: String {
+    case cached = "CACHED"
+    case notCached = "NOT_CACHED"
+  }
+
+  struct ConfigRefresh: TrackableSuperwallEvent {
+    let superwallEvent: SuperwallEvent = .configRefresh
+    let buildId: String
+    let retryCount: Int
+    let cacheStatus: ConfigCacheStatus
+    let fetchDuration: TimeInterval
+    var audienceFilterParams: [String: Any] = [:]
+
+    func getSuperwallParameters() async -> [String: Any] {
+      return [
+        "config_build_id": buildId,
+        "retry_count": retryCount,
+        "cache_status": cacheStatus.rawValue,
+        "fetch_duration": fetchDuration
+      ]
+    }
+  }
+
+  struct ConfigFail: TrackableSuperwallEvent {
+    let superwallEvent: SuperwallEvent = .configFail
+    let message: String
+    var audienceFilterParams: [String: Any] = [:]
+
+    func getSuperwallParameters() async -> [String: Any] {
+      return [
+        "error_message": message
+      ]
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
@@ -182,6 +182,9 @@ public enum SuperwallEvent {
   /// When all the experiment assignments are confirmed by calling ``Superwall/confirmAllAssignments()``.
   case confirmAllAssignments
 
+  /// When the Superwall configuration fails to be retrieved.
+  case configFail
+
   var canImplicitlyTriggerPaywall: Bool {
     switch self {
     case .appInstall,
@@ -321,6 +324,8 @@ extension SuperwallEvent {
       return .init(objcEvent: .configAttributes)
     case .confirmAllAssignments:
       return .init(objcEvent: .confirmAllAssignments)
+    case .configFail:
+      return .init(objcEvent: .configFail)
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
@@ -169,6 +169,9 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// When all the experiment assignments are confirmed by calling ``Superwall/confirmAllAssignments()``.
   case confirmAllAssignments
 
+  /// When the Superwall configuration fails to be retrieved.
+  case configFail
+
   public init(event: SuperwallEvent) {
     self = event.backingData.objcEvent
   }
@@ -273,6 +276,8 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "config_attributes"
     case .confirmAllAssignments:
       return "confirm_all_assignments"
+    case .configFail:
+      return "config_fail"
     }
   }
 }

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -167,11 +167,12 @@ class ConfigManager {
       }
       let fetchDuration = Date().timeIntervalSince(startAt)
 
+      let cacheStatus: InternalSuperwallEvent.ConfigCacheStatus = isUsingCachedConfig ? .cached : .notCached
       Task {
         let configRefresh = InternalSuperwallEvent.ConfigRefresh(
           buildId: config.buildId,
           retryCount: configRetryCount,
-          cacheStatus: isUsingCachedConfig ? .cached : .notCached,
+          cacheStatus: cacheStatus,
           fetchDuration: fetchDuration
         )
         await Superwall.shared.track(configRefresh)
@@ -197,13 +198,13 @@ class ConfigManager {
       Task {
         await preloadPaywalls()
       }
-      Task {
-        if isUsingCachedGeoInfo {
+      if isUsingCachedGeoInfo {
+        Task {
           await deviceHelper.getGeoInfo()
         }
       }
-      Task {
-        if isUsingCachedConfig {
+      if isUsingCachedConfig {
+        Task {
           await refreshConfiguration()
         }
       }

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Yusuf Tör on 22/06/2022.
 //
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length function_body_length file_length
 
 import UIKit
 import Combine
@@ -88,7 +88,11 @@ class ConfigManager {
     }
 
     do {
-      let newConfig = try await network.getConfig()
+      let startAt = Date()
+      let newConfig = try await network.getConfig { [weak self] attempt in
+        self?.configRetryCount = attempt
+      }
+      let fetchDuration = Date().timeIntervalSince(startAt)
 
       // Remove all paywalls and paywall vcs that have either been removed or changed.
       let removedOrChangedPaywallIds = ConfigLogic.getRemovedOrChangedPaywallIds(
@@ -99,7 +103,14 @@ class ConfigManager {
 
       await processConfig(newConfig, isFirstTime: false)
       configState.send(.retrieved(newConfig))
-      await Superwall.shared.track(InternalSuperwallEvent.ConfigRefresh())
+
+      let configRefresh = InternalSuperwallEvent.ConfigRefresh(
+        buildId: newConfig.buildId,
+        retryCount: configRetryCount,
+        cacheStatus: .notCached,
+        fetchDuration: fetchDuration
+      )
+      await Superwall.shared.track(configRefresh)
       Task { await preloadPaywalls() }
     } catch {
       Logger.debug(
@@ -116,13 +127,63 @@ class ConfigManager {
     do {
       _ = await factory.loadPurchasedProducts()
 
-      async let configRequest = network.getConfig { [weak self] attempt in
-        self?.configRetryCount = attempt
-        self?.configState.send(.retrying)
-      }
-      async let geoRequest: Void = deviceHelper.getGeoInfo()
+      let config: Config
+      var isUsingCachedConfig = false
+      var isUsingCachedGeoInfo = false
 
-      let (config, _) = try await (configRequest, geoRequest)
+      let startAt = Date()
+
+      // If config is cached, get config from the network but timeout after 300ms
+      // and default to the cached version. Then, refresh in the background.
+      if let cachedConfig = storage.get(LatestConfig.self),
+        cachedConfig.featureFlags.enableConfigRefresh {
+        let getConfigTask = Task {
+          try await network.getConfig(maxRetry: 0)
+        }
+
+        let timer = Timer(
+          timeInterval: 0.3,
+          repeats: false
+        ) { _ in
+          getConfigTask.cancel()
+        }
+        RunLoop.main.add(timer, forMode: .default)
+
+        do {
+          config = try await getConfigTask.value
+        } catch {
+          isUsingCachedConfig = true
+          config = cachedConfig
+        }
+
+        // Got config, cancel the timer.
+        timer.invalidate()
+      } else {
+        // Otherwise wait to get config
+        config = try await network.getConfig { [weak self] attempt in
+          self?.configRetryCount = attempt
+          self?.configState.send(.retrying)
+        }
+      }
+      let fetchDuration = Date().timeIntervalSince(startAt)
+
+      Task {
+        let configRefresh = InternalSuperwallEvent.ConfigRefresh(
+          buildId: config.buildId,
+          retryCount: configRetryCount,
+          cacheStatus: isUsingCachedConfig ? .cached : .notCached,
+          fetchDuration: fetchDuration
+        )
+        await Superwall.shared.track(configRefresh)
+      }
+
+      if let cachedGeoInfo = storage.get(LatestGeoInfo.self),
+        config.featureFlags.enableConfigRefresh {
+        deviceHelper.geoInfo = cachedGeoInfo
+        isUsingCachedGeoInfo = true
+      } else {
+        await deviceHelper.getGeoInfo()
+      }
 
       let deviceAttributes = await factory.makeSessionDeviceAttributes()
       await Superwall.shared.track(
@@ -133,9 +194,27 @@ class ConfigManager {
 
       configState.send(.retrieved(config))
 
-      Task { await preloadPaywalls() }
+      Task {
+        await preloadPaywalls()
+      }
+      Task {
+        if isUsingCachedGeoInfo {
+          await deviceHelper.getGeoInfo()
+        }
+      }
+      Task {
+        if isUsingCachedConfig {
+          await refreshConfiguration()
+        }
+      }
     } catch {
       configState.send(completion: .failure(error))
+
+      let configFallback = InternalSuperwallEvent.ConfigFail(
+        message: error.localizedDescription
+      )
+      await Superwall.shared.track(configFallback)
+
       Logger.debug(
         logLevel: .error,
         scope: .superwallCore,
@@ -151,6 +230,7 @@ class ConfigManager {
     isFirstTime: Bool
   ) async {
     storage.save(config.featureFlags.disableVerboseEvents, forType: DisableVerboseEvents.self)
+    storage.save(config, forType: LatestConfig.self)
     triggersByEventName = ConfigLogic.getTriggersByEventName(from: config.triggers)
     choosePaywallVariants(from: config.triggers)
     if isFirstTime {
@@ -211,9 +291,7 @@ class ConfigManager {
         )
       }
 
-      if Superwall.shared.options.paywalls.shouldPreload {
-        Task { await preloadAllPaywalls() }
-      }
+      Task { await preloadPaywalls() }
     } catch {
       Logger.debug(
         logLevel: .error,
@@ -287,38 +365,39 @@ class ConfigManager {
 
   /// Preloads paywalls referenced by triggers.
   func preloadAllPaywalls() async {
-    guard currentPreloadingTask == nil else {
-      return
-    }
-    currentPreloadingTask = Task {
-      guard let config = try? await configState
+    currentPreloadingTask = Task { [weak self, currentPreloadingTask] in
+      guard let self = self else {
+        return
+      }
+      // Wait until the previous task is finished before continuing.
+      await currentPreloadingTask?.value
+
+      guard let config = try? await self.configState
         .compactMap({ $0.getConfig() })
         .throwableAsync() else {
         return
       }
       let expressionEvaluator = ExpressionEvaluator(
-        storage: storage,
-        factory: factory
+        storage: self.storage,
+        factory: self.factory
       )
       let triggers = ConfigLogic.filterTriggers(
         config.triggers,
         removing: config.preloadingDisabled
       )
-      let confirmedAssignments = storage.getConfirmedAssignments()
+      let confirmedAssignments = self.storage.getConfirmedAssignments()
       var paywallIds = await ConfigLogic.getAllActiveTreatmentPaywallIds(
         fromTriggers: triggers,
         confirmedAssignments: confirmedAssignments,
-        unconfirmedAssignments: unconfirmedAssignments,
+        unconfirmedAssignments: self.unconfirmedAssignments,
         expressionEvaluator: expressionEvaluator
       )
       // Do not preload the presented paywall. This is because if config refreshes, we
       // don't want to refresh the presented paywall until it's dismissed and presented again.
-      if let presentedPaywallId = await paywallManager.presentedViewController?.paywall.identifier {
+      if let presentedPaywallId = await self.paywallManager.presentedViewController?.paywall.identifier {
         paywallIds.remove(presentedPaywallId)
       }
-      await preloadPaywalls(withIdentifiers: paywallIds)
-
-      currentPreloadingTask = nil
+      await self.preloadPaywalls(withIdentifiers: paywallIds)
     }
   }
 

--- a/Sources/SuperwallKit/Config/Models/ComputedPropertyRequest.swift
+++ b/Sources/SuperwallKit/Config/Models/ComputedPropertyRequest.swift
@@ -10,10 +10,10 @@ import Foundation
 /// A request to compute a device property associated with an event at runtime.
 @objc(SWKComputedPropertyRequest)
 @objcMembers
-public final class ComputedPropertyRequest: NSObject, Decodable {
+public final class ComputedPropertyRequest: NSObject, Codable {
   /// The type of device property to compute.
   @objc(SWKComputedPropertyRequestType)
-  public enum ComputedPropertyRequestType: Int, Decodable {
+  public enum ComputedPropertyRequestType: Int, Codable {
     /// The number of minutes since the event occurred.
     case minutesSince
 
@@ -106,6 +106,26 @@ public final class ComputedPropertyRequest: NSObject, Decodable {
           )
         )
       }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      let rawValue: String
+
+      switch self {
+      case .minutesSince:
+        rawValue = CodingKeys.minutesSince.rawValue
+      case .hoursSince:
+        rawValue = CodingKeys.hoursSince.rawValue
+      case .daysSince:
+        rawValue = CodingKeys.daysSince.rawValue
+      case .monthsSince:
+        rawValue = CodingKeys.monthsSince.rawValue
+      case .yearsSince:
+        rawValue = CodingKeys.yearsSince.rawValue
+      }
+
+      try container.encode(rawValue)
     }
   }
 

--- a/Sources/SuperwallKit/Config/Models/Config.swift
+++ b/Sources/SuperwallKit/Config/Models/Config.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct Config: Decodable {
-  let buildId: String
+struct Config: Codable {
+  var buildId: String
   var triggers: Set<Trigger>
   var paywalls: [Paywall]
   var logLevel: Int
@@ -49,6 +49,22 @@ struct Config: Decodable {
 
     let localization = try values.decode(LocalizationConfig.self, forKey: .localization)
     locales = Set(localization.locales.map { $0.locale })
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(buildId, forKey: .buildId)
+    try container.encode(triggers, forKey: .triggers)
+    try container.encode(paywalls, forKey: .paywalls)
+    try container.encode(logLevel, forKey: .logLevel)
+    try container.encode(appSessionTimeout, forKey: .appSessionTimeout)
+    try container.encode(preloadingDisabled, forKey: .preloadingDisabled)
+
+    let localizationConfig = LocalizationConfig(locales: locales.map { LocalizationConfig.LocaleConfig(locale: $0) })
+    try container.encode(localizationConfig, forKey: .localization)
+
+    try featureFlags.encode(to: encoder)
   }
 
   init(

--- a/Sources/SuperwallKit/Config/Models/FeatureFlags.swift
+++ b/Sources/SuperwallKit/Config/Models/FeatureFlags.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct RawFeatureFlag: Decodable {
+struct RawFeatureFlag: Codable {
   let key: String
   let enabled: Bool
 }
 
-struct FeatureFlags: Decodable {
+struct FeatureFlags: Codable {
   var enableSessionEvents: Bool
   var enableExpressionParameters: Bool
   var enableUserIdSeed: Bool
@@ -45,6 +45,25 @@ struct FeatureFlags: Decodable {
     enableMultiplePaywallUrls = rawFeatureFlags.value(forKey: "enable_multiple_paywall_urls", default: false)
     enableConfigRefresh = rawFeatureFlags.value(forKey: "enable_config_refresh", default: false)
     enableTextInteraction = rawFeatureFlags.value(forKey: "enable_text_interaction", default: false)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    let rawFeatureFlags = [
+      RawFeatureFlag(key: "enable_session_events", enabled: enableSessionEvents),
+      RawFeatureFlag(key: "enable_expression_params", enabled: enableExpressionParameters),
+      RawFeatureFlag(key: "enable_userid_seed", enabled: enableUserIdSeed),
+      RawFeatureFlag(key: "disable_verbose_events", enabled: disableVerboseEvents),
+      RawFeatureFlag(key: "enable_suppresses_incremental_rendering", enabled: enableSuppressesIncrementalRendering),
+      RawFeatureFlag(key: "enable_throttle_scheduling_policy", enabled: enableThrottleSchedulingPolicy),
+      RawFeatureFlag(key: "enable_none_scheduling_policy", enabled: enableNoneSchedulingPolicy),
+      RawFeatureFlag(key: "enable_multiple_paywall_urls", enabled: enableMultiplePaywallUrls),
+      RawFeatureFlag(key: "enable_config_refresh", enabled: enableConfigRefresh),
+      RawFeatureFlag(key: "enable_text_interaction", enabled: enableTextInteraction)
+    ]
+
+    try container.encode(rawFeatureFlags, forKey: .toggles)
   }
 
   init(

--- a/Sources/SuperwallKit/Config/Models/LocalizationConfig.swift
+++ b/Sources/SuperwallKit/Config/Models/LocalizationConfig.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct LocalizationConfig: Decodable {
-  struct LocaleConfig: Decodable {
+struct LocalizationConfig: Codable {
+  struct LocaleConfig: Codable {
     var locale: String
   }
 

--- a/Sources/SuperwallKit/Config/Models/OnDeviceCaching.swift
+++ b/Sources/SuperwallKit/Config/Models/OnDeviceCaching.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An enum whose cases indicate whether caching of the paywall is enabled or not.
-enum OnDeviceCaching: Decodable {
+enum OnDeviceCaching: Codable {
   case enabled
   case disabled
 
@@ -27,5 +27,19 @@ enum OnDeviceCaching: Decodable {
     case .disabled:
       self = .disabled
     }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let rawValue: String
+    switch self {
+    case .enabled:
+      rawValue = CodingKeys.enabled.rawValue
+    case .disabled:
+      rawValue = CodingKeys.disabled.rawValue
+    }
+
+    try container.encode(rawValue)
   }
 }

--- a/Sources/SuperwallKit/Config/Models/Survey.swift
+++ b/Sources/SuperwallKit/Config/Models/Survey.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A survey attached to a paywall.
 @objc(SWKSurvey)
 @objcMembers
-final public class Survey: NSObject, Decodable {
+final public class Survey: NSObject, Codable {
   /// The id of the survey.
   public let id: String
 

--- a/Sources/SuperwallKit/Config/Models/SurveyOption.swift
+++ b/Sources/SuperwallKit/Config/Models/SurveyOption.swift
@@ -10,7 +10,7 @@ import Foundation
 /// An option to display in a paywall survey.
 @objc(SWKSurveyOption)
 @objcMembers
-final public class SurveyOption: NSObject, Decodable {
+final public class SurveyOption: NSObject, Codable {
   /// The id of the survey option.
   public let id: String
 

--- a/Sources/SuperwallKit/Config/Models/SurveyShowCondition.swift
+++ b/Sources/SuperwallKit/Config/Models/SurveyShowCondition.swift
@@ -10,7 +10,7 @@ import Foundation
 /// An enum whose cases indicate when a survey should
 /// show.
 @objc(SWKSurveyShowCondition)
-public enum SurveyShowCondition: Int, Decodable {
+public enum SurveyShowCondition: Int, Codable {
   /// Shows the survey when the user manually closes the paywall.
   case onManualClose
 
@@ -40,5 +40,19 @@ public enum SurveyShowCondition: Int, Decodable {
         )
       )
     }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let rawValue: String
+    switch self {
+    case .onManualClose:
+      rawValue = CodingKeys.onManualClose.rawValue
+    case .onPurchase:
+      rawValue = CodingKeys.onPurchase.rawValue
+    }
+
+    try container.encode(rawValue)
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
+++ b/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A local notification.
 @objc(SWKLocalNotification)
 @objcMembers
-public final class LocalNotification: NSObject, Decodable {
+public final class LocalNotification: NSObject, Codable {
   /// The type of the notification.
   public let type: LocalNotificationType
 
@@ -57,7 +57,7 @@ extension LocalNotification: Stubbable {
 
 /// The type of notification.
 @objc(SWKLocalNotificationType)
-public enum LocalNotificationType: Int, Decodable {
+public enum LocalNotificationType: Int, Codable {
   /// The notification will fire after a transaction.
   case trialStarted
 
@@ -81,5 +81,17 @@ public enum LocalNotificationType: Int, Decodable {
         )
       )
     }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let rawValue: String
+    switch self {
+    case .trialStarted:
+      rawValue = CodingKeys.trialStarted.rawValue
+    }
+
+    try container.encode(rawValue)
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -12,7 +12,7 @@ struct Paywalls: Decodable {
   var paywalls: [Paywall]
 }
 
-struct Paywall: Decodable {
+struct Paywall: Codable {
   /// The id of the paywall in the database.
   var databaseId: String
 
@@ -246,6 +246,63 @@ struct Paywall: Decodable {
 
     manifest = try values.decodeIfPresent(ArchiveManifest.self, forKey: .manifest)
   }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(databaseId, forKey: .id)
+    try container.encode(identifier, forKey: .identifier)
+    try container.encode(name, forKey: .name)
+    try container.encode(cacheKey, forKey: .cacheKey)
+    try container.encode(buildId, forKey: .buildId)
+    try container.encode(url, forKey: .url)
+    try container.encode(urlConfig, forKey: .urlConfig)
+    try container.encode(htmlSubstitutions, forKey: .htmlSubstitutions)
+
+    if !surveys.isEmpty {
+      try container.encode(surveys, forKey: .surveys)
+    }
+
+    try container.encode(presentation.style, forKey: .presentationStyle)
+    try container.encode(presentation.condition, forKey: .presentationCondition)
+    try container.encode(presentation.delay, forKey: .presentationDelay)
+
+    try container.encode(backgroundColorHex, forKey: .backgroundColorHex)
+
+    if let darkBackgroundColorHex = darkBackgroundColorHex {
+      try container.encode(darkBackgroundColorHex, forKey: .darkBackgroundColorHex)
+    }
+
+    if !productItems.isEmpty {
+      try container.encode(productItems, forKey: .productItems)
+    }
+
+    try container.encodeIfPresent(responseLoadingInfo.startAt, forKey: .responseLoadStartTime)
+    try container.encodeIfPresent(responseLoadingInfo.endAt, forKey: .responseLoadCompleteTime)
+    try container.encodeIfPresent(responseLoadingInfo.failAt, forKey: .responseLoadFailTime)
+
+    try container.encodeIfPresent(webviewLoadingInfo.startAt, forKey: .webViewLoadStartTime)
+    try container.encodeIfPresent(webviewLoadingInfo.endAt, forKey: .webViewLoadCompleteTime)
+    try container.encodeIfPresent(webviewLoadingInfo.failAt, forKey: .webViewLoadFailTime)
+
+    try container.encodeIfPresent(productsLoadingInfo.startAt, forKey: .productsLoadStartTime)
+    try container.encodeIfPresent(productsLoadingInfo.endAt, forKey: .productsLoadCompleteTime)
+    try container.encodeIfPresent(productsLoadingInfo.failAt, forKey: .productsLoadFailTime)
+
+    try container.encodeIfPresent(featureGating, forKey: .featureGating)
+    try container.encodeIfPresent(onDeviceCache, forKey: .onDeviceCache)
+
+    if !localNotifications.isEmpty {
+      try container.encode(localNotifications, forKey: .localNotifications)
+    }
+
+    if !computedPropertyRequests.isEmpty {
+      try container.encode(computedPropertyRequests, forKey: .computedPropertyRequests)
+    }
+
+    try container.encodeIfPresent(manifest, forKey: .manifest)
+  }
+
 
   private static func makeProducts(from productItems: [ProductItem]) -> [Product] {
     var output: [Product] = []

--- a/Sources/SuperwallKit/Models/Paywall/PaywallPresentationInfo.swift
+++ b/Sources/SuperwallKit/Models/Paywall/PaywallPresentationInfo.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Information about the presentation of the paywall.
 @objc(SWKPaywallPresentationInfo)
 @objcMembers
-public final class PaywallPresentationInfo: NSObject {
+public final class PaywallPresentationInfo: NSObject, Codable {
   /// The presentation style of the paywall.
   public let style: PaywallPresentationStyle
 

--- a/Sources/SuperwallKit/Models/Paywall/PaywallPresentationStyle.swift
+++ b/Sources/SuperwallKit/Models/Paywall/PaywallPresentationStyle.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Used to override the presentation style of the paywall set on the dashboard.
 @objc(SWKPaywallPresentationStyle)
-public enum PaywallPresentationStyle: Int, Decodable, Sendable {
+public enum PaywallPresentationStyle: Int, Codable, Sendable {
   /// A view presentation style that uses the modal presentation style `.pageSheet`.
   case modal
   /// A view presentation style in which the presented paywall slides up to cover the screen.
@@ -29,6 +29,7 @@ public enum PaywallPresentationStyle: Int, Decodable, Sendable {
     case fullscreenNoAnimation = "NO_ANIMATION"
     case push = "PUSH"
     case drawer = "DRAWER"
+    case none = "NONE"
   }
 
   public init(from decoder: Decoder) throws {
@@ -48,7 +49,31 @@ public enum PaywallPresentationStyle: Int, Decodable, Sendable {
       presentationStyle = .push
     case .drawer:
       presentationStyle = .drawer
+    case .none:
+      presentationStyle = .none
     }
     self = presentationStyle
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let internalPresentationStyle: InternalPresentationStyle
+    switch self {
+    case .modal:
+      internalPresentationStyle = .modal
+    case .fullscreen:
+      internalPresentationStyle = .fullscreen
+    case .fullscreenNoAnimation:
+      internalPresentationStyle = .fullscreenNoAnimation
+    case .push:
+      internalPresentationStyle = .push
+    case .drawer:
+      internalPresentationStyle = .drawer
+    case .none:
+      internalPresentationStyle = .none
+    }
+
+    try container.encode(internalPresentationStyle.rawValue)
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/PresentationCondition.swift
+++ b/Sources/SuperwallKit/Models/Paywall/PresentationCondition.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// The condition for when a paywall should present.
 @objc(SWKPresentationCondition)
-public enum PresentationCondition: Int, Decodable {
+public enum PresentationCondition: Int, Codable {
   /// The paywall will always present, regardless of subscription status.
   case always
 
@@ -33,5 +33,19 @@ public enum PresentationCondition: Int, Decodable {
     case nil:
       self = .checkUserSubscription
     }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let rawValue: String
+    switch self {
+    case .always:
+      rawValue = CodingKeys.always.rawValue
+    case .checkUserSubscription:
+      rawValue = CodingKeys.checkUserSubscription.rawValue
+    }
+
+    try container.encode(rawValue)
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/WebViewURLConfig.swift
+++ b/Sources/SuperwallKit/Models/Paywall/WebViewURLConfig.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct WebViewURLConfig: Decodable {
+struct WebViewURLConfig: Codable {
   let endpoints: [WebViewEndpoint]
   let maxAttempts: Int
 }
 
-struct WebViewEndpoint: Decodable, Equatable {
+struct WebViewEndpoint: Codable, Equatable {
   var url: URL
   let timeout: TimeInterval
   var percentage: Double
@@ -38,6 +38,13 @@ struct WebViewEndpoint: Decodable, Equatable {
     self.url = try container.decode(URL.self, forKey: .url)
     self.timeout = try container.decode(Milliseconds.self, forKey: .timeoutMs) * 1000
     self.percentage = try container.decode(Double.self, forKey: .percentage)
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(url, forKey: .url)
+    try container.encode(timeout / 1000, forKey: .timeoutMs)
+    try container.encode(percentage, forKey: .percentage)
   }
 }
 

--- a/Sources/SuperwallKit/Models/Product/ProductVariable.swift
+++ b/Sources/SuperwallKit/Models/Product/ProductVariable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ProductVariable: Encodable, Equatable {
+struct ProductVariable: Codable, Equatable {
   let name: String
   let attributes: JSON
 

--- a/Sources/SuperwallKit/Models/Triggers/RawExperiment.swift
+++ b/Sources/SuperwallKit/Models/Triggers/RawExperiment.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An experiment without a confirmed variant assignment.
-struct RawExperiment: Decodable, Hashable {
+struct RawExperiment: Codable, Hashable {
   /// The ID of the experiment
   var id: String
 

--- a/Sources/SuperwallKit/Models/Triggers/Trigger.swift
+++ b/Sources/SuperwallKit/Models/Triggers/Trigger.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Trigger: Decodable, Hashable {
+struct Trigger: Codable, Hashable {
   var eventName: String
   var rules: [TriggerRule]
 }

--- a/Sources/SuperwallKit/Models/Triggers/TriggerRuleOccurrence.swift
+++ b/Sources/SuperwallKit/Models/Triggers/TriggerRuleOccurrence.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-struct TriggerRuleOccurrence: Decodable, Hashable {
-  struct RawInterval: Decodable {
-    enum IntervalType: String, Decodable {
+struct TriggerRuleOccurrence: Codable, Hashable {
+  struct RawInterval: Codable {
+    enum IntervalType: String, Codable {
       case minutes = "MINUTES"
       case infinity = "INFINITY"
 
@@ -17,6 +17,11 @@ struct TriggerRuleOccurrence: Decodable, Hashable {
         let container = try decoder.singleValueContainer()
         let rawValue = try container.decode(RawValue.self)
         self = IntervalType(rawValue: rawValue) ?? .infinity
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
       }
     }
     let type: IntervalType
@@ -49,6 +54,22 @@ struct TriggerRuleOccurrence: Decodable, Hashable {
       self.interval = .minutes(minutes)
     } else {
       self.interval = .infinity
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(key, forKey: .key)
+    try container.encode(maxCount, forKey: .maxCount)
+
+    switch interval {
+    case .minutes(let minutes):
+      let rawInterval = RawInterval(type: .minutes, minutes: minutes)
+      try container.encode(rawInterval, forKey: .interval)
+    case .infinity:
+      let rawInterval = RawInterval(type: .infinity, minutes: nil)
+      try container.encode(rawInterval, forKey: .interval)
     }
   }
 

--- a/Sources/SuperwallKit/Models/Triggers/VariantOption.swift
+++ b/Sources/SuperwallKit/Models/Triggers/VariantOption.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct VariantOption: Decodable, Hashable {
+struct VariantOption: Codable, Hashable {
   var type: Experiment.Variant.VariantType
   var id: String
   var percentage: Int
@@ -26,6 +26,14 @@ struct VariantOption: Decodable, Hashable {
     id = try values.decode(String.self, forKey: .variantId)
     percentage = try values.decode(Int.self, forKey: .percentage)
     paywallId = try values.decodeIfPresent(String.self, forKey: .paywallIdentifier)
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(type, forKey: .variantType)
+    try container.encode(id, forKey: .variantId)
+    try container.encode(percentage, forKey: .percentage)
+    try container.encode(paywallId, forKey: .paywallIdentifier)
   }
 
   init(

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -25,7 +25,7 @@ class DeviceHelper {
     return Locale(identifier: preferredIdentifier).identifier
   }
 
-  private var geoInfo: GeoInfo?
+  var geoInfo: GeoInfo?
 
   let appInstalledAtString: String
 
@@ -542,5 +542,8 @@ class DeviceHelper {
 
   func getGeoInfo() async {
     geoInfo = await network.getGeoInfo()
+    if let geoInfo = geoInfo {
+      storage.save(geoInfo, forType: LatestGeoInfo.self)
+    }
   }
 }

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -210,11 +210,13 @@ extension Endpoint where Response == Paywalls {
 extension Endpoint where Response == Config {
   static func config(
     requestId: String,
+    maxRetry: Int?,
     factory: ApiFactory
   ) -> Self {
     let queryItems = [URLQueryItem(name: "pk", value: factory.storage.apiKey)]
 
     return Endpoint(
+      retryCount: maxRetry ?? 6,
       components: Components(
         host: .base,
         path: Api.version1 + "static_config",

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -125,6 +125,7 @@ class Network {
 
   func getConfig(
     injectedApplicationStatePublisher: (AnyPublisher<UIApplication.State, Never>)? = nil,
+    maxRetry: Int? = nil,
     isRetryingCallback: ((Int) -> Void)? = nil
   ) async throws -> Config {
     try await appInForeground(injectedApplicationStatePublisher)
@@ -132,7 +133,11 @@ class Network {
     do {
       let requestId = UUID().uuidString
       var config = try await urlSession.request(
-        .config(requestId: requestId, factory: factory),
+        .config(
+          requestId: requestId,
+          maxRetry: maxRetry,
+          factory: factory
+        ),
         isRetryingCallback: isRetryingCallback
       )
       config.requestId = requestId

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -268,8 +268,6 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   }
 
   func loadWebView() {
-    let url = paywall.url
-
     if paywall.webviewLoadingInfo.startAt == nil {
       paywall.webviewLoadingInfo.startAt = Date()
     }
@@ -447,7 +445,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
         self.exitButton.alpha = 0.0
 
         Task(priority: .utility) {
-          let trackedEvent = InternalSuperwallEvent.PaywallWebviewLoad(
+          let trackedEvent = await InternalSuperwallEvent.PaywallWebviewLoad(
             state: .timeout,
             paywallInfo: self.info
           )

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -152,3 +152,19 @@ enum DisableVerboseEvents: Storable {
   static var directory: SearchPathDirectory = .appSpecificDocuments
   typealias Value = Bool
 }
+
+enum LatestConfig: Storable {
+  static var key: String {
+    "store.config"
+  }
+  static var directory: SearchPathDirectory = .appSpecificDocuments
+  typealias Value = Config
+}
+
+enum LatestGeoInfo: Storable {
+  static var key: String {
+    "store.geoInfo"
+  }
+  static var directory: SearchPathDirectory = .appSpecificDocuments
+  typealias Value = GeoInfo
+}

--- a/Tests/SuperwallKitTests/Config/ConfigManagerTests.swift
+++ b/Tests/SuperwallKitTests/Config/ConfigManagerTests.swift
@@ -11,6 +11,33 @@ import XCTest
 
 @available(iOS 14.0, *)
 final class ConfigManagerTests: XCTestCase {
+  func test_refreshConfiguration() async {
+    let dependencyContainer = DependencyContainer()
+    let network = NetworkMock(factory: dependencyContainer)
+    let newConfig: Config = .stub()
+      .setting(\.buildId, to: "123")
+    network.configReturnValue = .success(newConfig)
+
+    let storage = StorageMock()
+    let configManager = ConfigManager(
+      options: SuperwallOptions(),
+      storeKitManager: dependencyContainer.storeKitManager,
+      storage: storage,
+      network: network,
+      paywallManager: dependencyContainer.paywallManager,
+      deviceHelper: dependencyContainer.deviceHelper,
+      factory: dependencyContainer
+    )
+
+    let oldConfig: Config = .stub()
+      .setting(\.buildId, to: "abc")
+    configManager.configState.send(.retrieved(oldConfig))
+
+    await configManager.refreshConfiguration()
+
+    XCTAssertEqual(configManager.config?.buildId, "123")
+  }
+
   // MARK: - Confirm Assignments
   func test_confirmAssignment() async {
     let experimentId = "abc"

--- a/Tests/SuperwallKitTests/Network/NetworkMock.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkMock.swift
@@ -23,6 +23,7 @@ final class NetworkMock: Network {
   @MainActor
   override func getConfig(
     injectedApplicationStatePublisher: (AnyPublisher<UIApplication.State, Never>)? = nil,
+    maxRetry: Int? = nil,
     isRetryingCallback: ((Int) -> Void)? = nil
   ) async throws -> Config {
     getConfigCalled = true


### PR DESCRIPTION
## Changes in this pull request

- If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 300ms to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
- When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
- When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
