### PR TITLE
feature/ad-attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
 - When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
 - Adds the `config_cached` capability.
+- Adds the `SuperwallOption` `collectAdServicesAttribution`. When set to `true`, this will get the app-download campaign attributes associated with Apple Search Ads and attach them to the user attributes. This happens once per user per install. Calling `Superwall.shared.reset()` will fetch the attributes again and attach them to the new user.
+- Adds`adServicesAttributionRequest_start`, `adServicesAttributionRequest_fail`, and `adServicesAttributionRequest_complete` events for the lifecycle of collecting AdServices attributes.
 
 ### Fixes
 

--- a/Sources/SuperwallKit/Analytics/Ad Attribution/AdServicesAttributes.swift
+++ b/Sources/SuperwallKit/Analytics/Ad Attribution/AdServicesAttributes.swift
@@ -1,0 +1,132 @@
+//
+//  File.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 25/09/2024.
+//
+
+import Foundation
+
+/// An object that holds the AdServices attribution variables.
+@objc(SWKAdServicesAttributes)
+@objcMembers
+public final class AdServicesAttributes: NSObject, Codable {
+  /// The attribution value. A value of true returns if a user clicks an Apple Search Ads
+  /// impression up to 30 days before your app download. If the API can’t find a
+  /// matching attribution record, the attribution value is false.
+  public let attribution: Bool
+
+  /// The identifier of the organization that owns the campaign.
+  ///
+  /// Your orgId is the same as your account in the Apple Search Ads UI.
+  public let orgId: Int
+
+  /// The unique identifier for the campaign.
+  public let campaignId: Int
+
+  /// The identifier representing the assignment relationship between an ad object and an ad group. This applies to devices running iOS 15.2 and later.
+  public let adGroupId: Int?
+
+  /// The country or region for the campaign.
+  public let countryOrRegion: String
+
+  /// The identifier for the keyword.
+  ///
+  /// Note, when you enable search match, the API doesn’t return keywordId in the attribution response.
+  public let keywordId: Int?
+
+  /// The identifier representing the assignment relationship between an ad object and an ad group.
+  ///
+  /// This applies to devices running iOS 15.2 and later.
+  public let adId: Int?
+
+  /// Added by SDK
+  public internal(set) var token = ""
+
+  /// An enum whose cases represent the type of ad conversion.
+  @objc(SWKConversionType)
+  public enum ConversionType: Int, CustomStringConvertible, Codable {
+    /// If the user downloaded the app for the first time.
+    case download
+
+    /// If the user redownloaded the app.
+    case redownload
+
+    public var description: String {
+      switch self {
+      case .download:
+        return "Download"
+      case .redownload:
+        return "Redownload"
+      }
+    }
+
+    // Custom decoding to handle strings
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let stringValue = try container.decode(String.self)
+
+      switch stringValue {
+      case ConversionType.download.description:
+        self = .download
+      case ConversionType.redownload.description:
+        self = .redownload
+      default:
+        throw DecodingError.dataCorruptedError(
+          in: container,
+          debugDescription: "Invalid conversion type"
+        )
+      }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encode(self.description)
+    }
+  }
+
+  /// The type of conversion is either `Download` or `Redownload`.
+  public let conversionType: ConversionType
+
+  /// Can't get this without permission.
+  // let clickDate: Date
+
+  // Coding keys for encoding and decoding
+  private enum CodingKeys: String, CodingKey {
+    case attribution
+    case orgId
+    case campaignId
+    case adGroupId
+    case countryOrRegion
+    case keywordId
+    case adId
+    case conversionType
+    case token
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(attribution, forKey: .attribution)
+    try container.encode(orgId, forKey: .orgId)
+    try container.encode(campaignId, forKey: .campaignId)
+    try container.encodeIfPresent(adGroupId, forKey: .adGroupId)
+    try container.encode(countryOrRegion, forKey: .countryOrRegion)
+    try container.encodeIfPresent(keywordId, forKey: .keywordId)
+    try container.encodeIfPresent(adId, forKey: .adId)
+    try container.encode(conversionType.description, forKey: .conversionType)
+    try container.encode(token, forKey: .token)
+  }
+
+  public required init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.attribution = try container.decode(Bool.self, forKey: .attribution)
+    self.orgId = try container.decode(Int.self, forKey: .orgId)
+    self.campaignId = try container.decode(Int.self, forKey: .campaignId)
+    self.adGroupId = try container.decodeIfPresent(Int.self, forKey: .adGroupId)
+    self.countryOrRegion = try container.decode(String.self, forKey: .countryOrRegion)
+    self.keywordId = try container.decodeIfPresent(Int.self, forKey: .keywordId)
+    self.adId = try container.decodeIfPresent(Int.self, forKey: .adId)
+    self.conversionType = try container.decode(ConversionType.self, forKey: .conversionType)
+    self.token = try container.decodeIfPresent(String.self, forKey: .token) ?? ""
+  }
+}

--- a/Sources/SuperwallKit/Analytics/Ad Attribution/AttributionFetcher.swift
+++ b/Sources/SuperwallKit/Analytics/Ad Attribution/AttributionFetcher.swift
@@ -1,0 +1,67 @@
+//
+//  File.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 23/09/2024.
+//
+
+import Foundation
+#if canImport(AdServices)
+import AdServices
+#endif
+
+final class AttributionFetcher {
+  // should match OS availability in https://developer.apple.com/documentation/ad_services
+  @available(iOS 14.3, tvOS 14.3, macOS 11.1, watchOS 6.2, macCatalyst 14.3, *)
+  var adServicesToken: String? {
+    get async throws {
+      #if canImport(AdServices)
+      return try await Task<String?, Error>.detached {
+        #if targetEnvironment(simulator)
+        return Self.simulatorAdServicesToken
+        #else
+        return try Self.realAdServicesToken
+        #endif
+      }.value
+      #else
+      Logger.debug(
+        logLevel: .warn,
+        scope: .analytics,
+        message: "Tried to fetch AdServices attribution token on device without AdServices support."
+      )
+      return nil
+      #endif
+    }
+  }
+
+  #if canImport(AdServices)
+  @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+  private static var realAdServicesToken: String? {
+    get throws {
+      return try AAAttribution.attributionToken()
+    }
+  }
+
+  #if targetEnvironment(simulator)
+  private static var simulatorAdServicesToken: String? {
+    #if DEBUG
+    if let mockToken = ProcessInfo.processInfo.environment["SUPERWALL_MOCK_AD_SERVICES_TOKEN"] {
+      Logger.debug(
+        logLevel: .warn,
+        scope: .analytics,
+        message: "AdServices: mocking token: \(mockToken) for tests."
+      )
+      return mockToken
+    }
+    #endif
+
+    Logger.debug(
+      logLevel: .warn,
+      scope: .analytics,
+      message: "AdServices attribution token is not available in the simulator."
+    )
+    return nil
+  }
+  #endif
+  #endif
+}

--- a/Sources/SuperwallKit/Analytics/Ad Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Ad Attribution/AttributionPoster.swift
@@ -1,0 +1,79 @@
+//
+//  File.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 23/09/2024.
+//
+
+import Foundation
+
+final class AttributionPoster {
+  private let attributionFetcher = AttributionFetcher()
+  private let collectAdServicesAttribution: Bool
+  private unowned let storage: Storage
+  private unowned let network: Network
+
+  private var adServicesTokenToPostIfNeeded: String? {
+    get async throws {
+      #if os(tvOS) || os(watchOS)
+      return nil
+      #else
+      guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
+        return nil
+      }
+
+      guard storage.get(AdServicesAttributesStorage.self) == nil else {
+        return nil
+      }
+
+      await Superwall.shared.track(InternalSuperwallEvent.AdServicesAttribution(state: .start))
+      return try await attributionFetcher.adServicesToken
+      #endif
+    }
+  }
+
+  init(
+    collectAdServicesAttribution: Bool,
+    network: Network,
+    storage: Storage
+  ) {
+    self.collectAdServicesAttribution = collectAdServicesAttribution
+    self.network = network
+    self.storage = storage
+  }
+
+  // Should match OS availability in https://developer.apple.com/documentation/ad_services
+  @available(iOS 14.3, tvOS 14.3, watchOS 6.2, macOS 11.1, macCatalyst 14.3, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  func getAdServicesAttributesIfNeeded() async {
+    do {
+      guard collectAdServicesAttribution else {
+        return
+      }
+      guard let attributionToken = try await adServicesTokenToPostIfNeeded else {
+        return
+      }
+
+      let attributes = try await network.getAttributes(from: attributionToken)
+      attributes.token = attributionToken
+
+      storage.save(attributes, forType: AdServicesAttributesStorage.self)
+
+      // Remove the token because it changes after 24hrs and will be stored
+      // in complete event anyway.
+      var attributesDict = attributes.dictionary(withSnakeCase: true) ?? [:]
+      attributesDict["token"] = nil
+
+      Superwall.shared.setUserAttributes(attributesDict)
+
+      await Superwall.shared.track(
+        InternalSuperwallEvent.AdServicesAttribution(state: .complete(attributes))
+      )
+    } catch {
+      await Superwall.shared.track(
+        InternalSuperwallEvent.AdServicesAttribution(state: .fail(error))
+      )
+    }
+  }
+}

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -758,4 +758,36 @@ enum InternalSuperwallEvent {
       ]
     }
   }
+
+  struct AdServicesAttribution: TrackableSuperwallEvent {
+    enum State {
+      case start
+      case fail(Error)
+      case complete(AdServicesAttributes)
+    }
+    let state: State
+
+    var superwallEvent: SuperwallEvent {
+      switch state {
+      case .start:
+        return .adServicesAttributionRequestStart
+      case .fail(let error):
+        return .adServicesAttributionRequestFail(error: error)
+      case .complete(let attributes):
+        return .adServicesAttributionRequestComplete(attributes: attributes)
+      }
+    }
+    let audienceFilterParams: [String: Any] = [:]
+
+    func getSuperwallParameters() async -> [String: Any] {
+      switch state {
+      case .start:
+        return [:]
+      case .fail(let error):
+        return ["error_message": error.localizedDescription]
+      case .complete(let attributes):
+        return attributes.dictionary(withSnakeCase: true) ?? [:]
+      }
+    }
+  }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
@@ -185,6 +185,15 @@ public enum SuperwallEvent {
   /// When the Superwall configuration fails to be retrieved.
   case configFail
 
+  /// When the AdServices attribution request starts.
+  case adServicesAttributionRequestStart
+
+  /// When the AdServices attribution request fails.
+  case adServicesAttributionRequestFail(error: Error)
+
+  /// When the AdServices attribution request finishes.
+  case adServicesAttributionRequestComplete(attributes: AdServicesAttributes)
+
   var canImplicitlyTriggerPaywall: Bool {
     switch self {
     case .appInstall,
@@ -326,6 +335,12 @@ extension SuperwallEvent {
       return .init(objcEvent: .confirmAllAssignments)
     case .configFail:
       return .init(objcEvent: .configFail)
+    case .adServicesAttributionRequestStart:
+      return .init(objcEvent: .adServicesAttributionRequestStart)
+    case .adServicesAttributionRequestFail:
+      return .init(objcEvent: .adServicesAttributionRequestFail)
+    case .adServicesAttributionRequestComplete:
+      return .init(objcEvent: .adServicesAttributionRequestComplete)
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
@@ -172,6 +172,15 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// When the Superwall configuration fails to be retrieved.
   case configFail
 
+  /// When the AdServices attribution request starts.
+  case adServicesAttributionRequestStart
+
+  /// When the AdServices attribution request fails.
+  case adServicesAttributionRequestFail
+
+  /// When the AdServices attribution request finishes.
+  case adServicesAttributionRequestComplete
+
   public init(event: SuperwallEvent) {
     self = event.backingData.objcEvent
   }
@@ -278,6 +287,12 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "confirm_all_assignments"
     case .configFail:
       return "config_fail"
+    case .adServicesAttributionRequestStart:
+      return "adServicesAttributionRequest_start"
+    case .adServicesAttributionRequestFail:
+      return "adServicesAttributionRequest_fail"
+    case .adServicesAttributionRequestComplete:
+      return "adServicesAttributionRequest_complete"
     }
   }
 }

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -143,12 +143,10 @@ class ConfigManager {
         if let cachedConfig = cachedConfig,
           enableConfigRefresh {
           do {
-            let result = try await self.fetchWithTimeout(
-              {
-                try await self.network.getConfig(maxRetry: 0)
-              },
-              timeout: timeout
-            )
+            let result = try await self.fetchWithTimeout({
+              try await self.network.getConfig(maxRetry: 0)
+            },
+            timeout: timeout)
             return (result, false)
           } catch {
             // Return the cached config and set isUsingCached to true
@@ -172,12 +170,10 @@ class ConfigManager {
         if let cachedGeoInfo = cachedGeoInfo,
           enableConfigRefresh {
           do {
-            let geoInfo = try await self.fetchWithTimeout(
-              {
-                try await self.network.getGeoInfo(maxRetry: 0)
-              },
-              timeout: timeout
-            )
+            let geoInfo = try await self.fetchWithTimeout({
+              try await self.network.getGeoInfo(maxRetry: 0)
+            },
+            timeout: timeout)
             self.deviceHelper.geoInfo = geoInfo
             return false
           } catch {
@@ -227,7 +223,6 @@ class ConfigManager {
           await refreshConfiguration()
         }
       }
-
     } catch {
       configState.send(completion: .failure(error))
 

--- a/Sources/SuperwallKit/Config/Models/ComputedPropertyRequest.swift
+++ b/Sources/SuperwallKit/Config/Models/ComputedPropertyRequest.swift
@@ -134,4 +134,22 @@ public final class ComputedPropertyRequest: NSObject, Codable {
 
   /// The name of the event used to compute the device property.
   public let eventName: String
+
+  enum CodingKeys: CodingKey {
+    case type
+    case eventName
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(type, forKey: .type)
+    try container.encode(eventName, forKey: .eventName)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    type = try container.decode(ComputedPropertyRequestType.self, forKey: .type)
+    eventName = try container.decode(String.self, forKey: .eventName)
+    super.init()
+  }
 }

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -107,6 +107,10 @@ public final class SuperwallOptions: NSObject, Encodable {
       "geo-api.superwall.com"
     }
 
+    var adServicesHost: String {
+      "api-adservices.apple.com"
+    }
+
     private enum CodingKeys: String, CodingKey {
       case networkEnvironment
       case customDomain
@@ -150,6 +154,11 @@ public final class SuperwallOptions: NSObject, Encodable {
   ///
   /// Set this to `true` to forward events from the Game Controller to the Paywall via ``Superwall/gamepadValueChanged(gamepad:element:)``.
   public var isGameControllerEnabled = false
+
+  /// Collects the `AdServices` attributes and attaches them to the user attributes.
+  ///
+  /// Defaults to `false`.
+  public var collectAdServicesAttribution = false
 
   /// Configuration for printing to the console.
   @objc(SWKLogging)

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -38,6 +38,7 @@ final class DependencyContainer {
   var productPurchaser: ProductPurchaserSK1!
   var receiptManager: ReceiptManager!
   var purchaseController: PurchaseController!
+  var attributionPoster: AttributionPoster!
   // swiftlint:enable implicitly_unwrapped_optional
   let productsFetcher = ProductsFetcherSK1()
   let paywallArchiveManager = PaywallArchiveManager()
@@ -51,7 +52,6 @@ final class DependencyContainer {
       delegate: productsFetcher,
       receiptDelegate: purchaseController as? ReceiptDelegate
     )
-
     storeKitManager = StoreKitManager(productsFetcher: productsFetcher)
     delegateAdapter = SuperwallDelegateAdapter()
     storage = Storage(factory: self)
@@ -69,7 +69,11 @@ final class DependencyContainer {
 
     let options = options ?? SuperwallOptions()
     api = Api(networkEnvironment: options.networkEnvironment)
-
+    attributionPoster = AttributionPoster(
+      collectAdServicesAttribution: options.collectAdServicesAttribution,
+      network: network,
+      storage: storage
+    )
     deviceHelper = DeviceHelper(
       api: api,
       storage: storage,

--- a/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
+++ b/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
@@ -84,8 +84,14 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``SuperwallOptions/Logging-swift.class``
 
 ### Helpers
+
 - ``togglePaywallSpinner(isHidden:)``
 - ``latestPaywallInfo``
 - ``presentedViewController``
 - ``userId``
 - ``isLoggedIn``
+
+### Apple AdServices Attribution
+
+- ``AdServicesAttributes``
+- ``SuperwallOptions/collectAdServicesAttribution``

--- a/Sources/SuperwallKit/Documentation.docc/SuperwallKit.md
+++ b/Sources/SuperwallKit/Documentation.docc/SuperwallKit.md
@@ -4,7 +4,7 @@ The client SDK for [Superwall](https://superwall.com), a service that lets you r
 
 ## Overview
 
-Superwall makes it easy to show paywalls in your app using UIKit or SwiftUI. If you haven't already, [sign up for a free Superwall account](https://superwall.com/sign-up). Configure the SDK with your API key and present our example paywall in response to a tracked event. When you're ready to use your own paywalls, head to the Superwall dashboard and use the paywall editor to configure them. Then, create a Campaign and define rules to determine when to show paywalls to users.
+Superwall makes it easy to show paywalls in your app using UIKit or SwiftUI. If you haven't already, [sign up for a free Superwall account](https://superwall.com/sign-up). Configure the SDK with your API key and present our example paywall in response to a registered event. When you're ready to use your own paywalls, head to the Superwall dashboard and use the paywall editor to configure them. Then, create a Campaign and define audiences to determine when to show paywalls to users.
 
 See our [docs](https://docs.superwall.com/docs) for more information.
 

--- a/Sources/SuperwallKit/Logger/LogScope.swift
+++ b/Sources/SuperwallKit/Logger/LogScope.swift
@@ -11,6 +11,7 @@ import Foundation
 @objc(SWKLogScope)
 public enum LogScope: Int, Encodable, Sendable, CustomStringConvertible {
   case localizationManager
+  case analytics
   case bounceButton
   case coreData
   case configManager
@@ -35,6 +36,8 @@ public enum LogScope: Int, Encodable, Sendable, CustomStringConvertible {
 
   public var description: String {
     switch self {
+    case .analytics:
+      return "analytics"
     case .localizationManager:
       return "localizationManager"
     case .bounceButton:

--- a/Sources/SuperwallKit/Network/API.swift
+++ b/Sources/SuperwallKit/Network/API.swift
@@ -11,6 +11,7 @@ enum EndpointHost {
   case base
   case collector
   case geo
+  case adServices
 }
 
 protocol ApiHostConfig {
@@ -23,12 +24,14 @@ struct Api {
   let base: Base
   let collector: Collector
   let geo: Geo
+  let adServices: AdServices
   static let version1 = "/api/v1/"
 
   init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
-    self.base = Base(networkEnvironment: networkEnvironment)
-    self.collector = Collector(networkEnvironment: networkEnvironment)
-    self.geo = Geo(networkEnvironment: networkEnvironment)
+    base = Base(networkEnvironment: networkEnvironment)
+    collector = Collector(networkEnvironment: networkEnvironment)
+    geo = Geo(networkEnvironment: networkEnvironment)
+    adServices = AdServices(networkEnvironment: networkEnvironment)
   }
 
   func getConfig(host: EndpointHost) -> ApiHostConfig {
@@ -39,66 +42,52 @@ struct Api {
       return collector
     case .geo:
       return geo
+    case .adServices:
+      return adServices
     }
   }
 
   struct Base: ApiHostConfig {
     private let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var port: Int? { return networkEnvironment.port }
+    var scheme: String { return networkEnvironment.scheme }
+    var host: String { return networkEnvironment.baseHost }
 
     init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
       self.networkEnvironment = networkEnvironment
-    }
-
-    var port: Int? {
-      return networkEnvironment.port
-    }
-
-    var scheme: String {
-      return networkEnvironment.scheme
-    }
-
-    var host: String {
-      return networkEnvironment.baseHost
     }
   }
 
   struct Collector: ApiHostConfig {
     private let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var port: Int? { return networkEnvironment.port }
+    var scheme: String { return networkEnvironment.scheme }
+    var host: String { return networkEnvironment.collectorHost }
 
     init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
       self.networkEnvironment = networkEnvironment
-    }
-
-    var port: Int? {
-      return networkEnvironment.port
-    }
-
-    var scheme: String {
-      return networkEnvironment.scheme
-    }
-
-    var host: String {
-      return networkEnvironment.collectorHost
     }
   }
 
   struct Geo: ApiHostConfig {
     private let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var port: Int? { return networkEnvironment.port }
+    var scheme: String { return networkEnvironment.scheme }
+    var host: String { return networkEnvironment.geoHost }
 
     init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
       self.networkEnvironment = networkEnvironment
     }
+  }
 
-    var port: Int? {
-      return networkEnvironment.port
-    }
+  struct AdServices: ApiHostConfig {
+    private let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var port: Int? { return networkEnvironment.port }
+    var scheme: String { return networkEnvironment.scheme }
+    var host: String { return networkEnvironment.adServicesHost }
 
-    var scheme: String {
-      return networkEnvironment.scheme
-    }
-
-    var host: String {
-      return networkEnvironment.geoHost
+    init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
+      self.networkEnvironment = networkEnvironment
     }
   }
 }

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Endpoint<Response: Decodable> {
+struct Endpoint<Kind: EndpointKind, Response: Decodable> {
   enum HttpMethod: String {
     case get = "GET"
     case post = "POST"
@@ -21,14 +21,15 @@ struct Endpoint<Response: Decodable> {
   }
 
   var retryCount = 6
+  var retryInterval: Seconds?
   var components: Components?
   var url: URL?
   var method: HttpMethod = .get
-  var requestId: String = UUID().uuidString
-  var isForDebugging = false
-  let factory: ApiFactory
 
-  func makeRequest() async -> URLRequest? {
+  func makeRequest(
+    with data: Kind.RequestData,
+    factory: ApiFactory
+  ) async -> URLRequest? {
     let url: URL
 
     if let components = components {
@@ -59,27 +60,16 @@ struct Endpoint<Response: Decodable> {
     if let bodyData = components?.bodyData {
       request.httpBody = bodyData
     }
-
-    let headers = await factory.makeHeaders(
-      fromRequest: request,
-      isForDebugging: isForDebugging,
-      requestId: requestId
-    )
-
-    for header in headers {
-      request.setValue(
-        header.value,
-        forHTTPHeaderField: header.key
-      )
-    }
-
+    await Kind.prepare(&request, with: data)
     return request
   }
 }
 
 // MARK: - EventsResponse
-extension Endpoint where Response == EventsResponse {
-  static func events(eventsRequest: EventsRequest, factory: ApiFactory) -> Self {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == EventsResponse {
+  static func events(eventsRequest: EventsRequest) -> Self {
     let bodyData = try? JSONEncoder.toSnakeCase.encode(eventsRequest)
 
     return Endpoint(
@@ -88,12 +78,11 @@ extension Endpoint where Response == EventsResponse {
         path: Api.version1 + "events",
         bodyData: bodyData
       ),
-      method: .post,
-      factory: factory
+      method: .post
     )
   }
 
-  static func sessionEvents(_ session: SessionEventsRequest, factory: ApiFactory) -> Self {
+  static func sessionEvents(_ session: SessionEventsRequest) -> Self {
     let bodyData = try? JSONEncoder.toSnakeCase.encode(session)
 
     return Endpoint(
@@ -102,33 +91,39 @@ extension Endpoint where Response == EventsResponse {
         path: Api.version1 + "session_events",
         bodyData: bodyData
       ),
-      method: .post,
-      factory: factory
+      method: .post
     )
   }
 }
 
 // MARK: - Paywall
-extension Endpoint where Response == Paywall {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == Paywall {
   static func paywall(
     withIdentifier identifier: String? = nil,
     fromEvent event: EventData? = nil,
     retryCount: Int,
-    factory: ApiFactory
+    appUserId: String?,
+    apiKey: String,
+    config: Config?,
+    locale: String
   ) -> Self {
-    let bodyData: Data?
+    var bodyData: Data?
 
     if let identifier = identifier {
       return paywall(
         byIdentifier: identifier,
         retryCount: retryCount,
-        factory: factory
+        apiKey: apiKey,
+        config: config,
+        locale: locale
       )
     } else if let event = event {
       let bodyDict = ["event": event.jsonData]
       bodyData = try? JSONEncoder.toSnakeCase.encode(bodyDict)
-    } else {
-      let body = PaywallRequestBody(appUserId: factory.identityManager.userId)
+    } else if let appUserId = appUserId {
+      let body = PaywallRequestBody(appUserId: appUserId)
       bodyData = try? JSONEncoder.toSnakeCase.encode(body)
     }
 
@@ -139,35 +134,36 @@ extension Endpoint where Response == Paywall {
         path: Api.version1 + "paywall",
         bodyData: bodyData
       ),
-      method: .post,
-      factory: factory
+      method: .post
     )
   }
 
   static private func paywall(
     byIdentifier identifier: String,
     retryCount: Int,
-    factory: ApiFactory
+    apiKey: String,
+    config: Config?,
+    locale: String
   ) -> Self {
     // WARNING: Do not modify anything about this request without considering our cache eviction code
     // we must know all the exact urls we need to invalidate so changing the order, inclusion, etc of any query
     // parameters will cause issues
-    var queryItems = [URLQueryItem(name: "pk", value: factory.storage.apiKey)]
+    var queryItems = [URLQueryItem(name: "pk", value: apiKey)]
 
     // In the config endpoint we return all the locales, this code will check if:
     // 1. The device locale (ex: en_US) exists in the locales list
     // 2. The shortend device locale (ex: en) exists in the locale list
     // If either exist (preferring the most specific) include the locale in the
     // the url as a query param.
-    if let config = factory.configManager.config {
-      if config.locales.contains(factory.deviceHelper.locale) {
+    if let config = config {
+      if config.locales.contains(locale) {
         let localeQuery = URLQueryItem(
           name: "locale",
-          value: factory.deviceHelper.locale
+          value: locale
         )
         queryItems.append(localeQuery)
       } else {
-        let shortLocale = factory.deviceHelper.locale.split(separator: "_")[0]
+        let shortLocale = locale.split(separator: "_")[0]
         if config.locales.contains(String(shortLocale)) {
           let localeQuery = URLQueryItem(
             name: "locale",
@@ -185,35 +181,35 @@ extension Endpoint where Response == Paywall {
         path: Api.version1 + "paywall/\(identifier)",
         queryItems: queryItems
       ),
-      method: .get,
-      factory: factory
+      method: .get
     )
   }
 }
 
 // MARK: - PaywallsResponse
-extension Endpoint where Response == Paywalls {
-  static func paywalls(factory: ApiFactory) -> Self {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == Paywalls {
+  static func paywalls() -> Self {
     return Endpoint(
       components: Components(
         host: .base,
         path: Api.version1 + "paywalls"
       ),
-      method: .get,
-      isForDebugging: true,
-      factory: factory
+      method: .get
     )
   }
 }
 
 // MARK: - ConfigResponse
-extension Endpoint where Response == Config {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == Config {
   static func config(
-    requestId: String,
     maxRetry: Int?,
-    factory: ApiFactory
+    apiKey: String
   ) -> Self {
-    let queryItems = [URLQueryItem(name: "pk", value: factory.storage.apiKey)]
+    let queryItems = [URLQueryItem(name: "pk", value: apiKey)]
 
     return Endpoint(
       retryCount: maxRetry ?? 6,
@@ -222,29 +218,27 @@ extension Endpoint where Response == Config {
         path: Api.version1 + "static_config",
         queryItems: queryItems
       ),
-      method: .get,
-      requestId: requestId,
-      factory: factory
+      method: .get
     )
   }
 }
 
 // MARK: - ConfirmedAssignmentResponse
-extension Endpoint where Response == ConfirmedAssignmentResponse {
-  static func assignments(factory: ApiFactory) -> Self {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == ConfirmedAssignmentResponse {
+  static func assignments() -> Self {
     return Endpoint(
       components: Components(
         host: .base,
         path: Api.version1 + "assignments"
       ),
-      method: .get,
-      factory: factory
+      method: .get
     )
   }
 
   static func confirmAssignments(
-    _ confirmableAssignments: AssignmentPostback,
-    factory: ApiFactory
+    _ confirmableAssignments: AssignmentPostback
   ) -> Self {
     let bodyData = try? JSONEncoder.toSnakeCase.encode(confirmableAssignments)
 
@@ -254,16 +248,16 @@ extension Endpoint where Response == ConfirmedAssignmentResponse {
         path: Api.version1 + "confirm_assignments",
         bodyData: bodyData
       ),
-      method: .post,
-      factory: factory
+      method: .post
     )
   }
 }
 
 // MARK: - GeoWrapper
-extension Endpoint where Response == GeoWrapper {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == GeoWrapper {
   static func geo(
-    factory: ApiFactory,
     maxRetry: Int?
   ) -> Self {
     return Endpoint(
@@ -272,8 +266,29 @@ extension Endpoint where Response == GeoWrapper {
         host: .geo,
         path: Api.version1 + "geo"
       ),
-      method: .get,
-      factory: factory
+      method: .get
+    )
+  }
+}
+
+// MARK: - AdServicesAttributes
+extension Endpoint where
+  Kind == EndpointKinds.AdServices,
+  Response == AdServicesAttributes {
+  static func adServicesAttribution(
+    token: String
+  ) -> Self {
+    let bodyData = Data(token.utf8)
+
+    return Endpoint(
+      retryCount: 3,
+      retryInterval: 5,
+      components: Components(
+        host: .adServices,
+        path: Api.version1,
+        bodyData: bodyData
+      ),
+      method: .post
     )
   }
 }

--- a/Sources/SuperwallKit/Network/EndpointKind.swift
+++ b/Sources/SuperwallKit/Network/EndpointKind.swift
@@ -1,0 +1,75 @@
+//
+//  EndpointKind.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 25/09/2024.
+//
+
+import Foundation
+
+protocol EndpointKind {
+  associatedtype RequestData
+  static var jsonDecoder: JSONDecoder { get }
+  static func prepare(
+    _ request: inout URLRequest,
+    with data: RequestData
+  ) async
+
+  static func makeDefaultComponents(
+    factory: ApiFactory,
+    host: EndpointHost
+  ) -> ApiHostConfig
+}
+
+extension EndpointKind {
+  static func makeDefaultComponents(
+    factory: ApiFactory,
+    host: EndpointHost
+  ) -> ApiHostConfig {
+    factory.makeDefaultComponents(host: host)
+  }
+}
+
+struct SuperwallRequestData {
+  let factory: ApiFactory
+  var requestId = UUID().uuidString
+  var isForDebugging = false
+}
+
+enum EndpointKinds {
+  enum Superwall: EndpointKind {
+    static var jsonDecoder = JSONDecoder.fromSnakeCase
+
+    static func prepare(
+      _ request: inout URLRequest,
+      with data: SuperwallRequestData
+    ) async {
+      let headers = await data.factory.makeHeaders(
+        fromRequest: request,
+        isForDebugging: data.isForDebugging,
+        requestId: data.requestId
+      )
+
+      for header in headers {
+        request.setValue(
+          header.value,
+          forHTTPHeaderField: header.key
+        )
+      }
+    }
+  }
+
+  enum AdServices: EndpointKind {
+    static var jsonDecoder = JSONDecoder()
+
+    static func prepare(
+      _ request: inout URLRequest,
+      with _: Void
+    ) async {
+      request.setValue(
+        "Content-Type",
+        forHTTPHeaderField: "text/plain"
+      )
+    }
+  }
+}

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yusuf Tör on 04/03/2022.
 //
+// swiftlint:disable type_body_length
 
 import Foundation
 import UIKit
@@ -15,10 +16,10 @@ class Network {
   private var applicationStateSubject: CurrentValueSubject<UIApplication.State, Never> = .init(.background)
 
   init(
-    urlSession: CustomURLSession = CustomURLSession(),
+    urlSession: CustomURLSession? = nil,
     factory: ApiFactory
   ) {
-    self.urlSession = urlSession
+    self.urlSession = urlSession ?? CustomURLSession(factory: factory)
     self.factory = factory
 
     Task { @MainActor [weak self] in
@@ -47,7 +48,10 @@ class Network {
 
   func sendEvents(events: EventsRequest) async {
     do {
-      let result = try await urlSession.request(.events(eventsRequest: events, factory: factory))
+      let result = try await urlSession.request(
+        .events(eventsRequest: events),
+        data: SuperwallRequestData(factory: factory)
+      )
       switch result.status {
       case .ok:
         break
@@ -81,8 +85,12 @@ class Network {
           withIdentifier: identifier,
           fromEvent: event,
           retryCount: retryCount,
-          factory: factory
-        )
+          appUserId: factory.identityManager.userId,
+          apiKey: factory.storage.apiKey,
+          config: factory.configManager.config,
+          locale: factory.deviceHelper.locale
+        ),
+        data: SuperwallRequestData(factory: factory)
       )
     } catch {
       if identifier == nil {
@@ -110,7 +118,13 @@ class Network {
 
   func getPaywalls() async throws -> [Paywall] {
     do {
-      let response = try await urlSession.request(.paywalls(factory: factory))
+      let response = try await urlSession.request(
+        .paywalls(),
+        data: SuperwallRequestData(
+          factory: factory,
+          isForDebugging: true
+        )
+      )
       return response.paywalls
     } catch {
       Logger.debug(
@@ -134,9 +148,12 @@ class Network {
       let requestId = UUID().uuidString
       var config = try await urlSession.request(
         .config(
-          requestId: requestId,
           maxRetry: maxRetry,
-          factory: factory
+          apiKey: factory.storage.apiKey
+        ),
+        data: SuperwallRequestData(
+          factory: factory,
+          requestId: requestId
         ),
         isRetryingCallback: isRetryingCallback
       )
@@ -173,7 +190,10 @@ class Network {
   ) async throws -> GeoInfo? {
     do {
       try await appInForeground(injectedApplicationStatePublisher)
-      let geoWrapper = try await urlSession.request(.geo(factory: factory, maxRetry: maxRetry))
+      let geoWrapper = try await urlSession.request(
+        .geo(maxRetry: maxRetry),
+        data: SuperwallRequestData(factory: factory)
+      )
       return geoWrapper.info
     } catch {
       Logger.debug(
@@ -188,7 +208,10 @@ class Network {
 
   func confirmAssignments(_ confirmableAssignments: AssignmentPostback) async {
     do {
-      try await urlSession.request(.confirmAssignments(confirmableAssignments, factory: factory))
+      try await urlSession.request(
+        .confirmAssignments(confirmableAssignments),
+        data: SuperwallRequestData(factory: factory)
+      )
     } catch {
       Logger.debug(
         logLevel: .error,
@@ -202,7 +225,10 @@ class Network {
 
   func getAssignments() async throws -> [Assignment] {
     do {
-      let result = try await urlSession.request(.assignments(factory: factory))
+      let result = try await urlSession.request(
+        .assignments(),
+        data: SuperwallRequestData(factory: factory)
+      )
       return result.assignments
     } catch {
       Logger.debug(
@@ -217,7 +243,10 @@ class Network {
 
   func sendSessionEvents(_ session: SessionEventsRequest) async {
     do {
-      let result = try await urlSession.request(.sessionEvents(session, factory: factory))
+      let result = try await urlSession.request(
+        .sessionEvents(session),
+        data: SuperwallRequestData(factory: factory)
+      )
       switch result.status {
       case .ok:
         break
@@ -237,6 +266,24 @@ class Network {
         info: ["payload": session],
         error: error
       )
+    }
+  }
+
+  func getAttributes(from token: String) async throws -> AdServicesAttributes {
+    do {
+      let result = try await urlSession.request(
+        .adServicesAttribution(token: token),
+        data: ()
+      )
+      return result
+    } catch {
+      Logger.debug(
+        logLevel: .error,
+        scope: .network,
+        message: "Request failed to get AdServices attributes",
+        error: error
+      )
+      throw error
     }
   }
 }

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -168,3 +168,11 @@ enum LatestGeoInfo: Storable {
   static var directory: SearchPathDirectory = .appSpecificDocuments
   typealias Value = GeoInfo
 }
+
+enum AdServicesAttributesStorage: Storable {
+  static var key: String {
+    "store.adServicesAttributes"
+  }
+  static var directory: SearchPathDirectory = .userSpecificDocuments
+  typealias Value = AdServicesAttributes
+}

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -254,6 +254,14 @@ public final class Superwall: NSObject, ObservableObject {
     // This is because the function isn't marked to run on the main thread,
     // therefore, we don't need to make this detached.
     Task {
+      Task {
+        #if os(iOS) || os(macOS) || VISION_OS
+        if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+          await dependencyContainer.attributionPoster.getAdServicesAttributesIfNeeded()
+        }
+        #endif
+      }
+
       dependencyContainer.storage.configure(apiKey: apiKey)
 
       dependencyContainer.storage.recordAppInstall(trackEvent: track)
@@ -625,6 +633,12 @@ public final class Superwall: NSObject, ObservableObject {
     dependencyContainer.configManager.reset()
     Task {
       await Superwall.shared.track(InternalSuperwallEvent.Reset())
+
+      #if os(iOS) || os(macOS) || VISION_OS
+      if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+        await dependencyContainer.attributionPoster.getAdServicesAttributesIfNeeded()
+      }
+      #endif
     }
   }
 }

--- a/Tests/SuperwallKitTests/Network/Custom URL Session/CustomURLSessionMock.swift
+++ b/Tests/SuperwallKitTests/Network/Custom URL Session/CustomURLSessionMock.swift
@@ -11,12 +11,12 @@ import Foundation
 final class CustomURLSessionMock: CustomURLSession {
   var didRequest = false
 
-  @discardableResult
-  override func request<Response>(
-    _ endpoint: Endpoint<Response>,
+  override func request<Kind, Response>(
+    _ endpoint: Endpoint<Kind, Response>,
+    data: Kind.RequestData,
     isRetryingCallback: ((Int) -> Void)? = nil
-  ) async throws -> Response {
+  ) async throws -> Response where Kind : EndpointKind, Response : Decodable {
     didRequest = true
-    return try await super.request(endpoint)
+    return try await super.request(endpoint, data: data, isRetryingCallback: isRetryingCallback)
   }
 }

--- a/Tests/SuperwallKitTests/Network/NetworkTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkTests.swift
@@ -31,7 +31,8 @@ final class NetworkTests: XCTestCase {
 
   // MARK: - Config
   func test_config_inBackground() async {
-    let urlSession = CustomURLSessionMock()
+    let dependencyContainer = DependencyContainer()
+    let urlSession = CustomURLSessionMock(factory: dependencyContainer)
     let publisher = CurrentValueSubject<UIApplication.State, Never>(.background)
       .eraseToAnyPublisher()
     let expectation = expectation(description: "config completed")
@@ -49,8 +50,8 @@ final class NetworkTests: XCTestCase {
   }
 
   func test_config_inForeground() async {
-    let urlSession = CustomURLSessionMock()
     let dependencyContainer = DependencyContainer()
+    let urlSession = CustomURLSessionMock(factory: dependencyContainer)
     let network = Network(urlSession: urlSession, factory: dependencyContainer)
     let publisher = CurrentValueSubject<UIApplication.State, Never>(.active)
       .eraseToAnyPublisher()
@@ -63,8 +64,8 @@ final class NetworkTests: XCTestCase {
   }
 
   func test_config_inBackgroundThenForeground() async {
-    let urlSession = CustomURLSessionMock()
     let dependencyContainer = DependencyContainer()
+    let urlSession = CustomURLSessionMock(factory: dependencyContainer)
     let network = Network(urlSession: urlSession, factory: dependencyContainer)
     let publisher = [UIApplication.State.background, UIApplication.State.active]
       .publisher


### PR DESCRIPTION
## Changes in this pull request

- Adds the `SuperwallOption` `collectAdServicesAttribution`. When set to `true`, this will get the app-download campaign attributes associated with Apple Search Ads and attach them to the user attributes. This happens once per user per install. Calling `Superwall.shared.reset()` will fetch the attributes again and attach them to the new user.
- Adds`adServicesAttributionRequest_start`, `adServicesAttributionRequest_fail`, and `adServicesAttributionRequest_complete` events for the lifecycle of collecting AdServices attributes.
- Fixes tests.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
