### PR TITLE
3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Adds `Superwall.shared.confirmAllAssignments()`, which confirms assignments for all placements and returns an array of all confirmed experiment assignments. Note that the assignments may be different when a placement is registered due to changes in user, placement, or device parameters used in audience filters.
+- Adds a published property `Superwall.shared.configurationStatus`, which replaces `isConfigured`. This is an enum which can either be `pending`, `configured`, or `failed`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
 - When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
 - Adds the `config_cached` capability.
+- Adds the `SuperwallOption` `collectAdServicesAttribution`. When set to `true`, this will get the app-download campaign attributes associated with Apple Search Ads and attach them to the user attributes. This happens once per user per install. Calling `Superwall.shared.reset()` will fetch the attributes again and attach them to the new user.
+- Adds`adServicesAttributionRequest_start`, `adServicesAttributionRequest_fail`, and `adServicesAttributionRequest_complete` events for the lifecycle of collecting AdServices attributes.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ## 3.9.0
 
-- If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 300ms to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
+- If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 1s to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
 - When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
 - When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
-## 3.7.5
+## 3.8.0
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ## 3.9.0
 
+### Enhancements
+
 - If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 1s to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
 - When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
 - When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
+
+### Fixes
+
+- Adds in missing `weak self` references inside task group closures.
 
 ## 3.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 1s to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
 - When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
 - When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
-- Adds the `config_cached` capability.
+- Adds the `config_caching` capability.
 - Adds the `SuperwallOption` `collectAdServicesAttribution`. When set to `true`, this will get the app-download campaign attributes associated with Apple Search Ads and attach them to the user attributes. This happens once per user per install. Calling `Superwall.shared.reset()` will fetch the attributes again and attach them to the new user.
 - Adds`adServicesAttributionRequest_start`, `adServicesAttributionRequest_fail`, and `adServicesAttributionRequest_complete` events for the lifecycle of collecting AdServices attributes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 1s to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
 - When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
 - When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
+- Adds the `config_cached` capability.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 3.9.0
+
+- If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 300ms to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
+- When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
+- When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
+
 ## 3.8.0
 
 ### Enhancements

--- a/Examples/SwiftUI/Superwall-SwiftUI/Superwall_SwiftUI-Products.storekit
+++ b/Examples/SwiftUI/Superwall-SwiftUI/Superwall_SwiftUI-Products.storekit
@@ -1,4 +1,14 @@
 {
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
   "identifier" : "88130D01",
   "nonRenewingSubscriptions" : [
 
@@ -97,13 +107,16 @@
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "sw_8999_yr",
           "subscriptionGroupID" : "49A58F4B",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         }
       ]
     }
   ],
   "version" : {
-    "major" : 3,
+    "major" : 4,
     "minor" : 0
   }
 }

--- a/Sources/SuperwallKit/Analytics/Ad Attribution/AdServicesAttributes.swift
+++ b/Sources/SuperwallKit/Analytics/Ad Attribution/AdServicesAttributes.swift
@@ -1,0 +1,132 @@
+//
+//  File.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 25/09/2024.
+//
+
+import Foundation
+
+/// An object that holds the AdServices attribution variables.
+@objc(SWKAdServicesAttributes)
+@objcMembers
+public final class AdServicesAttributes: NSObject, Codable {
+  /// The attribution value. A value of true returns if a user clicks an Apple Search Ads
+  /// impression up to 30 days before your app download. If the API can’t find a
+  /// matching attribution record, the attribution value is false.
+  public let attribution: Bool
+
+  /// The identifier of the organization that owns the campaign.
+  ///
+  /// Your orgId is the same as your account in the Apple Search Ads UI.
+  public let orgId: Int
+
+  /// The unique identifier for the campaign.
+  public let campaignId: Int
+
+  /// The identifier representing the assignment relationship between an ad object and an ad group. This applies to devices running iOS 15.2 and later.
+  public let adGroupId: Int?
+
+  /// The country or region for the campaign.
+  public let countryOrRegion: String
+
+  /// The identifier for the keyword.
+  ///
+  /// Note, when you enable search match, the API doesn’t return keywordId in the attribution response.
+  public let keywordId: Int?
+
+  /// The identifier representing the assignment relationship between an ad object and an ad group.
+  ///
+  /// This applies to devices running iOS 15.2 and later.
+  public let adId: Int?
+
+  /// Added by SDK
+  public internal(set) var token = ""
+
+  /// An enum whose cases represent the type of ad conversion.
+  @objc(SWKConversionType)
+  public enum ConversionType: Int, CustomStringConvertible, Codable {
+    /// If the user downloaded the app for the first time.
+    case download
+
+    /// If the user redownloaded the app.
+    case redownload
+
+    public var description: String {
+      switch self {
+      case .download:
+        return "Download"
+      case .redownload:
+        return "Redownload"
+      }
+    }
+
+    // Custom decoding to handle strings
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let stringValue = try container.decode(String.self)
+
+      switch stringValue {
+      case ConversionType.download.description:
+        self = .download
+      case ConversionType.redownload.description:
+        self = .redownload
+      default:
+        throw DecodingError.dataCorruptedError(
+          in: container,
+          debugDescription: "Invalid conversion type"
+        )
+      }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encode(self.description)
+    }
+  }
+
+  /// The type of conversion is either `Download` or `Redownload`.
+  public let conversionType: ConversionType
+
+  /// Can't get this without permission.
+  // let clickDate: Date
+
+  // Coding keys for encoding and decoding
+  private enum CodingKeys: String, CodingKey {
+    case attribution
+    case orgId
+    case campaignId
+    case adGroupId
+    case countryOrRegion
+    case keywordId
+    case adId
+    case conversionType
+    case token
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(attribution, forKey: .attribution)
+    try container.encode(orgId, forKey: .orgId)
+    try container.encode(campaignId, forKey: .campaignId)
+    try container.encodeIfPresent(adGroupId, forKey: .adGroupId)
+    try container.encode(countryOrRegion, forKey: .countryOrRegion)
+    try container.encodeIfPresent(keywordId, forKey: .keywordId)
+    try container.encodeIfPresent(adId, forKey: .adId)
+    try container.encode(conversionType.description, forKey: .conversionType)
+    try container.encode(token, forKey: .token)
+  }
+
+  public required init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.attribution = try container.decode(Bool.self, forKey: .attribution)
+    self.orgId = try container.decode(Int.self, forKey: .orgId)
+    self.campaignId = try container.decode(Int.self, forKey: .campaignId)
+    self.adGroupId = try container.decodeIfPresent(Int.self, forKey: .adGroupId)
+    self.countryOrRegion = try container.decode(String.self, forKey: .countryOrRegion)
+    self.keywordId = try container.decodeIfPresent(Int.self, forKey: .keywordId)
+    self.adId = try container.decodeIfPresent(Int.self, forKey: .adId)
+    self.conversionType = try container.decode(ConversionType.self, forKey: .conversionType)
+    self.token = try container.decodeIfPresent(String.self, forKey: .token) ?? ""
+  }
+}

--- a/Sources/SuperwallKit/Analytics/Ad Attribution/AttributionFetcher.swift
+++ b/Sources/SuperwallKit/Analytics/Ad Attribution/AttributionFetcher.swift
@@ -1,0 +1,67 @@
+//
+//  File.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 23/09/2024.
+//
+
+import Foundation
+#if canImport(AdServices)
+import AdServices
+#endif
+
+final class AttributionFetcher {
+  // should match OS availability in https://developer.apple.com/documentation/ad_services
+  @available(iOS 14.3, tvOS 14.3, macOS 11.1, watchOS 6.2, macCatalyst 14.3, *)
+  var adServicesToken: String? {
+    get async throws {
+      #if canImport(AdServices)
+      return try await Task<String?, Error>.detached {
+        #if targetEnvironment(simulator)
+        return Self.simulatorAdServicesToken
+        #else
+        return try Self.realAdServicesToken
+        #endif
+      }.value
+      #else
+      Logger.debug(
+        logLevel: .warn,
+        scope: .analytics,
+        message: "Tried to fetch AdServices attribution token on device without AdServices support."
+      )
+      return nil
+      #endif
+    }
+  }
+
+  #if canImport(AdServices)
+  @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+  private static var realAdServicesToken: String? {
+    get throws {
+      return try AAAttribution.attributionToken()
+    }
+  }
+
+  #if targetEnvironment(simulator)
+  private static var simulatorAdServicesToken: String? {
+    #if DEBUG
+    if let mockToken = ProcessInfo.processInfo.environment["SUPERWALL_MOCK_AD_SERVICES_TOKEN"] {
+      Logger.debug(
+        logLevel: .warn,
+        scope: .analytics,
+        message: "AdServices: mocking token: \(mockToken) for tests."
+      )
+      return mockToken
+    }
+    #endif
+
+    Logger.debug(
+      logLevel: .warn,
+      scope: .analytics,
+      message: "AdServices attribution token is not available in the simulator."
+    )
+    return nil
+  }
+  #endif
+  #endif
+}

--- a/Sources/SuperwallKit/Analytics/Ad Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Ad Attribution/AttributionPoster.swift
@@ -1,0 +1,79 @@
+//
+//  File.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 23/09/2024.
+//
+
+import Foundation
+
+final class AttributionPoster {
+  private let attributionFetcher = AttributionFetcher()
+  private let collectAdServicesAttribution: Bool
+  private unowned let storage: Storage
+  private unowned let network: Network
+
+  private var adServicesTokenToPostIfNeeded: String? {
+    get async throws {
+      #if os(tvOS) || os(watchOS)
+      return nil
+      #else
+      guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
+        return nil
+      }
+
+      guard storage.get(AdServicesAttributesStorage.self) == nil else {
+        return nil
+      }
+
+      await Superwall.shared.track(InternalSuperwallEvent.AdServicesAttribution(state: .start))
+      return try await attributionFetcher.adServicesToken
+      #endif
+    }
+  }
+
+  init(
+    collectAdServicesAttribution: Bool,
+    network: Network,
+    storage: Storage
+  ) {
+    self.collectAdServicesAttribution = collectAdServicesAttribution
+    self.network = network
+    self.storage = storage
+  }
+
+  // Should match OS availability in https://developer.apple.com/documentation/ad_services
+  @available(iOS 14.3, tvOS 14.3, watchOS 6.2, macOS 11.1, macCatalyst 14.3, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  func getAdServicesAttributesIfNeeded() async {
+    do {
+      guard collectAdServicesAttribution else {
+        return
+      }
+      guard let attributionToken = try await adServicesTokenToPostIfNeeded else {
+        return
+      }
+
+      let attributes = try await network.getAttributes(from: attributionToken)
+      attributes.token = attributionToken
+
+      storage.save(attributes, forType: AdServicesAttributesStorage.self)
+
+      // Remove the token because it changes after 24hrs and will be stored
+      // in complete event anyway.
+      var attributesDict = attributes.dictionary(withSnakeCase: true) ?? [:]
+      attributesDict["token"] = nil
+
+      Superwall.shared.setUserAttributes(attributesDict)
+
+      await Superwall.shared.track(
+        InternalSuperwallEvent.AdServicesAttribution(state: .complete(attributes))
+      )
+    } catch {
+      await Superwall.shared.track(
+        InternalSuperwallEvent.AdServicesAttribution(state: .fail(error))
+      )
+    }
+  }
+}

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -194,12 +194,6 @@ enum InternalSuperwallEvent {
     func getSuperwallParameters() async -> [String: Any] { [:] }
   }
 
-  struct ConfigRefresh: TrackableSuperwallEvent {
-    let superwallEvent: SuperwallEvent = .configRefresh
-    var audienceFilterParams: [String: Any] = [:]
-    func getSuperwallParameters() async -> [String: Any] { [:] }
-  }
-
   struct ConfigAttributes: TrackableSuperwallEvent {
     let superwallEvent: SuperwallEvent = .configAttributes
     let options: SuperwallOptions
@@ -727,6 +721,41 @@ enum InternalSuperwallEvent {
       }
       params += await paywallInfo.eventParams()
       return params
+    }
+  }
+
+  enum ConfigCacheStatus: String {
+    case cached = "CACHED"
+    case notCached = "NOT_CACHED"
+  }
+
+  struct ConfigRefresh: TrackableSuperwallEvent {
+    let superwallEvent: SuperwallEvent = .configRefresh
+    let buildId: String
+    let retryCount: Int
+    let cacheStatus: ConfigCacheStatus
+    let fetchDuration: TimeInterval
+    var audienceFilterParams: [String: Any] = [:]
+
+    func getSuperwallParameters() async -> [String: Any] {
+      return [
+        "config_build_id": buildId,
+        "retry_count": retryCount,
+        "cache_status": cacheStatus.rawValue,
+        "fetch_duration": fetchDuration
+      ]
+    }
+  }
+
+  struct ConfigFail: TrackableSuperwallEvent {
+    let superwallEvent: SuperwallEvent = .configFail
+    let message: String
+    var audienceFilterParams: [String: Any] = [:]
+
+    func getSuperwallParameters() async -> [String: Any] {
+      return [
+        "error_message": message
+      ]
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -758,4 +758,36 @@ enum InternalSuperwallEvent {
       ]
     }
   }
+
+  struct AdServicesAttribution: TrackableSuperwallEvent {
+    enum State {
+      case start
+      case fail(Error)
+      case complete(AdServicesAttributes)
+    }
+    let state: State
+
+    var superwallEvent: SuperwallEvent {
+      switch state {
+      case .start:
+        return .adServicesAttributionRequestStart
+      case .fail(let error):
+        return .adServicesAttributionRequestFail(error: error)
+      case .complete(let attributes):
+        return .adServicesAttributionRequestComplete(attributes: attributes)
+      }
+    }
+    let audienceFilterParams: [String: Any] = [:]
+
+    func getSuperwallParameters() async -> [String: Any] {
+      switch state {
+      case .start:
+        return [:]
+      case .fail(let error):
+        return ["error_message": error.localizedDescription]
+      case .complete(let attributes):
+        return attributes.dictionary(withSnakeCase: true) ?? [:]
+      }
+    }
+  }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
@@ -182,6 +182,9 @@ public enum SuperwallEvent {
   /// When all the experiment assignments are confirmed by calling ``Superwall/confirmAllAssignments()``.
   case confirmAllAssignments
 
+  /// When the Superwall configuration fails to be retrieved.
+  case configFail
+
   var canImplicitlyTriggerPaywall: Bool {
     switch self {
     case .appInstall,
@@ -321,6 +324,8 @@ extension SuperwallEvent {
       return .init(objcEvent: .configAttributes)
     case .confirmAllAssignments:
       return .init(objcEvent: .confirmAllAssignments)
+    case .configFail:
+      return .init(objcEvent: .configFail)
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
@@ -185,6 +185,15 @@ public enum SuperwallEvent {
   /// When the Superwall configuration fails to be retrieved.
   case configFail
 
+  /// When the AdServices attribution request starts.
+  case adServicesAttributionRequestStart
+
+  /// When the AdServices attribution request fails.
+  case adServicesAttributionRequestFail(error: Error)
+
+  /// When the AdServices attribution request finishes.
+  case adServicesAttributionRequestComplete(attributes: AdServicesAttributes)
+
   var canImplicitlyTriggerPaywall: Bool {
     switch self {
     case .appInstall,
@@ -326,6 +335,12 @@ extension SuperwallEvent {
       return .init(objcEvent: .confirmAllAssignments)
     case .configFail:
       return .init(objcEvent: .configFail)
+    case .adServicesAttributionRequestStart:
+      return .init(objcEvent: .adServicesAttributionRequestStart)
+    case .adServicesAttributionRequestFail:
+      return .init(objcEvent: .adServicesAttributionRequestFail)
+    case .adServicesAttributionRequestComplete:
+      return .init(objcEvent: .adServicesAttributionRequestComplete)
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
@@ -169,6 +169,9 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// When all the experiment assignments are confirmed by calling ``Superwall/confirmAllAssignments()``.
   case confirmAllAssignments
 
+  /// When the Superwall configuration fails to be retrieved.
+  case configFail
+
   public init(event: SuperwallEvent) {
     self = event.backingData.objcEvent
   }
@@ -273,6 +276,8 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "config_attributes"
     case .confirmAllAssignments:
       return "confirm_all_assignments"
+    case .configFail:
+      return "config_fail"
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
@@ -172,6 +172,15 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// When the Superwall configuration fails to be retrieved.
   case configFail
 
+  /// When the AdServices attribution request starts.
+  case adServicesAttributionRequestStart
+
+  /// When the AdServices attribution request fails.
+  case adServicesAttributionRequestFail
+
+  /// When the AdServices attribution request finishes.
+  case adServicesAttributionRequestComplete
+
   public init(event: SuperwallEvent) {
     self = event.backingData.objcEvent
   }
@@ -278,6 +287,12 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "confirm_all_assignments"
     case .configFail:
       return "config_fail"
+    case .adServicesAttributionRequestStart:
+      return "adServicesAttributionRequest_start"
+    case .adServicesAttributionRequestFail:
+      return "adServicesAttributionRequest_fail"
+    case .adServicesAttributionRequestComplete:
+      return "adServicesAttributionRequest_complete"
     }
   }
 }

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -143,12 +143,10 @@ class ConfigManager {
         if let cachedConfig = cachedConfig,
           enableConfigRefresh {
           do {
-            let result = try await self.fetchWithTimeout(
-              {
-                try await self.network.getConfig(maxRetry: 0)
-              },
-              timeout: timeout
-            )
+            let result = try await self.fetchWithTimeout({
+              try await self.network.getConfig(maxRetry: 0)
+            },
+            timeout: timeout)
             return (result, false)
           } catch {
             // Return the cached config and set isUsingCached to true
@@ -172,12 +170,10 @@ class ConfigManager {
         if let cachedGeoInfo = cachedGeoInfo,
           enableConfigRefresh {
           do {
-            let geoInfo = try await self.fetchWithTimeout(
-              {
-                try await self.network.getGeoInfo(maxRetry: 0)
-              },
-              timeout: timeout
-            )
+            let geoInfo = try await self.fetchWithTimeout({
+              try await self.network.getGeoInfo(maxRetry: 0)
+            },
+            timeout: timeout)
             self.deviceHelper.geoInfo = geoInfo
             return false
           } catch {
@@ -227,7 +223,6 @@ class ConfigManager {
           await refreshConfiguration()
         }
       }
-
     } catch {
       configState.send(completion: .failure(error))
 

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -142,7 +142,7 @@ class ConfigManager {
         }
 
         let timer = Timer(
-          timeInterval: 0.3,
+          timeInterval: 1,
           repeats: false
         ) { _ in
           getConfigTask.cancel()

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Yusuf Tör on 22/06/2022.
 //
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length function_body_length file_length
 
 import UIKit
 import Combine
@@ -88,7 +88,11 @@ class ConfigManager {
     }
 
     do {
-      let newConfig = try await network.getConfig()
+      let startAt = Date()
+      let newConfig = try await network.getConfig { [weak self] attempt in
+        self?.configRetryCount = attempt
+      }
+      let fetchDuration = Date().timeIntervalSince(startAt)
 
       // Remove all paywalls and paywall vcs that have either been removed or changed.
       let removedOrChangedPaywallIds = ConfigLogic.getRemovedOrChangedPaywallIds(
@@ -99,7 +103,14 @@ class ConfigManager {
 
       await processConfig(newConfig, isFirstTime: false)
       configState.send(.retrieved(newConfig))
-      await Superwall.shared.track(InternalSuperwallEvent.ConfigRefresh())
+
+      let configRefresh = InternalSuperwallEvent.ConfigRefresh(
+        buildId: newConfig.buildId,
+        retryCount: configRetryCount,
+        cacheStatus: .notCached,
+        fetchDuration: fetchDuration
+      )
+      await Superwall.shared.track(configRefresh)
       Task { await preloadPaywalls() }
     } catch {
       Logger.debug(
@@ -116,13 +127,64 @@ class ConfigManager {
     do {
       _ = await factory.loadPurchasedProducts()
 
-      async let configRequest = network.getConfig { [weak self] attempt in
-        self?.configRetryCount = attempt
-        self?.configState.send(.retrying)
-      }
-      async let geoRequest: Void = deviceHelper.getGeoInfo()
+      let config: Config
+      var isUsingCachedConfig = false
+      var isUsingCachedGeoInfo = false
 
-      let (config, _) = try await (configRequest, geoRequest)
+      let startAt = Date()
+
+      // If config is cached, get config from the network but timeout after 300ms
+      // and default to the cached version. Then, refresh in the background.
+      if let cachedConfig = storage.get(LatestConfig.self),
+        cachedConfig.featureFlags.enableConfigRefresh {
+        let getConfigTask = Task {
+          try await network.getConfig(maxRetry: 0)
+        }
+
+        let timer = Timer(
+          timeInterval: 0.3,
+          repeats: false
+        ) { _ in
+          getConfigTask.cancel()
+        }
+        RunLoop.main.add(timer, forMode: .default)
+
+        do {
+          config = try await getConfigTask.value
+        } catch {
+          isUsingCachedConfig = true
+          config = cachedConfig
+        }
+
+        // Got config, cancel the timer.
+        timer.invalidate()
+      } else {
+        // Otherwise wait to get config
+        config = try await network.getConfig { [weak self] attempt in
+          self?.configRetryCount = attempt
+          self?.configState.send(.retrying)
+        }
+      }
+      let fetchDuration = Date().timeIntervalSince(startAt)
+
+      let cacheStatus: InternalSuperwallEvent.ConfigCacheStatus = isUsingCachedConfig ? .cached : .notCached
+      Task {
+        let configRefresh = InternalSuperwallEvent.ConfigRefresh(
+          buildId: config.buildId,
+          retryCount: configRetryCount,
+          cacheStatus: cacheStatus,
+          fetchDuration: fetchDuration
+        )
+        await Superwall.shared.track(configRefresh)
+      }
+
+      if let cachedGeoInfo = storage.get(LatestGeoInfo.self),
+        config.featureFlags.enableConfigRefresh {
+        deviceHelper.geoInfo = cachedGeoInfo
+        isUsingCachedGeoInfo = true
+      } else {
+        await deviceHelper.getGeoInfo()
+      }
 
       let deviceAttributes = await factory.makeSessionDeviceAttributes()
       await Superwall.shared.track(
@@ -133,9 +195,27 @@ class ConfigManager {
 
       configState.send(.retrieved(config))
 
-      Task { await preloadPaywalls() }
+      Task {
+        await preloadPaywalls()
+      }
+      if isUsingCachedGeoInfo {
+        Task {
+          await deviceHelper.getGeoInfo()
+        }
+      }
+      if isUsingCachedConfig {
+        Task {
+          await refreshConfiguration()
+        }
+      }
     } catch {
       configState.send(completion: .failure(error))
+
+      let configFallback = InternalSuperwallEvent.ConfigFail(
+        message: error.localizedDescription
+      )
+      await Superwall.shared.track(configFallback)
+
       Logger.debug(
         logLevel: .error,
         scope: .superwallCore,
@@ -151,6 +231,7 @@ class ConfigManager {
     isFirstTime: Bool
   ) async {
     storage.save(config.featureFlags.disableVerboseEvents, forType: DisableVerboseEvents.self)
+    storage.save(config, forType: LatestConfig.self)
     triggersByEventName = ConfigLogic.getTriggersByEventName(from: config.triggers)
     choosePaywallVariants(from: config.triggers)
     if isFirstTime {
@@ -211,9 +292,7 @@ class ConfigManager {
         )
       }
 
-      if Superwall.shared.options.paywalls.shouldPreload {
-        Task { await preloadAllPaywalls() }
-      }
+      Task { await preloadPaywalls() }
     } catch {
       Logger.debug(
         logLevel: .error,
@@ -287,38 +366,39 @@ class ConfigManager {
 
   /// Preloads paywalls referenced by triggers.
   func preloadAllPaywalls() async {
-    guard currentPreloadingTask == nil else {
-      return
-    }
-    currentPreloadingTask = Task {
-      guard let config = try? await configState
+    currentPreloadingTask = Task { [weak self, currentPreloadingTask] in
+      guard let self = self else {
+        return
+      }
+      // Wait until the previous task is finished before continuing.
+      await currentPreloadingTask?.value
+
+      guard let config = try? await self.configState
         .compactMap({ $0.getConfig() })
         .throwableAsync() else {
         return
       }
       let expressionEvaluator = ExpressionEvaluator(
-        storage: storage,
-        factory: factory
+        storage: self.storage,
+        factory: self.factory
       )
       let triggers = ConfigLogic.filterTriggers(
         config.triggers,
         removing: config.preloadingDisabled
       )
-      let confirmedAssignments = storage.getConfirmedAssignments()
+      let confirmedAssignments = self.storage.getConfirmedAssignments()
       var paywallIds = await ConfigLogic.getAllActiveTreatmentPaywallIds(
         fromTriggers: triggers,
         confirmedAssignments: confirmedAssignments,
-        unconfirmedAssignments: unconfirmedAssignments,
+        unconfirmedAssignments: self.unconfirmedAssignments,
         expressionEvaluator: expressionEvaluator
       )
       // Do not preload the presented paywall. This is because if config refreshes, we
       // don't want to refresh the presented paywall until it's dismissed and presented again.
-      if let presentedPaywallId = await paywallManager.presentedViewController?.paywall.identifier {
+      if let presentedPaywallId = await self.paywallManager.presentedViewController?.paywall.identifier {
         paywallIds.remove(presentedPaywallId)
       }
-      await preloadPaywalls(withIdentifiers: paywallIds)
-
-      currentPreloadingTask = nil
+      await self.preloadPaywalls(withIdentifiers: paywallIds)
     }
   }
 

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -432,7 +432,7 @@ class ConfigManager {
             presentationSourceType: nil,
             retryCount: 6
           )
-          guard let paywall = try? await paywallManager.getPaywall(from: request) else {
+          guard let paywall = try? await self.paywallManager.getPaywall(from: request) else {
             return
           }
 

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -127,45 +127,72 @@ class ConfigManager {
     do {
       _ = await factory.loadPurchasedProducts()
 
-      let config: Config
-      var isUsingCachedConfig = false
-      var isUsingCachedGeoInfo = false
-
       let startAt = Date()
 
-      // If config is cached, get config from the network but timeout after 300ms
-      // and default to the cached version. Then, refresh in the background.
-      if let cachedConfig = storage.get(LatestConfig.self),
-        cachedConfig.featureFlags.enableConfigRefresh {
-        let getConfigTask = Task {
-          try await network.getConfig(maxRetry: 0)
-        }
+      // Retrieve cached config and determine if refresh is enabled
+      let cachedConfig = storage.get(LatestConfig.self)
+      let enableConfigRefresh = cachedConfig?.featureFlags.enableConfigRefresh ?? false
+      let timeout: TimeInterval = 1
 
-        let timer = Timer(
-          timeInterval: 1,
-          repeats: false
-        ) { _ in
-          getConfigTask.cancel()
+      // Prepare tasks for fetching config and geoInfo concurrently
+      // Return a tuple including the `isUsingCached` flag
+      async let configResult: (config: Config, isUsingCached: Bool) = { [weak self] in
+        guard let self = self else {
+          throw CancellationError()
         }
-        RunLoop.main.add(timer, forMode: .default)
+        if let cachedConfig = cachedConfig,
+          enableConfigRefresh {
+          do {
+            let result = try await self.fetchWithTimeout(
+              {
+                try await self.network.getConfig(maxRetry: 0)
+              },
+              timeout: timeout
+            )
+            return (result, false)
+          } catch {
+            // Return the cached config and set isUsingCached to true
+            return (cachedConfig, true)
+          }
+        } else {
+          let config = try await self.network.getConfig { attempt in
+            self.configRetryCount = attempt
+            self.configState.send(.retrying)
+          }
+          return (config, false)
+        }
+      }()
 
-        do {
-          config = try await getConfigTask.value
-        } catch {
-          isUsingCachedConfig = true
-          config = cachedConfig
+      async let isUsingCachedGeo: Bool = { [weak self] in
+        guard let self = self else {
+          return false
         }
+        let cachedGeoInfo = self.storage.get(LatestGeoInfo.self)
 
-        // Got config, cancel the timer.
-        timer.invalidate()
-      } else {
-        // Otherwise wait to get config
-        config = try await network.getConfig { [weak self] attempt in
-          self?.configRetryCount = attempt
-          self?.configState.send(.retrying)
+        if let cachedGeoInfo = cachedGeoInfo,
+          enableConfigRefresh {
+          do {
+            let geoInfo = try await self.fetchWithTimeout(
+              {
+                try await self.network.getGeoInfo(maxRetry: 0)
+              },
+              timeout: timeout
+            )
+            self.deviceHelper.geoInfo = geoInfo
+            return false
+          } catch {
+            self.deviceHelper.geoInfo = cachedGeoInfo
+            return true
+          }
+        } else {
+          await self.deviceHelper.getGeoInfo()
+          return false
         }
-      }
-      let fetchDuration = Date().timeIntervalSince(startAt)
+      }()
+
+      let (config, isUsingCachedConfig) = try await configResult
+      let configFetchDuration = Date().timeIntervalSince(startAt)
+      let isUsingCachedGeoInfo = await isUsingCachedGeo
 
       let cacheStatus: InternalSuperwallEvent.ConfigCacheStatus = isUsingCachedConfig ? .cached : .notCached
       Task {
@@ -173,17 +200,9 @@ class ConfigManager {
           buildId: config.buildId,
           retryCount: configRetryCount,
           cacheStatus: cacheStatus,
-          fetchDuration: fetchDuration
+          fetchDuration: configFetchDuration
         )
         await Superwall.shared.track(configRefresh)
-      }
-
-      if let cachedGeoInfo = storage.get(LatestGeoInfo.self),
-        config.featureFlags.enableConfigRefresh {
-        deviceHelper.geoInfo = cachedGeoInfo
-        isUsingCachedGeoInfo = true
-      } else {
-        await deviceHelper.getGeoInfo()
       }
 
       let deviceAttributes = await factory.makeSessionDeviceAttributes()
@@ -208,6 +227,7 @@ class ConfigManager {
           await refreshConfiguration()
         }
       }
+
     } catch {
       configState.send(completion: .failure(error))
 
@@ -223,6 +243,32 @@ class ConfigManager {
         info: nil,
         error: error
       )
+    }
+  }
+
+  func fetchWithTimeout<T>(_ task: @escaping () async throws -> T, timeout: TimeInterval) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+      group.addTask {
+        try await task()
+      }
+
+      group.addTask {
+        try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+        throw CancellationError()
+      }
+
+      do {
+        let result = try await group.next()
+        group.cancelAll()
+        if let result = result {
+          return result
+        } else {
+          throw CancellationError()
+        }
+      } catch {
+        group.cancelAll()
+        throw error
+      }
     }
   }
 

--- a/Sources/SuperwallKit/Config/ConfigurationStatus.swift
+++ b/Sources/SuperwallKit/Config/ConfigurationStatus.swift
@@ -1,0 +1,19 @@
+//
+//  ConfigurationStatus.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 12/09/2024.
+//
+
+/// An enum representing the configuration status of the SDK.
+@objc(SWKConfigurationStatus)
+public enum ConfigurationStatus: Int {
+  /// The configuration process is not yet completed.
+  case pending
+
+  /// The configuration process completed successfully.
+  case configured
+
+  /// The configuration process failed.
+  case failed
+}

--- a/Sources/SuperwallKit/Config/Models/ComputedPropertyRequest.swift
+++ b/Sources/SuperwallKit/Config/Models/ComputedPropertyRequest.swift
@@ -134,4 +134,22 @@ public final class ComputedPropertyRequest: NSObject, Codable {
 
   /// The name of the event used to compute the device property.
   public let eventName: String
+
+  enum CodingKeys: CodingKey {
+    case type
+    case eventName
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(type, forKey: .type)
+    try container.encode(eventName, forKey: .eventName)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    type = try container.decode(ComputedPropertyRequestType.self, forKey: .type)
+    eventName = try container.decode(String.self, forKey: .eventName)
+    super.init()
+  }
 }

--- a/Sources/SuperwallKit/Config/Models/ComputedPropertyRequest.swift
+++ b/Sources/SuperwallKit/Config/Models/ComputedPropertyRequest.swift
@@ -10,10 +10,10 @@ import Foundation
 /// A request to compute a device property associated with an event at runtime.
 @objc(SWKComputedPropertyRequest)
 @objcMembers
-public final class ComputedPropertyRequest: NSObject, Decodable {
+public final class ComputedPropertyRequest: NSObject, Codable {
   /// The type of device property to compute.
   @objc(SWKComputedPropertyRequestType)
-  public enum ComputedPropertyRequestType: Int, Decodable {
+  public enum ComputedPropertyRequestType: Int, Codable {
     /// The number of minutes since the event occurred.
     case minutesSince
 
@@ -106,6 +106,26 @@ public final class ComputedPropertyRequest: NSObject, Decodable {
           )
         )
       }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      let rawValue: String
+
+      switch self {
+      case .minutesSince:
+        rawValue = CodingKeys.minutesSince.rawValue
+      case .hoursSince:
+        rawValue = CodingKeys.hoursSince.rawValue
+      case .daysSince:
+        rawValue = CodingKeys.daysSince.rawValue
+      case .monthsSince:
+        rawValue = CodingKeys.monthsSince.rawValue
+      case .yearsSince:
+        rawValue = CodingKeys.yearsSince.rawValue
+      }
+
+      try container.encode(rawValue)
     }
   }
 

--- a/Sources/SuperwallKit/Config/Models/Config.swift
+++ b/Sources/SuperwallKit/Config/Models/Config.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct Config: Decodable {
-  let buildId: String
+struct Config: Codable {
+  var buildId: String
   var triggers: Set<Trigger>
   var paywalls: [Paywall]
   var logLevel: Int
@@ -49,6 +49,22 @@ struct Config: Decodable {
 
     let localization = try values.decode(LocalizationConfig.self, forKey: .localization)
     locales = Set(localization.locales.map { $0.locale })
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(buildId, forKey: .buildId)
+    try container.encode(triggers, forKey: .triggers)
+    try container.encode(paywalls, forKey: .paywalls)
+    try container.encode(logLevel, forKey: .logLevel)
+    try container.encode(appSessionTimeout, forKey: .appSessionTimeout)
+    try container.encode(preloadingDisabled, forKey: .preloadingDisabled)
+
+    let localizationConfig = LocalizationConfig(locales: locales.map { LocalizationConfig.LocaleConfig(locale: $0) })
+    try container.encode(localizationConfig, forKey: .localization)
+
+    try featureFlags.encode(to: encoder)
   }
 
   init(

--- a/Sources/SuperwallKit/Config/Models/FeatureFlags.swift
+++ b/Sources/SuperwallKit/Config/Models/FeatureFlags.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct RawFeatureFlag: Decodable {
+struct RawFeatureFlag: Codable {
   let key: String
   let enabled: Bool
 }
 
-struct FeatureFlags: Decodable {
+struct FeatureFlags: Codable {
   var enableSessionEvents: Bool
   var enableExpressionParameters: Bool
   var enableUserIdSeed: Bool
@@ -45,6 +45,25 @@ struct FeatureFlags: Decodable {
     enableMultiplePaywallUrls = rawFeatureFlags.value(forKey: "enable_multiple_paywall_urls", default: false)
     enableConfigRefresh = rawFeatureFlags.value(forKey: "enable_config_refresh", default: false)
     enableTextInteraction = rawFeatureFlags.value(forKey: "enable_text_interaction", default: false)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    let rawFeatureFlags = [
+      RawFeatureFlag(key: "enable_session_events", enabled: enableSessionEvents),
+      RawFeatureFlag(key: "enable_expression_params", enabled: enableExpressionParameters),
+      RawFeatureFlag(key: "enable_userid_seed", enabled: enableUserIdSeed),
+      RawFeatureFlag(key: "disable_verbose_events", enabled: disableVerboseEvents),
+      RawFeatureFlag(key: "enable_suppresses_incremental_rendering", enabled: enableSuppressesIncrementalRendering),
+      RawFeatureFlag(key: "enable_throttle_scheduling_policy", enabled: enableThrottleSchedulingPolicy),
+      RawFeatureFlag(key: "enable_none_scheduling_policy", enabled: enableNoneSchedulingPolicy),
+      RawFeatureFlag(key: "enable_multiple_paywall_urls", enabled: enableMultiplePaywallUrls),
+      RawFeatureFlag(key: "enable_config_refresh", enabled: enableConfigRefresh),
+      RawFeatureFlag(key: "enable_text_interaction", enabled: enableTextInteraction)
+    ]
+
+    try container.encode(rawFeatureFlags, forKey: .toggles)
   }
 
   init(

--- a/Sources/SuperwallKit/Config/Models/FeatureGatingBehaviour.swift
+++ b/Sources/SuperwallKit/Config/Models/FeatureGatingBehaviour.swift
@@ -47,12 +47,6 @@ public enum FeatureGatingBehavior: Int, Codable, CustomStringConvertible, Sendab
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
-
-    switch self {
-    case .gated:
-      try container.encode(FeatureGatingBehavior.gated.rawValue)
-    case .nonGated:
-      try container.encode(FeatureGatingBehavior.nonGated.rawValue)
-    }
+    try container.encode(description)
   }
 }

--- a/Sources/SuperwallKit/Config/Models/LocalizationConfig.swift
+++ b/Sources/SuperwallKit/Config/Models/LocalizationConfig.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct LocalizationConfig: Decodable {
-  struct LocaleConfig: Decodable {
+struct LocalizationConfig: Codable {
+  struct LocaleConfig: Codable {
     var locale: String
   }
 

--- a/Sources/SuperwallKit/Config/Models/OnDeviceCaching.swift
+++ b/Sources/SuperwallKit/Config/Models/OnDeviceCaching.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An enum whose cases indicate whether caching of the paywall is enabled or not.
-enum OnDeviceCaching: Decodable {
+enum OnDeviceCaching: Codable {
   case enabled
   case disabled
 
@@ -27,5 +27,19 @@ enum OnDeviceCaching: Decodable {
     case .disabled:
       self = .disabled
     }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let rawValue: String
+    switch self {
+    case .enabled:
+      rawValue = CodingKeys.enabled.rawValue
+    case .disabled:
+      rawValue = CodingKeys.disabled.rawValue
+    }
+
+    try container.encode(rawValue)
   }
 }

--- a/Sources/SuperwallKit/Config/Models/Survey.swift
+++ b/Sources/SuperwallKit/Config/Models/Survey.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A survey attached to a paywall.
 @objc(SWKSurvey)
 @objcMembers
-final public class Survey: NSObject, Decodable {
+final public class Survey: NSObject, Codable {
   /// The id of the survey.
   public let id: String
 

--- a/Sources/SuperwallKit/Config/Models/SurveyOption.swift
+++ b/Sources/SuperwallKit/Config/Models/SurveyOption.swift
@@ -10,7 +10,7 @@ import Foundation
 /// An option to display in a paywall survey.
 @objc(SWKSurveyOption)
 @objcMembers
-final public class SurveyOption: NSObject, Decodable {
+final public class SurveyOption: NSObject, Codable {
   /// The id of the survey option.
   public let id: String
 

--- a/Sources/SuperwallKit/Config/Models/SurveyShowCondition.swift
+++ b/Sources/SuperwallKit/Config/Models/SurveyShowCondition.swift
@@ -10,7 +10,7 @@ import Foundation
 /// An enum whose cases indicate when a survey should
 /// show.
 @objc(SWKSurveyShowCondition)
-public enum SurveyShowCondition: Int, Decodable {
+public enum SurveyShowCondition: Int, Codable {
   /// Shows the survey when the user manually closes the paywall.
   case onManualClose
 
@@ -40,5 +40,19 @@ public enum SurveyShowCondition: Int, Decodable {
         )
       )
     }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let rawValue: String
+    switch self {
+    case .onManualClose:
+      rawValue = CodingKeys.onManualClose.rawValue
+    case .onPurchase:
+      rawValue = CodingKeys.onPurchase.rawValue
+    }
+
+    try container.encode(rawValue)
   }
 }

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -107,6 +107,10 @@ public final class SuperwallOptions: NSObject, Encodable {
       "geo-api.superwall.com"
     }
 
+    var adServicesHost: String {
+      "api-adservices.apple.com"
+    }
+
     private enum CodingKeys: String, CodingKey {
       case networkEnvironment
       case customDomain
@@ -150,6 +154,11 @@ public final class SuperwallOptions: NSObject, Encodable {
   ///
   /// Set this to `true` to forward events from the Game Controller to the Paywall via ``Superwall/gamepadValueChanged(gamepad:element:)``.
   public var isGameControllerEnabled = false
+
+  /// Collects the `AdServices` attributes and attaches them to the user attributes.
+  ///
+  /// Defaults to `false`.
+  public var collectAdServicesAttribution = false
 
   /// Configuration for printing to the console.
   @objc(SWKLogging)

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -38,6 +38,7 @@ final class DependencyContainer {
   var productPurchaser: ProductPurchaserSK1!
   var receiptManager: ReceiptManager!
   var purchaseController: PurchaseController!
+  var attributionPoster: AttributionPoster!
   // swiftlint:enable implicitly_unwrapped_optional
   let productsFetcher = ProductsFetcherSK1()
   let paywallArchiveManager = PaywallArchiveManager()
@@ -51,7 +52,6 @@ final class DependencyContainer {
       delegate: productsFetcher,
       receiptDelegate: purchaseController as? ReceiptDelegate
     )
-
     storeKitManager = StoreKitManager(productsFetcher: productsFetcher)
     delegateAdapter = SuperwallDelegateAdapter()
     storage = Storage(factory: self)
@@ -69,7 +69,11 @@ final class DependencyContainer {
 
     let options = options ?? SuperwallOptions()
     api = Api(networkEnvironment: options.networkEnvironment)
-
+    attributionPoster = AttributionPoster(
+      collectAdServicesAttribution: options.collectAdServicesAttribution,
+      network: network,
+      storage: storage
+    )
     deviceHelper = DeviceHelper(
       api: api,
       storage: storage,

--- a/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
+++ b/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
@@ -25,6 +25,10 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``PaywallOptions``
 - ``preloadAllPaywalls()``
 - ``preloadPaywalls(forEvents:)``
+- ``confirmAllAssignments()``
+- ``configurationStatus``
+- ``ConfigurationStatus``
+- ``isConfigured``
 
 ### Presenting and Dismissing a Paywall
 
@@ -85,4 +89,3 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``presentedViewController``
 - ``userId``
 - ``isLoggedIn``
-- ``isConfigured``

--- a/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
+++ b/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
@@ -84,8 +84,14 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``SuperwallOptions/Logging-swift.class``
 
 ### Helpers
+
 - ``togglePaywallSpinner(isHidden:)``
 - ``latestPaywallInfo``
 - ``presentedViewController``
 - ``userId``
 - ``isLoggedIn``
+
+### Apple AdServices Attribution
+
+- ``AdServicesAttributes``
+- ``SuperwallOptions/collectAdServicesAttribution``

--- a/Sources/SuperwallKit/Documentation.docc/SuperwallKit.md
+++ b/Sources/SuperwallKit/Documentation.docc/SuperwallKit.md
@@ -4,7 +4,7 @@ The client SDK for [Superwall](https://superwall.com), a service that lets you r
 
 ## Overview
 
-Superwall makes it easy to show paywalls in your app using UIKit or SwiftUI. If you haven't already, [sign up for a free Superwall account](https://superwall.com/sign-up). Configure the SDK with your API key and present our example paywall in response to a tracked event. When you're ready to use your own paywalls, head to the Superwall dashboard and use the paywall editor to configure them. Then, create a Campaign and define rules to determine when to show paywalls to users.
+Superwall makes it easy to show paywalls in your app using UIKit or SwiftUI. If you haven't already, [sign up for a free Superwall account](https://superwall.com/sign-up). Configure the SDK with your API key and present our example paywall in response to a registered event. When you're ready to use your own paywalls, head to the Superwall dashboard and use the paywall editor to configure them. Then, create a Campaign and define audiences to determine when to show paywalls to users.
 
 See our [docs](https://docs.superwall.com/docs) for more information.
 

--- a/Sources/SuperwallKit/Logger/LogScope.swift
+++ b/Sources/SuperwallKit/Logger/LogScope.swift
@@ -11,6 +11,7 @@ import Foundation
 @objc(SWKLogScope)
 public enum LogScope: Int, Encodable, Sendable, CustomStringConvertible {
   case localizationManager
+  case analytics
   case bounceButton
   case coreData
   case configManager
@@ -35,6 +36,8 @@ public enum LogScope: Int, Encodable, Sendable, CustomStringConvertible {
 
   public var description: String {
     switch self {
+    case .analytics:
+      return "analytics"
     case .localizationManager:
       return "localizationManager"
     case .bounceButton:

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.8.0
+3.9.0
 """

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.7.5
+3.8.0
 """

--- a/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
+++ b/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A local notification.
 @objc(SWKLocalNotification)
 @objcMembers
-public final class LocalNotification: NSObject, Decodable {
+public final class LocalNotification: NSObject, Codable {
   /// The type of the notification.
   public let type: LocalNotificationType
 
@@ -57,7 +57,7 @@ extension LocalNotification: Stubbable {
 
 /// The type of notification.
 @objc(SWKLocalNotificationType)
-public enum LocalNotificationType: Int, Decodable {
+public enum LocalNotificationType: Int, Codable {
   /// The notification will fire after a transaction.
   case trialStarted
 
@@ -81,5 +81,17 @@ public enum LocalNotificationType: Int, Decodable {
         )
       )
     }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let rawValue: String
+    switch self {
+    case .trialStarted:
+      rawValue = CodingKeys.trialStarted.rawValue
+    }
+
+    try container.encode(rawValue)
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -12,7 +12,7 @@ struct Paywalls: Decodable {
   var paywalls: [Paywall]
 }
 
-struct Paywall: Decodable {
+struct Paywall: Codable {
   /// The id of the paywall in the database.
   var databaseId: String
 
@@ -246,6 +246,63 @@ struct Paywall: Decodable {
 
     manifest = try values.decodeIfPresent(ArchiveManifest.self, forKey: .manifest)
   }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(databaseId, forKey: .id)
+    try container.encode(identifier, forKey: .identifier)
+    try container.encode(name, forKey: .name)
+    try container.encode(cacheKey, forKey: .cacheKey)
+    try container.encode(buildId, forKey: .buildId)
+    try container.encode(url, forKey: .url)
+    try container.encode(urlConfig, forKey: .urlConfig)
+    try container.encode(htmlSubstitutions, forKey: .htmlSubstitutions)
+
+    if !surveys.isEmpty {
+      try container.encode(surveys, forKey: .surveys)
+    }
+
+    try container.encode(presentation.style, forKey: .presentationStyle)
+    try container.encode(presentation.condition, forKey: .presentationCondition)
+    try container.encode(presentation.delay, forKey: .presentationDelay)
+
+    try container.encode(backgroundColorHex, forKey: .backgroundColorHex)
+
+    if let darkBackgroundColorHex = darkBackgroundColorHex {
+      try container.encode(darkBackgroundColorHex, forKey: .darkBackgroundColorHex)
+    }
+
+    if !productItems.isEmpty {
+      try container.encode(productItems, forKey: .productItems)
+    }
+
+    try container.encodeIfPresent(responseLoadingInfo.startAt, forKey: .responseLoadStartTime)
+    try container.encodeIfPresent(responseLoadingInfo.endAt, forKey: .responseLoadCompleteTime)
+    try container.encodeIfPresent(responseLoadingInfo.failAt, forKey: .responseLoadFailTime)
+
+    try container.encodeIfPresent(webviewLoadingInfo.startAt, forKey: .webViewLoadStartTime)
+    try container.encodeIfPresent(webviewLoadingInfo.endAt, forKey: .webViewLoadCompleteTime)
+    try container.encodeIfPresent(webviewLoadingInfo.failAt, forKey: .webViewLoadFailTime)
+
+    try container.encodeIfPresent(productsLoadingInfo.startAt, forKey: .productsLoadStartTime)
+    try container.encodeIfPresent(productsLoadingInfo.endAt, forKey: .productsLoadCompleteTime)
+    try container.encodeIfPresent(productsLoadingInfo.failAt, forKey: .productsLoadFailTime)
+
+    try container.encodeIfPresent(featureGating, forKey: .featureGating)
+    try container.encodeIfPresent(onDeviceCache, forKey: .onDeviceCache)
+
+    if !localNotifications.isEmpty {
+      try container.encode(localNotifications, forKey: .localNotifications)
+    }
+
+    if !computedPropertyRequests.isEmpty {
+      try container.encode(computedPropertyRequests, forKey: .computedPropertyRequests)
+    }
+
+    try container.encodeIfPresent(manifest, forKey: .manifest)
+  }
+
 
   private static func makeProducts(from productItems: [ProductItem]) -> [Product] {
     var output: [Product] = []

--- a/Sources/SuperwallKit/Models/Paywall/PaywallPresentationInfo.swift
+++ b/Sources/SuperwallKit/Models/Paywall/PaywallPresentationInfo.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Information about the presentation of the paywall.
 @objc(SWKPaywallPresentationInfo)
 @objcMembers
-public final class PaywallPresentationInfo: NSObject {
+public final class PaywallPresentationInfo: NSObject, Codable {
   /// The presentation style of the paywall.
   public let style: PaywallPresentationStyle
 

--- a/Sources/SuperwallKit/Models/Paywall/PaywallPresentationStyle.swift
+++ b/Sources/SuperwallKit/Models/Paywall/PaywallPresentationStyle.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Used to override the presentation style of the paywall set on the dashboard.
 @objc(SWKPaywallPresentationStyle)
-public enum PaywallPresentationStyle: Int, Decodable, Sendable {
+public enum PaywallPresentationStyle: Int, Codable, Sendable {
   /// A view presentation style that uses the modal presentation style `.pageSheet`.
   case modal
   /// A view presentation style in which the presented paywall slides up to cover the screen.
@@ -29,6 +29,7 @@ public enum PaywallPresentationStyle: Int, Decodable, Sendable {
     case fullscreenNoAnimation = "NO_ANIMATION"
     case push = "PUSH"
     case drawer = "DRAWER"
+    case none = "NONE"
   }
 
   public init(from decoder: Decoder) throws {
@@ -48,7 +49,31 @@ public enum PaywallPresentationStyle: Int, Decodable, Sendable {
       presentationStyle = .push
     case .drawer:
       presentationStyle = .drawer
+    case .none:
+      presentationStyle = .none
     }
     self = presentationStyle
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let internalPresentationStyle: InternalPresentationStyle
+    switch self {
+    case .modal:
+      internalPresentationStyle = .modal
+    case .fullscreen:
+      internalPresentationStyle = .fullscreen
+    case .fullscreenNoAnimation:
+      internalPresentationStyle = .fullscreenNoAnimation
+    case .push:
+      internalPresentationStyle = .push
+    case .drawer:
+      internalPresentationStyle = .drawer
+    case .none:
+      internalPresentationStyle = .none
+    }
+
+    try container.encode(internalPresentationStyle.rawValue)
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/PresentationCondition.swift
+++ b/Sources/SuperwallKit/Models/Paywall/PresentationCondition.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// The condition for when a paywall should present.
 @objc(SWKPresentationCondition)
-public enum PresentationCondition: Int, Decodable {
+public enum PresentationCondition: Int, Codable {
   /// The paywall will always present, regardless of subscription status.
   case always
 
@@ -33,5 +33,19 @@ public enum PresentationCondition: Int, Decodable {
     case nil:
       self = .checkUserSubscription
     }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    let rawValue: String
+    switch self {
+    case .always:
+      rawValue = CodingKeys.always.rawValue
+    case .checkUserSubscription:
+      rawValue = CodingKeys.checkUserSubscription.rawValue
+    }
+
+    try container.encode(rawValue)
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/WebViewURLConfig.swift
+++ b/Sources/SuperwallKit/Models/Paywall/WebViewURLConfig.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct WebViewURLConfig: Decodable {
+struct WebViewURLConfig: Codable {
   let endpoints: [WebViewEndpoint]
   let maxAttempts: Int
 }
 
-struct WebViewEndpoint: Decodable, Equatable {
+struct WebViewEndpoint: Codable, Equatable {
   var url: URL
   let timeout: TimeInterval
   var percentage: Double
@@ -38,6 +38,13 @@ struct WebViewEndpoint: Decodable, Equatable {
     self.url = try container.decode(URL.self, forKey: .url)
     self.timeout = try container.decode(Milliseconds.self, forKey: .timeoutMs) * 1000
     self.percentage = try container.decode(Double.self, forKey: .percentage)
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(url, forKey: .url)
+    try container.encode(timeout / 1000, forKey: .timeoutMs)
+    try container.encode(percentage, forKey: .percentage)
   }
 }
 

--- a/Sources/SuperwallKit/Models/Product/ProductVariable.swift
+++ b/Sources/SuperwallKit/Models/Product/ProductVariable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ProductVariable: Encodable, Equatable {
+struct ProductVariable: Codable, Equatable {
   let name: String
   let attributes: JSON
 

--- a/Sources/SuperwallKit/Models/Triggers/RawExperiment.swift
+++ b/Sources/SuperwallKit/Models/Triggers/RawExperiment.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An experiment without a confirmed variant assignment.
-struct RawExperiment: Decodable, Hashable {
+struct RawExperiment: Codable, Hashable {
   /// The ID of the experiment
   var id: String
 

--- a/Sources/SuperwallKit/Models/Triggers/Trigger.swift
+++ b/Sources/SuperwallKit/Models/Triggers/Trigger.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Trigger: Decodable, Hashable {
+struct Trigger: Codable, Hashable {
   var eventName: String
   var rules: [TriggerRule]
 }

--- a/Sources/SuperwallKit/Models/Triggers/TriggerRuleOccurrence.swift
+++ b/Sources/SuperwallKit/Models/Triggers/TriggerRuleOccurrence.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-struct TriggerRuleOccurrence: Decodable, Hashable {
-  struct RawInterval: Decodable {
-    enum IntervalType: String, Decodable {
+struct TriggerRuleOccurrence: Codable, Hashable {
+  struct RawInterval: Codable {
+    enum IntervalType: String, Codable {
       case minutes = "MINUTES"
       case infinity = "INFINITY"
 
@@ -17,6 +17,11 @@ struct TriggerRuleOccurrence: Decodable, Hashable {
         let container = try decoder.singleValueContainer()
         let rawValue = try container.decode(RawValue.self)
         self = IntervalType(rawValue: rawValue) ?? .infinity
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
       }
     }
     let type: IntervalType
@@ -49,6 +54,22 @@ struct TriggerRuleOccurrence: Decodable, Hashable {
       self.interval = .minutes(minutes)
     } else {
       self.interval = .infinity
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(key, forKey: .key)
+    try container.encode(maxCount, forKey: .maxCount)
+
+    switch interval {
+    case .minutes(let minutes):
+      let rawInterval = RawInterval(type: .minutes, minutes: minutes)
+      try container.encode(rawInterval, forKey: .interval)
+    case .infinity:
+      let rawInterval = RawInterval(type: .infinity, minutes: nil)
+      try container.encode(rawInterval, forKey: .interval)
     }
   }
 

--- a/Sources/SuperwallKit/Models/Triggers/VariantOption.swift
+++ b/Sources/SuperwallKit/Models/Triggers/VariantOption.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct VariantOption: Decodable, Hashable {
+struct VariantOption: Codable, Hashable {
   var type: Experiment.Variant.VariantType
   var id: String
   var percentage: Int
@@ -26,6 +26,14 @@ struct VariantOption: Decodable, Hashable {
     id = try values.decode(String.self, forKey: .variantId)
     percentage = try values.decode(Int.self, forKey: .percentage)
     paywallId = try values.decodeIfPresent(String.self, forKey: .paywallIdentifier)
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(type, forKey: .variantType)
+    try container.encode(id, forKey: .variantId)
+    try container.encode(percentage, forKey: .percentage)
+    try container.encode(paywallId, forKey: .paywallIdentifier)
   }
 
   init(

--- a/Sources/SuperwallKit/Network/API.swift
+++ b/Sources/SuperwallKit/Network/API.swift
@@ -11,6 +11,7 @@ enum EndpointHost {
   case base
   case collector
   case geo
+  case adServices
 }
 
 protocol ApiHostConfig {
@@ -23,12 +24,14 @@ struct Api {
   let base: Base
   let collector: Collector
   let geo: Geo
+  let adServices: AdServices
   static let version1 = "/api/v1/"
 
   init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
-    self.base = Base(networkEnvironment: networkEnvironment)
-    self.collector = Collector(networkEnvironment: networkEnvironment)
-    self.geo = Geo(networkEnvironment: networkEnvironment)
+    base = Base(networkEnvironment: networkEnvironment)
+    collector = Collector(networkEnvironment: networkEnvironment)
+    geo = Geo(networkEnvironment: networkEnvironment)
+    adServices = AdServices(networkEnvironment: networkEnvironment)
   }
 
   func getConfig(host: EndpointHost) -> ApiHostConfig {
@@ -39,66 +42,52 @@ struct Api {
       return collector
     case .geo:
       return geo
+    case .adServices:
+      return adServices
     }
   }
 
   struct Base: ApiHostConfig {
     private let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var port: Int? { return networkEnvironment.port }
+    var scheme: String { return networkEnvironment.scheme }
+    var host: String { return networkEnvironment.baseHost }
 
     init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
       self.networkEnvironment = networkEnvironment
-    }
-
-    var port: Int? {
-      return networkEnvironment.port
-    }
-
-    var scheme: String {
-      return networkEnvironment.scheme
-    }
-
-    var host: String {
-      return networkEnvironment.baseHost
     }
   }
 
   struct Collector: ApiHostConfig {
     private let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var port: Int? { return networkEnvironment.port }
+    var scheme: String { return networkEnvironment.scheme }
+    var host: String { return networkEnvironment.collectorHost }
 
     init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
       self.networkEnvironment = networkEnvironment
-    }
-
-    var port: Int? {
-      return networkEnvironment.port
-    }
-
-    var scheme: String {
-      return networkEnvironment.scheme
-    }
-
-    var host: String {
-      return networkEnvironment.collectorHost
     }
   }
 
   struct Geo: ApiHostConfig {
     private let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var port: Int? { return networkEnvironment.port }
+    var scheme: String { return networkEnvironment.scheme }
+    var host: String { return networkEnvironment.geoHost }
 
     init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
       self.networkEnvironment = networkEnvironment
     }
+  }
 
-    var port: Int? {
-      return networkEnvironment.port
-    }
+  struct AdServices: ApiHostConfig {
+    private let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var port: Int? { return networkEnvironment.port }
+    var scheme: String { return networkEnvironment.scheme }
+    var host: String { return networkEnvironment.adServicesHost }
 
-    var scheme: String {
-      return networkEnvironment.scheme
-    }
-
-    var host: String {
-      return networkEnvironment.geoHost
+    init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
+      self.networkEnvironment = networkEnvironment
     }
   }
 }

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -540,8 +540,8 @@ class DeviceHelper {
     self.sdkVersionPadded = Self.makePaddedSdkVersion(using: sdkVersion)
   }
 
-  func getGeoInfo() async {
-    geoInfo = await network.getGeoInfo()
+  func getGeoInfo(maxRetry: Int? = nil) async {
+    geoInfo = try? await network.getGeoInfo(maxRetry: maxRetry)
     if let geoInfo = geoInfo {
       storage.save(geoInfo, forType: LatestGeoInfo.self)
     }

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -25,7 +25,7 @@ class DeviceHelper {
     return Locale(identifier: preferredIdentifier).identifier
   }
 
-  private var geoInfo: GeoInfo?
+  var geoInfo: GeoInfo?
 
   let appInstalledAtString: String
 
@@ -542,5 +542,8 @@ class DeviceHelper {
 
   func getGeoInfo() async {
     geoInfo = await network.getGeoInfo()
+    if let geoInfo = geoInfo {
+      storage.save(geoInfo, forType: LatestGeoInfo.self)
+    }
   }
 }

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -456,7 +456,8 @@ class DeviceHelper {
     PaywallEventReceiverCapability(),
     MultiplePaywallUrlsCapability(),
     ConfigRefreshCapability(),
-    WebViewTextInteractionCapability()
+    WebViewTextInteractionCapability(),
+    ConfigCaching()
   ]
 
   func getTemplateDevice() async -> [String: Any] {

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -210,11 +210,13 @@ extension Endpoint where Response == Paywalls {
 extension Endpoint where Response == Config {
   static func config(
     requestId: String,
+    maxRetry: Int?,
     factory: ApiFactory
   ) -> Self {
     let queryItems = [URLQueryItem(name: "pk", value: factory.storage.apiKey)]
 
     return Endpoint(
+      retryCount: maxRetry ?? 6,
       components: Components(
         host: .base,
         path: Api.version1 + "static_config",

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -262,8 +262,12 @@ extension Endpoint where Response == ConfirmedAssignmentResponse {
 
 // MARK: - GeoWrapper
 extension Endpoint where Response == GeoWrapper {
-  static func geo(factory: ApiFactory) -> Self {
+  static func geo(
+    factory: ApiFactory,
+    maxRetry: Int?
+  ) -> Self {
     return Endpoint(
+      retryCount: maxRetry ?? 6,
       components: Components(
         host: .geo,
         path: Api.version1 + "geo"

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Endpoint<Response: Decodable> {
+struct Endpoint<Kind: EndpointKind, Response: Decodable> {
   enum HttpMethod: String {
     case get = "GET"
     case post = "POST"
@@ -21,14 +21,15 @@ struct Endpoint<Response: Decodable> {
   }
 
   var retryCount = 6
+  var retryInterval: Seconds?
   var components: Components?
   var url: URL?
   var method: HttpMethod = .get
-  var requestId: String = UUID().uuidString
-  var isForDebugging = false
-  let factory: ApiFactory
 
-  func makeRequest() async -> URLRequest? {
+  func makeRequest(
+    with data: Kind.RequestData,
+    factory: ApiFactory
+  ) async -> URLRequest? {
     let url: URL
 
     if let components = components {
@@ -59,27 +60,16 @@ struct Endpoint<Response: Decodable> {
     if let bodyData = components?.bodyData {
       request.httpBody = bodyData
     }
-
-    let headers = await factory.makeHeaders(
-      fromRequest: request,
-      isForDebugging: isForDebugging,
-      requestId: requestId
-    )
-
-    for header in headers {
-      request.setValue(
-        header.value,
-        forHTTPHeaderField: header.key
-      )
-    }
-
+    await Kind.prepare(&request, with: data)
     return request
   }
 }
 
 // MARK: - EventsResponse
-extension Endpoint where Response == EventsResponse {
-  static func events(eventsRequest: EventsRequest, factory: ApiFactory) -> Self {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == EventsResponse {
+  static func events(eventsRequest: EventsRequest) -> Self {
     let bodyData = try? JSONEncoder.toSnakeCase.encode(eventsRequest)
 
     return Endpoint(
@@ -88,12 +78,11 @@ extension Endpoint where Response == EventsResponse {
         path: Api.version1 + "events",
         bodyData: bodyData
       ),
-      method: .post,
-      factory: factory
+      method: .post
     )
   }
 
-  static func sessionEvents(_ session: SessionEventsRequest, factory: ApiFactory) -> Self {
+  static func sessionEvents(_ session: SessionEventsRequest) -> Self {
     let bodyData = try? JSONEncoder.toSnakeCase.encode(session)
 
     return Endpoint(
@@ -102,33 +91,39 @@ extension Endpoint where Response == EventsResponse {
         path: Api.version1 + "session_events",
         bodyData: bodyData
       ),
-      method: .post,
-      factory: factory
+      method: .post
     )
   }
 }
 
 // MARK: - Paywall
-extension Endpoint where Response == Paywall {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == Paywall {
   static func paywall(
     withIdentifier identifier: String? = nil,
     fromEvent event: EventData? = nil,
     retryCount: Int,
-    factory: ApiFactory
+    appUserId: String?,
+    apiKey: String,
+    config: Config?,
+    locale: String
   ) -> Self {
-    let bodyData: Data?
+    var bodyData: Data?
 
     if let identifier = identifier {
       return paywall(
         byIdentifier: identifier,
         retryCount: retryCount,
-        factory: factory
+        apiKey: apiKey,
+        config: config,
+        locale: locale
       )
     } else if let event = event {
       let bodyDict = ["event": event.jsonData]
       bodyData = try? JSONEncoder.toSnakeCase.encode(bodyDict)
-    } else {
-      let body = PaywallRequestBody(appUserId: factory.identityManager.userId)
+    } else if let appUserId = appUserId {
+      let body = PaywallRequestBody(appUserId: appUserId)
       bodyData = try? JSONEncoder.toSnakeCase.encode(body)
     }
 
@@ -139,35 +134,36 @@ extension Endpoint where Response == Paywall {
         path: Api.version1 + "paywall",
         bodyData: bodyData
       ),
-      method: .post,
-      factory: factory
+      method: .post
     )
   }
 
   static private func paywall(
     byIdentifier identifier: String,
     retryCount: Int,
-    factory: ApiFactory
+    apiKey: String,
+    config: Config?,
+    locale: String
   ) -> Self {
     // WARNING: Do not modify anything about this request without considering our cache eviction code
     // we must know all the exact urls we need to invalidate so changing the order, inclusion, etc of any query
     // parameters will cause issues
-    var queryItems = [URLQueryItem(name: "pk", value: factory.storage.apiKey)]
+    var queryItems = [URLQueryItem(name: "pk", value: apiKey)]
 
     // In the config endpoint we return all the locales, this code will check if:
     // 1. The device locale (ex: en_US) exists in the locales list
     // 2. The shortend device locale (ex: en) exists in the locale list
     // If either exist (preferring the most specific) include the locale in the
     // the url as a query param.
-    if let config = factory.configManager.config {
-      if config.locales.contains(factory.deviceHelper.locale) {
+    if let config = config {
+      if config.locales.contains(locale) {
         let localeQuery = URLQueryItem(
           name: "locale",
-          value: factory.deviceHelper.locale
+          value: locale
         )
         queryItems.append(localeQuery)
       } else {
-        let shortLocale = factory.deviceHelper.locale.split(separator: "_")[0]
+        let shortLocale = locale.split(separator: "_")[0]
         if config.locales.contains(String(shortLocale)) {
           let localeQuery = URLQueryItem(
             name: "locale",
@@ -185,35 +181,35 @@ extension Endpoint where Response == Paywall {
         path: Api.version1 + "paywall/\(identifier)",
         queryItems: queryItems
       ),
-      method: .get,
-      factory: factory
+      method: .get
     )
   }
 }
 
 // MARK: - PaywallsResponse
-extension Endpoint where Response == Paywalls {
-  static func paywalls(factory: ApiFactory) -> Self {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == Paywalls {
+  static func paywalls() -> Self {
     return Endpoint(
       components: Components(
         host: .base,
         path: Api.version1 + "paywalls"
       ),
-      method: .get,
-      isForDebugging: true,
-      factory: factory
+      method: .get
     )
   }
 }
 
 // MARK: - ConfigResponse
-extension Endpoint where Response == Config {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == Config {
   static func config(
-    requestId: String,
     maxRetry: Int?,
-    factory: ApiFactory
+    apiKey: String
   ) -> Self {
-    let queryItems = [URLQueryItem(name: "pk", value: factory.storage.apiKey)]
+    let queryItems = [URLQueryItem(name: "pk", value: apiKey)]
 
     return Endpoint(
       retryCount: maxRetry ?? 6,
@@ -222,29 +218,27 @@ extension Endpoint where Response == Config {
         path: Api.version1 + "static_config",
         queryItems: queryItems
       ),
-      method: .get,
-      requestId: requestId,
-      factory: factory
+      method: .get
     )
   }
 }
 
 // MARK: - ConfirmedAssignmentResponse
-extension Endpoint where Response == ConfirmedAssignmentResponse {
-  static func assignments(factory: ApiFactory) -> Self {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == ConfirmedAssignmentResponse {
+  static func assignments() -> Self {
     return Endpoint(
       components: Components(
         host: .base,
         path: Api.version1 + "assignments"
       ),
-      method: .get,
-      factory: factory
+      method: .get
     )
   }
 
   static func confirmAssignments(
-    _ confirmableAssignments: AssignmentPostback,
-    factory: ApiFactory
+    _ confirmableAssignments: AssignmentPostback
   ) -> Self {
     let bodyData = try? JSONEncoder.toSnakeCase.encode(confirmableAssignments)
 
@@ -254,16 +248,16 @@ extension Endpoint where Response == ConfirmedAssignmentResponse {
         path: Api.version1 + "confirm_assignments",
         bodyData: bodyData
       ),
-      method: .post,
-      factory: factory
+      method: .post
     )
   }
 }
 
 // MARK: - GeoWrapper
-extension Endpoint where Response == GeoWrapper {
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == GeoWrapper {
   static func geo(
-    factory: ApiFactory,
     maxRetry: Int?
   ) -> Self {
     return Endpoint(
@@ -272,8 +266,29 @@ extension Endpoint where Response == GeoWrapper {
         host: .geo,
         path: Api.version1 + "geo"
       ),
-      method: .get,
-      factory: factory
+      method: .get
+    )
+  }
+}
+
+// MARK: - AdServicesAttributes
+extension Endpoint where
+  Kind == EndpointKinds.AdServices,
+  Response == AdServicesAttributes {
+  static func adServicesAttribution(
+    token: String
+  ) -> Self {
+    let bodyData = Data(token.utf8)
+
+    return Endpoint(
+      retryCount: 3,
+      retryInterval: 5,
+      components: Components(
+        host: .adServices,
+        path: Api.version1,
+        bodyData: bodyData
+      ),
+      method: .post
     )
   }
 }

--- a/Sources/SuperwallKit/Network/EndpointKind.swift
+++ b/Sources/SuperwallKit/Network/EndpointKind.swift
@@ -1,0 +1,75 @@
+//
+//  EndpointKind.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 25/09/2024.
+//
+
+import Foundation
+
+protocol EndpointKind {
+  associatedtype RequestData
+  static var jsonDecoder: JSONDecoder { get }
+  static func prepare(
+    _ request: inout URLRequest,
+    with data: RequestData
+  ) async
+
+  static func makeDefaultComponents(
+    factory: ApiFactory,
+    host: EndpointHost
+  ) -> ApiHostConfig
+}
+
+extension EndpointKind {
+  static func makeDefaultComponents(
+    factory: ApiFactory,
+    host: EndpointHost
+  ) -> ApiHostConfig {
+    factory.makeDefaultComponents(host: host)
+  }
+}
+
+struct SuperwallRequestData {
+  let factory: ApiFactory
+  var requestId = UUID().uuidString
+  var isForDebugging = false
+}
+
+enum EndpointKinds {
+  enum Superwall: EndpointKind {
+    static var jsonDecoder = JSONDecoder.fromSnakeCase
+
+    static func prepare(
+      _ request: inout URLRequest,
+      with data: SuperwallRequestData
+    ) async {
+      let headers = await data.factory.makeHeaders(
+        fromRequest: request,
+        isForDebugging: data.isForDebugging,
+        requestId: data.requestId
+      )
+
+      for header in headers {
+        request.setValue(
+          header.value,
+          forHTTPHeaderField: header.key
+        )
+      }
+    }
+  }
+
+  enum AdServices: EndpointKind {
+    static var jsonDecoder = JSONDecoder()
+
+    static func prepare(
+      _ request: inout URLRequest,
+      with _: Void
+    ) async {
+      request.setValue(
+        "Content-Type",
+        forHTTPHeaderField: "text/plain"
+      )
+    }
+  }
+}

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yusuf Tör on 04/03/2022.
 //
+// swiftlint:disable type_body_length
 
 import Foundation
 import UIKit
@@ -15,10 +16,10 @@ class Network {
   private var applicationStateSubject: CurrentValueSubject<UIApplication.State, Never> = .init(.background)
 
   init(
-    urlSession: CustomURLSession = CustomURLSession(),
+    urlSession: CustomURLSession? = nil,
     factory: ApiFactory
   ) {
-    self.urlSession = urlSession
+    self.urlSession = urlSession ?? CustomURLSession(factory: factory)
     self.factory = factory
 
     Task { @MainActor [weak self] in
@@ -47,7 +48,10 @@ class Network {
 
   func sendEvents(events: EventsRequest) async {
     do {
-      let result = try await urlSession.request(.events(eventsRequest: events, factory: factory))
+      let result = try await urlSession.request(
+        .events(eventsRequest: events),
+        data: SuperwallRequestData(factory: factory)
+      )
       switch result.status {
       case .ok:
         break
@@ -81,8 +85,12 @@ class Network {
           withIdentifier: identifier,
           fromEvent: event,
           retryCount: retryCount,
-          factory: factory
-        )
+          appUserId: factory.identityManager.userId,
+          apiKey: factory.storage.apiKey,
+          config: factory.configManager.config,
+          locale: factory.deviceHelper.locale
+        ),
+        data: SuperwallRequestData(factory: factory)
       )
     } catch {
       if identifier == nil {
@@ -110,7 +118,13 @@ class Network {
 
   func getPaywalls() async throws -> [Paywall] {
     do {
-      let response = try await urlSession.request(.paywalls(factory: factory))
+      let response = try await urlSession.request(
+        .paywalls(),
+        data: SuperwallRequestData(
+          factory: factory,
+          isForDebugging: true
+        )
+      )
       return response.paywalls
     } catch {
       Logger.debug(
@@ -134,9 +148,12 @@ class Network {
       let requestId = UUID().uuidString
       var config = try await urlSession.request(
         .config(
-          requestId: requestId,
           maxRetry: maxRetry,
-          factory: factory
+          apiKey: factory.storage.apiKey
+        ),
+        data: SuperwallRequestData(
+          factory: factory,
+          requestId: requestId
         ),
         isRetryingCallback: isRetryingCallback
       )
@@ -173,7 +190,10 @@ class Network {
   ) async throws -> GeoInfo? {
     do {
       try await appInForeground(injectedApplicationStatePublisher)
-      let geoWrapper = try await urlSession.request(.geo(factory: factory, maxRetry: maxRetry))
+      let geoWrapper = try await urlSession.request(
+        .geo(maxRetry: maxRetry),
+        data: SuperwallRequestData(factory: factory)
+      )
       return geoWrapper.info
     } catch {
       Logger.debug(
@@ -188,7 +208,10 @@ class Network {
 
   func confirmAssignments(_ confirmableAssignments: AssignmentPostback) async {
     do {
-      try await urlSession.request(.confirmAssignments(confirmableAssignments, factory: factory))
+      try await urlSession.request(
+        .confirmAssignments(confirmableAssignments),
+        data: SuperwallRequestData(factory: factory)
+      )
     } catch {
       Logger.debug(
         logLevel: .error,
@@ -202,7 +225,10 @@ class Network {
 
   func getAssignments() async throws -> [Assignment] {
     do {
-      let result = try await urlSession.request(.assignments(factory: factory))
+      let result = try await urlSession.request(
+        .assignments(),
+        data: SuperwallRequestData(factory: factory)
+      )
       return result.assignments
     } catch {
       Logger.debug(
@@ -217,7 +243,10 @@ class Network {
 
   func sendSessionEvents(_ session: SessionEventsRequest) async {
     do {
-      let result = try await urlSession.request(.sessionEvents(session, factory: factory))
+      let result = try await urlSession.request(
+        .sessionEvents(session),
+        data: SuperwallRequestData(factory: factory)
+      )
       switch result.status {
       case .ok:
         break
@@ -237,6 +266,24 @@ class Network {
         info: ["payload": session],
         error: error
       )
+    }
+  }
+
+  func getAttributes(from token: String) async throws -> AdServicesAttributes {
+    do {
+      let result = try await urlSession.request(
+        .adServicesAttribution(token: token),
+        data: ()
+      )
+      return result
+    } catch {
+      Logger.debug(
+        logLevel: .error,
+        scope: .network,
+        message: "Request failed to get AdServices attributes",
+        error: error
+      )
+      throw error
     }
   }
 }

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -125,6 +125,7 @@ class Network {
 
   func getConfig(
     injectedApplicationStatePublisher: (AnyPublisher<UIApplication.State, Never>)? = nil,
+    maxRetry: Int? = nil,
     isRetryingCallback: ((Int) -> Void)? = nil
   ) async throws -> Config {
     try await appInForeground(injectedApplicationStatePublisher)
@@ -132,7 +133,11 @@ class Network {
     do {
       let requestId = UUID().uuidString
       var config = try await urlSession.request(
-        .config(requestId: requestId, factory: factory),
+        .config(
+          requestId: requestId,
+          maxRetry: maxRetry,
+          factory: factory
+        ),
         isRetryingCallback: isRetryingCallback
       )
       config.requestId = requestId

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -168,11 +168,12 @@ class Network {
   }
 
   func getGeoInfo(
-    injectedApplicationStatePublisher: (AnyPublisher<UIApplication.State, Never>)? = nil
-  ) async -> GeoInfo? {
+    injectedApplicationStatePublisher: (AnyPublisher<UIApplication.State, Never>)? = nil,
+    maxRetry: Int?
+  ) async throws -> GeoInfo? {
     do {
       try await appInForeground(injectedApplicationStatePublisher)
-      let geoWrapper = try await urlSession.request(.geo(factory: factory))
+      let geoWrapper = try await urlSession.request(.geo(factory: factory, maxRetry: maxRetry))
       return geoWrapper.info
     } catch {
       Logger.debug(
@@ -181,7 +182,7 @@ class Network {
         message: "Request Failed: /geo",
         error: error
       )
-      return nil
+      throw error
     }
   }
 

--- a/Sources/SuperwallKit/Paywall/Capabilities/Capabilities.swift
+++ b/Sources/SuperwallKit/Paywall/Capabilities/Capabilities.swift
@@ -37,6 +37,10 @@ struct ConfigRefreshCapability: Capability {
   let name = "config_refresh"
 }
 
+struct ConfigCaching: Capability {
+  let name = "config_caching"
+}
+
 struct WebViewTextInteractionCapability: Capability {
   let name = "webview_text_interaction"
 }

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -268,8 +268,6 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   }
 
   func loadWebView() {
-    let url = paywall.url
-
     if paywall.webviewLoadingInfo.startAt == nil {
       paywall.webviewLoadingInfo.startAt = Date()
     }
@@ -447,7 +445,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
         self.exitButton.alpha = 0.0
 
         Task(priority: .utility) {
-          let trackedEvent = InternalSuperwallEvent.PaywallWebviewLoad(
+          let trackedEvent = await InternalSuperwallEvent.PaywallWebviewLoad(
             state: .timeout,
             paywallInfo: self.info
           )

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/SWWebView.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/SWWebView.swift
@@ -159,8 +159,8 @@ extension SWWebView: SWWebViewLoadingDelegate {
     }
     load(request)
 
-    return try await withCheckedThrowingContinuation { continuation in
-      self.completion = { [weak self] error in
+    return try await withCheckedThrowingContinuation { [weak self] continuation in
+      self?.completion = { [weak self] error in
         if let error = error {
           continuation.resume(throwing: error)
         } else {

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -168,3 +168,11 @@ enum LatestGeoInfo: Storable {
   static var directory: SearchPathDirectory = .appSpecificDocuments
   typealias Value = GeoInfo
 }
+
+enum AdServicesAttributesStorage: Storable {
+  static var key: String {
+    "store.adServicesAttributes"
+  }
+  static var directory: SearchPathDirectory = .userSpecificDocuments
+  typealias Value = AdServicesAttributes
+}

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -152,3 +152,19 @@ enum DisableVerboseEvents: Storable {
   static var directory: SearchPathDirectory = .appSpecificDocuments
   typealias Value = Bool
 }
+
+enum LatestConfig: Storable {
+  static var key: String {
+    "store.config"
+  }
+  static var directory: SearchPathDirectory = .appSpecificDocuments
+  typealias Value = Config
+}
+
+enum LatestGeoInfo: Storable {
+  static var key: String {
+    "store.geoInfo"
+  }
+  static var directory: SearchPathDirectory = .appSpecificDocuments
+  typealias Value = GeoInfo
+}

--- a/Sources/SuperwallKit/StoreKit/Products/ProductsFetcherSK1.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/ProductsFetcherSK1.swift
@@ -44,8 +44,8 @@ class ProductsFetcherSK1: NSObject {
     forPaywall paywall: Paywall?,
     event: EventData?
   ) async throws -> Set<StoreProduct> {
-    let sk1Products = try await withCheckedThrowingContinuation { continuation in
-      products(withIdentifiers: identifiers, forPaywall: paywall, event: event) { result in
+    let sk1Products = try await withCheckedThrowingContinuation { [weak self] continuation in
+      self?.products(withIdentifiers: identifiers, forPaywall: paywall, event: event) { result in
         continuation.resume(with: result)
       }
     }

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -254,6 +254,14 @@ public final class Superwall: NSObject, ObservableObject {
     // This is because the function isn't marked to run on the main thread,
     // therefore, we don't need to make this detached.
     Task {
+      Task {
+        #if os(iOS) || os(macOS) || VISION_OS
+        if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+          await dependencyContainer.attributionPoster.getAdServicesAttributesIfNeeded()
+        }
+        #endif
+      }
+
       dependencyContainer.storage.configure(apiKey: apiKey)
 
       dependencyContainer.storage.recordAppInstall(trackEvent: track)
@@ -625,6 +633,12 @@ public final class Superwall: NSObject, ObservableObject {
     dependencyContainer.configManager.reset()
     Task {
       await Superwall.shared.track(InternalSuperwallEvent.Reset())
+
+      #if os(iOS) || os(macOS) || VISION_OS
+      if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+        await dependencyContainer.attributionPoster.getAdServicesAttributesIfNeeded()
+      }
+      #endif
     }
   }
 }

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.8.0"
+    s.version      = "3.9.0"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.7.5"
+    s.version      = "3.8.0"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Tests/SuperwallKitTests/Config/ConfigManagerTests.swift
+++ b/Tests/SuperwallKitTests/Config/ConfigManagerTests.swift
@@ -11,6 +11,33 @@ import XCTest
 
 @available(iOS 14.0, *)
 final class ConfigManagerTests: XCTestCase {
+  func test_refreshConfiguration() async {
+    let dependencyContainer = DependencyContainer()
+    let network = NetworkMock(factory: dependencyContainer)
+    let newConfig: Config = .stub()
+      .setting(\.buildId, to: "123")
+    network.configReturnValue = .success(newConfig)
+
+    let storage = StorageMock()
+    let configManager = ConfigManager(
+      options: SuperwallOptions(),
+      storeKitManager: dependencyContainer.storeKitManager,
+      storage: storage,
+      network: network,
+      paywallManager: dependencyContainer.paywallManager,
+      deviceHelper: dependencyContainer.deviceHelper,
+      factory: dependencyContainer
+    )
+
+    let oldConfig: Config = .stub()
+      .setting(\.buildId, to: "abc")
+    configManager.configState.send(.retrieved(oldConfig))
+
+    await configManager.refreshConfiguration()
+
+    XCTAssertEqual(configManager.config?.buildId, "123")
+  }
+
   // MARK: - Confirm Assignments
   func test_confirmAssignment() async {
     let experimentId = "abc"

--- a/Tests/SuperwallKitTests/Network/Custom URL Session/CustomURLSessionMock.swift
+++ b/Tests/SuperwallKitTests/Network/Custom URL Session/CustomURLSessionMock.swift
@@ -11,12 +11,12 @@ import Foundation
 final class CustomURLSessionMock: CustomURLSession {
   var didRequest = false
 
-  @discardableResult
-  override func request<Response>(
-    _ endpoint: Endpoint<Response>,
+  override func request<Kind, Response>(
+    _ endpoint: Endpoint<Kind, Response>,
+    data: Kind.RequestData,
     isRetryingCallback: ((Int) -> Void)? = nil
-  ) async throws -> Response {
+  ) async throws -> Response where Kind : EndpointKind, Response : Decodable {
     didRequest = true
-    return try await super.request(endpoint)
+    return try await super.request(endpoint, data: data, isRetryingCallback: isRetryingCallback)
   }
 }

--- a/Tests/SuperwallKitTests/Network/NetworkMock.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkMock.swift
@@ -23,6 +23,7 @@ final class NetworkMock: Network {
   @MainActor
   override func getConfig(
     injectedApplicationStatePublisher: (AnyPublisher<UIApplication.State, Never>)? = nil,
+    maxRetry: Int? = nil,
     isRetryingCallback: ((Int) -> Void)? = nil
   ) async throws -> Config {
     getConfigCalled = true

--- a/Tests/SuperwallKitTests/Network/NetworkTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkTests.swift
@@ -31,7 +31,8 @@ final class NetworkTests: XCTestCase {
 
   // MARK: - Config
   func test_config_inBackground() async {
-    let urlSession = CustomURLSessionMock()
+    let dependencyContainer = DependencyContainer()
+    let urlSession = CustomURLSessionMock(factory: dependencyContainer)
     let publisher = CurrentValueSubject<UIApplication.State, Never>(.background)
       .eraseToAnyPublisher()
     let expectation = expectation(description: "config completed")
@@ -49,8 +50,8 @@ final class NetworkTests: XCTestCase {
   }
 
   func test_config_inForeground() async {
-    let urlSession = CustomURLSessionMock()
     let dependencyContainer = DependencyContainer()
+    let urlSession = CustomURLSessionMock(factory: dependencyContainer)
     let network = Network(urlSession: urlSession, factory: dependencyContainer)
     let publisher = CurrentValueSubject<UIApplication.State, Never>(.active)
       .eraseToAnyPublisher()
@@ -63,8 +64,8 @@ final class NetworkTests: XCTestCase {
   }
 
   func test_config_inBackgroundThenForeground() async {
-    let urlSession = CustomURLSessionMock()
     let dependencyContainer = DependencyContainer()
+    let urlSession = CustomURLSessionMock(factory: dependencyContainer)
     let network = Network(urlSession: urlSession, factory: dependencyContainer)
     let publisher = [UIApplication.State.background, UIApplication.State.active]
       .publisher

--- a/Tests/SuperwallKitTests/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandlerDelegateMock.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandlerDelegateMock.swift
@@ -10,9 +10,16 @@ import Foundation
 
 final class FakeWebView: SWWebView {
   var willHandleJs = false
+
+  #if compiler(>=6.0.0)
   override func evaluateJavaScript(_ javaScriptString: String, completionHandler: (@MainActor (Any?, (any Error)?) -> Void)? = nil) {
     willHandleJs = true
   }
+  #else
+  override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, (any Error)?) -> Void)? = nil) {
+    willHandleJs = true
+  }
+  #endif
 }
 
 final class PaywallMessageHandlerDelegateMock: PaywallMessageHandlerDelegate {


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- If a network issue occurs while retrieving the latest Superwall configuration, or it takes longer than 1s to retrieve, the SDK falls back to a cached version. Then it tries to refresh it in the background. This behavior is behind a feature flag.
- When the Superwall configuration is set or refreshed, a `config_refresh` event is tracked, which will give insight into whether a cached version of the Superwall configuration is being used or not.
- When the Superwall configuration fails to be retrieved, a `config_fail` event is tracked.
- Adds the `config_caching` capability.
- Adds the `SuperwallOption` `collectAdServicesAttribution`. When set to `true`, this will get the app-download campaign attributes associated with Apple Search Ads and attach them to the user attributes. This happens once per user per install. Calling `Superwall.shared.reset()` will fetch the attributes again and attach them to the new user.
- Adds`adServicesAttributionRequest_start`, `adServicesAttributionRequest_fail`, and `adServicesAttributionRequest_complete` events for the lifecycle of collecting AdServices attributes.

### Fixes

- Adds in missing `weak self` references inside task group closures.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
