### PR TITLE
Publicly expose loadingState of PaywallController and add a proper delegate method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 3.9.3
+
+### Enhancements
+
+- Adds the `loadingStateDidChange` capability on the `PaywallViewControllerDelegate` to be notified when the loading state of the presented `PaywallViewController` did change.
+- Adds a published property `loadingStatePublisher` on the `PaywallViewController` to be notified when the loading state of the presented `PaywallViewController` did change.
+
 ## 3.9.2
 
 ### Fixes

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal/Loading State/PaywallLoadingState.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal/Loading State/PaywallLoadingState.swift
@@ -1,0 +1,60 @@
+//
+//  PaywallLoadingState.swift
+//  SuperwallKit
+//
+//  Created by Thomas LE GRAVIER on 01/10/2024.
+//
+
+import Foundation
+
+/// Contains the possible loading state of a paywall.
+public enum PaywallLoadingState {
+  /// The initial state of the paywall
+  case unknown
+
+  /// When a purchase is loading
+  case loadingPurchase
+
+  /// When the paywall URL is loading
+  case loadingURL
+
+  /// When the user has manually shown the spinner
+  case manualLoading
+
+  /// When everything has loaded.
+  case ready
+
+  func convertForObjc() -> PaywallLoadingStateObjc {
+    switch self {
+    case .unknown:
+      return .unknown
+    case .loadingPurchase:
+      return .loadingPurchase
+    case .loadingURL:
+      return .loadingURL
+    case .manualLoading:
+      return .manualLoading
+    case .ready:
+      return .ready
+    }
+  }
+}
+
+/// Objective-C-only enum. Contains the possible loading state of a paywall.
+@objc(SWKPaywallLoadingState)
+public enum PaywallLoadingStateObjc: Int, Sendable {
+  /// The initial state of the paywall
+  case unknown
+
+  /// When a purchase is loading
+  case loadingPurchase
+
+  /// When the paywall URL is loading
+  case loadingURL
+
+  /// When the user has manually shown the spinner
+  case manualLoading
+
+  /// When everything has loaded.
+  case ready
+}

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegate.swift
@@ -28,6 +28,18 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     didFinishWith result: PaywallResult,
     shouldDismiss: Bool
   )
+
+  /// Tells the delegate that the loading state of a paywall did change.
+  ///
+  /// - Parameters:
+  ///   - paywall: The ``PaywallViewController`` that the user is interacting with.
+  ///   - loadingState: A ``PaywallLoadingState`` enum that contains the loading state of
+  ///   the ``PaywallViewController``.
+  @MainActor
+  func paywall(
+    _ paywall: PaywallViewController,
+    loadingStateDidChangeWith loadingState: PaywallLoadingState
+  )
 }
 
 /// Objective-C-only interface for responding to user interactions with a ``PaywallViewController`` that
@@ -52,6 +64,18 @@ public protocol PaywallViewControllerDelegateObjc: AnyObject {
     didFinishWithResult result: PaywallResultObjc,
     shouldDismiss: Bool
   )
+    
+  /// Tells the delegate that the loading state of a paywall did change.
+  ///
+  /// - Parameters:
+  ///   - paywall: The ``PaywallViewController`` that the user is interacting with.
+  ///   - loadingState: A ``PaywallLoadingState`` enum that contains the loading state of
+  ///   the ``PaywallViewController``.
+  @MainActor
+  func paywall(
+    _ paywall: PaywallViewController,
+    didChangeWithLoadingState loadingState: PaywallLoadingStateObjc
+  )
 }
 
 protocol PaywallViewControllerEventDelegate: AnyObject {
@@ -59,21 +83,4 @@ protocol PaywallViewControllerEventDelegate: AnyObject {
     _ paywallEvent: PaywallWebEvent,
     on paywallViewController: PaywallViewController
   ) async
-}
-
-enum PaywallLoadingState {
-  /// The initial state of the paywall
-  case unknown
-
-  /// When a purchase is loading
-  case loadingPurchase
-
-  /// When the paywall URL is loading
-  case loadingURL
-
-  /// When the user has manually shown the spinner
-  case manualLoading
-
-  /// When everything has loaded.
-  case ready
 }

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
@@ -33,6 +33,15 @@ final class PaywallViewControllerDelegateAdapter {
     swiftDelegate?.paywall(paywall, didFinishWith: result, shouldDismiss: shouldDismiss)
     objcDelegate?.paywall(paywall, didFinishWithResult: result.convertForObjc(), shouldDismiss: shouldDismiss)
   }
+    
+  @MainActor
+  func loadingStateDidChange(
+    paywall: PaywallViewController,
+    loadingState: PaywallLoadingState
+  ) {
+    swiftDelegate?.paywall(paywall, loadingStateDidChangeWith: loadingState)
+    objcDelegate?.paywall(paywall, didChangeWithLoadingState: loadingState.convertForObjc())
+  }
 }
 
 // MARK: - Stubbable

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -19,6 +19,11 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     return paywallStateSubject?.eraseToAnyPublisher()
   }
 
+  /// A publisher that emits ``PaywallLoadingState`` objects, which tell you the loading state of the presented paywall.
+  public var loadingStatePublisher: AnyPublisher<PaywallLoadingState, Never>? {
+    return paywallLoadingStateSubject?.eraseToAnyPublisher()
+  }
+
   /// Defines whether the presentation should animate based on the presentation style.
   @objc public var presentationIsAnimated: Bool {
     return presentationStyle != .fullscreenNoAnimation
@@ -60,6 +65,11 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     didSet {
       if loadingState != oldValue {
         loadingStateDidChange(from: oldValue)
+        paywallLoadingStateSubject?.send(loadingState)
+        delegate?.loadingStateDidChange(
+         paywall: self,
+         loadingState: loadingState
+        )
       }
     }
   }
@@ -72,6 +82,9 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   ///
   /// This publisher is set on presentation of the paywall.
   private var paywallStateSubject: PassthroughSubject<PaywallState, Never>?
+
+  /// This publisher is set on loading state change of the paywall.
+  private var paywallLoadingStateSubject: PassthroughSubject<PaywallLoadingState, Never>?
 
   private weak var eventDelegate: PaywallViewControllerEventDelegate?
 


### PR DESCRIPTION
## Changes in this pull request

- Adds the `loadingStateDidChange` capability on the `PaywallViewControllerDelegate` to be notified when the loading state of the presented `PaywallViewController` did change.
- Adds a published property `loadingStatePublisher` on the `PaywallViewController` to be notified when the loading state of the presented `PaywallViewController` did change.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
