### PR TITLE
Publicly expose loadingState of PaywallController and add a proper delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,14 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
-## 3.10.1
-
-### Enhancements
-
-- Adds the `loadingStateDidChange` capability on the `PaywallViewControllerDelegate` to be notified when the loading state of the presented `PaywallViewController` did change.
-- Adds a published property `loadingStatePublisher` on the `PaywallViewController` to be notified when the loading state of the presented `PaywallViewController` did change.
-
 ## 3.10.0
 
 ### Enhancements
 
 - Adds `purchase(_:)` to initiate a purchase of an `SKProduct` via Superwall regardless of whether you are using paywalls or not.
 - Adds `restorePurchases()` to restore purchases via Superwall.
+- Adds an optional `paywall(_:loadingStateDidChange)` function to the `PaywallViewControllerDelegate`. This is called when the loading state of the presented `PaywallViewController` did change.
+- Makes `loadingState` on the `PaywallViewController` a public published property.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 3.10.1
+
+### Enhancements
+
+- Adds the `loadingStateDidChange` capability on the `PaywallViewControllerDelegate` to be notified when the loading state of the presented `PaywallViewController` did change.
+- Adds a published property `loadingStatePublisher` on the `PaywallViewController` to be notified when the loading state of the presented `PaywallViewController` did change.
+
 ## 3.10.0
 
 ### Enhancements

--- a/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
+++ b/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
@@ -55,6 +55,9 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``SuperwallEventObjc``
 - ``PaywallSkippedReason``
 - ``PaywallSkippedReasonObjc``
+- ``PaywallViewController``
+- ``PaywallViewControllerDelegate``
+- ``PaywallViewControllerDelegateObjc``
 
 ### Handling Purchases
 

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal/Loading State/PaywallLoadingState.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal/Loading State/PaywallLoadingState.swift
@@ -7,42 +7,9 @@
 
 import Foundation
 
-/// Contains the possible loading state of a paywall.
-public enum PaywallLoadingState {
-  /// The initial state of the paywall
-  case unknown
-
-  /// When a purchase is loading
-  case loadingPurchase
-
-  /// When the paywall URL is loading
-  case loadingURL
-
-  /// When the user has manually shown the spinner
-  case manualLoading
-
-  /// When everything has loaded.
-  case ready
-
-  func convertForObjc() -> PaywallLoadingStateObjc {
-    switch self {
-    case .unknown:
-      return .unknown
-    case .loadingPurchase:
-      return .loadingPurchase
-    case .loadingURL:
-      return .loadingURL
-    case .manualLoading:
-      return .manualLoading
-    case .ready:
-      return .ready
-    }
-  }
-}
-
-/// Objective-C-only enum. Contains the possible loading state of a paywall.
+/// Contains the possible loading states of a paywall.
 @objc(SWKPaywallLoadingState)
-public enum PaywallLoadingStateObjc: Int, Sendable {
+public enum PaywallLoadingState: Int, Sendable {
   /// The initial state of the paywall
   case unknown
 

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal/Loading State/PaywallLoadingState.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal/Loading State/PaywallLoadingState.swift
@@ -1,0 +1,60 @@
+//
+//  PaywallLoadingState.swift
+//  SuperwallKit
+//
+//  Created by Thomas LE GRAVIER on 03/10/2024.
+//
+
+import Foundation
+
+/// Contains the possible loading state of a paywall.
+public enum PaywallLoadingState {
+  /// The initial state of the paywall
+  case unknown
+
+  /// When a purchase is loading
+  case loadingPurchase
+
+  /// When the paywall URL is loading
+  case loadingURL
+
+  /// When the user has manually shown the spinner
+  case manualLoading
+
+  /// When everything has loaded.
+  case ready
+
+  func convertForObjc() -> PaywallLoadingStateObjc {
+    switch self {
+    case .unknown:
+      return .unknown
+    case .loadingPurchase:
+      return .loadingPurchase
+    case .loadingURL:
+      return .loadingURL
+    case .manualLoading:
+      return .manualLoading
+    case .ready:
+      return .ready
+    }
+  }
+}
+
+/// Objective-C-only enum. Contains the possible loading state of a paywall.
+@objc(SWKPaywallLoadingState)
+public enum PaywallLoadingStateObjc: Int, Sendable {
+  /// The initial state of the paywall
+  case unknown
+
+  /// When a purchase is loading
+  case loadingPurchase
+
+  /// When the paywall URL is loading
+  case loadingURL
+
+  /// When the user has manually shown the spinner
+  case manualLoading
+
+  /// When everything has loaded.
+  case ready
+}

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegate.swift
@@ -28,6 +28,18 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     didFinishWith result: PaywallResult,
     shouldDismiss: Bool
   )
+
+  /// Tells the delegate that the loading state of a paywall did change.
+  ///
+  /// - Parameters:
+  ///   - paywall: The ``PaywallViewController`` that the user is interacting with.
+  ///   - loadingState: A ``PaywallLoadingState`` enum that contains the loading state of
+  ///   the ``PaywallViewController``.
+  @MainActor
+  func paywall(
+    _ paywall: PaywallViewController,
+    loadingStateDidChangeWith loadingState: PaywallLoadingState
+  )
 }
 
 /// Objective-C-only interface for responding to user interactions with a ``PaywallViewController`` that
@@ -52,6 +64,18 @@ public protocol PaywallViewControllerDelegateObjc: AnyObject {
     didFinishWithResult result: PaywallResultObjc,
     shouldDismiss: Bool
   )
+
+  /// Tells the delegate that the loading state of a paywall did change.
+  ///
+  /// - Parameters:
+  ///   - paywall: The ``PaywallViewController`` that the user is interacting with.
+  ///   - loadingState: A ``PaywallLoadingState`` enum that contains the loading state of
+  ///   the ``PaywallViewController``.
+  @MainActor
+  func paywall(
+    _ paywall: PaywallViewController,
+    didChangeWithLoadingState loadingState: PaywallLoadingStateObjc
+  )
 }
 
 protocol PaywallViewControllerEventDelegate: AnyObject {
@@ -59,21 +83,4 @@ protocol PaywallViewControllerEventDelegate: AnyObject {
     _ paywallEvent: PaywallWebEvent,
     on paywallViewController: PaywallViewController
   ) async
-}
-
-enum PaywallLoadingState {
-  /// The initial state of the paywall
-  case unknown
-
-  /// When a purchase is loading
-  case loadingPurchase
-
-  /// When the paywall URL is loading
-  case loadingURL
-
-  /// When the user has manually shown the spinner
-  case manualLoading
-
-  /// When everything has loaded.
-  case ready
 }

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegate.swift
@@ -29,7 +29,7 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     shouldDismiss: Bool
   )
 
-  /// Tells the delegate that the loading state of a paywall did change.
+  /// Tells the delegate that the loading state of the paywall did change.
   ///
   /// - Parameters:
   ///   - paywall: The ``PaywallViewController`` that the user is interacting with.
@@ -38,8 +38,15 @@ public protocol PaywallViewControllerDelegate: AnyObject {
   @MainActor
   func paywall(
     _ paywall: PaywallViewController,
-    loadingStateDidChangeWith loadingState: PaywallLoadingState
+    loadingStateDidChange loadingState: PaywallLoadingState
   )
+}
+
+extension PaywallViewControllerDelegate {
+  public func paywall(
+    _ paywall: PaywallViewController,
+    loadingStateDidChange loadingState: PaywallLoadingState
+  ) {}
 }
 
 /// Objective-C-only interface for responding to user interactions with a ``PaywallViewController`` that
@@ -65,7 +72,7 @@ public protocol PaywallViewControllerDelegateObjc: AnyObject {
     shouldDismiss: Bool
   )
 
-  /// Tells the delegate that the loading state of a paywall did change.
+  /// Tells the delegate that the loading state of the paywall did change.
   ///
   /// - Parameters:
   ///   - paywall: The ``PaywallViewController`` that the user is interacting with.
@@ -74,8 +81,15 @@ public protocol PaywallViewControllerDelegateObjc: AnyObject {
   @MainActor
   func paywall(
     _ paywall: PaywallViewController,
-    didChangeWithLoadingState loadingState: PaywallLoadingStateObjc
+    loadingStateDidChange loadingState: PaywallLoadingState
   )
+}
+
+extension PaywallViewControllerDelegateObjc {
+  public func paywall(
+    _ paywall: PaywallViewController,
+    loadingStateDidChange loadingState: PaywallLoadingState
+  ) {}
 }
 
 protocol PaywallViewControllerEventDelegate: AnyObject {

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
@@ -33,6 +33,15 @@ final class PaywallViewControllerDelegateAdapter {
     swiftDelegate?.paywall(paywall, didFinishWith: result, shouldDismiss: shouldDismiss)
     objcDelegate?.paywall(paywall, didFinishWithResult: result.convertForObjc(), shouldDismiss: shouldDismiss)
   }
+
+  @MainActor
+   func loadingStateDidChange(
+    paywall: PaywallViewController,
+    loadingState: PaywallLoadingState
+  ) {
+    swiftDelegate?.paywall(paywall, loadingStateDidChangeWith: loadingState)
+    objcDelegate?.paywall(paywall, didChangeWithLoadingState: loadingState.convertForObjc())
+  }
 }
 
 // MARK: - Stubbable

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
@@ -35,12 +35,12 @@ final class PaywallViewControllerDelegateAdapter {
   }
 
   @MainActor
-   func loadingStateDidChange(
+  func loadingStateDidChange(
     paywall: PaywallViewController,
     loadingState: PaywallLoadingState
   ) {
-    swiftDelegate?.paywall(paywall, loadingStateDidChangeWith: loadingState)
-    objcDelegate?.paywall(paywall, didChangeWithLoadingState: loadingState.convertForObjc())
+    swiftDelegate?.paywall(paywall, loadingStateDidChange: loadingState)
+    objcDelegate?.paywall(paywall, loadingStateDidChange: loadingState)
   }
 }
 

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -19,6 +19,11 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     return paywallStateSubject?.eraseToAnyPublisher()
   }
 
+  /// A publisher that emits ``PaywallLoadingState`` objects, which tell you the loading state of the presented paywall.
+  public var loadingStatePublisher: AnyPublisher<PaywallLoadingState, Never>? {
+    return paywallLoadingStateSubject?.eraseToAnyPublisher()
+  }
+
   /// Defines whether the presentation should animate based on the presentation style.
   @objc public var presentationIsAnimated: Bool {
     return presentationStyle != .fullscreenNoAnimation
@@ -60,6 +65,11 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     didSet {
       if loadingState != oldValue {
         loadingStateDidChange(from: oldValue)
+        paywallLoadingStateSubject?.send(loadingState)
+        delegate?.loadingStateDidChange(
+         paywall: self,
+         loadingState: loadingState
+        )
       }
     }
   }
@@ -73,6 +83,9 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   /// This publisher is set on presentation of the paywall.
   private var paywallStateSubject: PassthroughSubject<PaywallState, Never>?
 
+  /// This publisher is set on loading state change of the paywall.
+  private var paywallLoadingStateSubject: PassthroughSubject<PaywallLoadingState, Never>?
+
   private weak var eventDelegate: PaywallViewControllerEventDelegate?
 
   /// Defines whether the view controller is being presented or not.
@@ -85,10 +98,10 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   private var paywallResult: PaywallResult?
 
   /// A timer that shows the refresh buttons/modal when it fires.
-	private var showRefreshTimer: Timer?
+  private var showRefreshTimer: Timer?
 
   /// Defines when Safari is presenting in app.
-	private var isSafariVCPresented = false
+  private var isSafariVCPresented = false
 
   /// The presentation style for the paywall.
   private var presentationStyle: PaywallPresentationStyle
@@ -199,7 +212,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
 
   public override func viewDidLoad() {
     super.viewDidLoad()
-		configureUI()
+    configureUI()
     loadWebView()
 	}
 

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -19,11 +19,6 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     return paywallStateSubject?.eraseToAnyPublisher()
   }
 
-  /// A publisher that emits ``PaywallLoadingState`` objects, which tell you the loading state of the presented paywall.
-  public var loadingStatePublisher: AnyPublisher<PaywallLoadingState, Never>? {
-    return paywallLoadingStateSubject?.eraseToAnyPublisher()
-  }
-
   /// Defines whether the presentation should animate based on the presentation style.
   @objc public var presentationIsAnimated: Bool {
     return presentationStyle != .fullscreenNoAnimation
@@ -60,15 +55,16 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     )
   }
 
-  /// The loading state of the paywall.
-  var loadingState: PaywallLoadingState = .unknown {
+  /// A published property that indicates the loading state of the paywall.
+  ///
+  /// This is a published value
+  @Published public internal(set) var loadingState: PaywallLoadingState = .unknown {
     didSet {
       if loadingState != oldValue {
         loadingStateDidChange(from: oldValue)
-        paywallLoadingStateSubject?.send(loadingState)
         delegate?.loadingStateDidChange(
-         paywall: self,
-         loadingState: loadingState
+          paywall: self,
+          loadingState: loadingState
         )
       }
     }
@@ -82,9 +78,6 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   ///
   /// This publisher is set on presentation of the paywall.
   private var paywallStateSubject: PassthroughSubject<PaywallState, Never>?
-
-  /// This publisher is set on loading state change of the paywall.
-  private var paywallLoadingStateSubject: PassthroughSubject<PaywallLoadingState, Never>?
 
   private weak var eventDelegate: PaywallViewControllerEventDelegate?
 


### PR DESCRIPTION
## Changes in this pull request

- Adds the `loadingStateDidChange` capability on the `PaywallViewControllerDelegate` to be notified when the loading state of the presented `PaywallViewController` did change.
- Adds a published property `loadingStatePublisher` on the `PaywallViewController` to be notified when the loading state of the presented `PaywallViewController` did change.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
