### PR TITLE
3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 3.10.2
+
+### Enhancements
+
+- Adds `maxConfigRetryCount` as a `SuperwallOption`. Use this to determine the number of times the SDK will attempt to get the Superwall configuration after a network failure before it times out.
+
 ## 3.10.1
 
 ### Fixes

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -552,9 +552,13 @@ enum InternalSuperwallEvent {
     }
 
     func getSuperwallParameters() async -> [String: Any] {
+      var eventParams: [String: Any] = [
+        "store": "APP_STORE"
+      ]
+
       switch state {
       case .restore:
-        var eventParams = await paywallInfo.eventParams(forProduct: product)
+        eventParams += await paywallInfo.eventParams(forProduct: product)
         if let transactionDict = model?.dictionary(withSnakeCase: true) {
           eventParams += transactionDict
         }
@@ -564,7 +568,7 @@ enum InternalSuperwallEvent {
         .abandon,
         .complete,
         .timeout:
-        var eventParams = await paywallInfo.eventParams(forProduct: product)
+        eventParams += await paywallInfo.eventParams(forProduct: product)
         if let transactionDict = model?.dictionary(withSnakeCase: true) {
           eventParams += transactionDict
         }

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -160,6 +160,20 @@ public final class SuperwallOptions: NSObject, Encodable {
   /// Defaults to `false`.
   public var collectAdServicesAttribution = false
 
+  /// Determines the number of times the SDK will attempt to get the Superwall configuration after a network
+  /// failure before it times out. Defaults to 6.
+  ///
+  /// Adjust this if you want the SDK to call the ``PaywallPresentationHandler/onError(_:)``
+  /// handler of the ``PaywallPresentationHandler`` faster when you call ``Superwall/register(event:)``
+  public var maxConfigRetryCount = 6 {
+    didSet {
+      // Must be >= 0
+      if maxConfigRetryCount < 0 {
+        maxConfigRetryCount = 0
+      }
+    }
+  }
+
   /// Configuration for printing to the console.
   @objc(SWKLogging)
   @objcMembers

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -55,7 +55,11 @@ final class DependencyContainer {
     storeKitManager = StoreKitManager(productsFetcher: productsFetcher)
     delegateAdapter = SuperwallDelegateAdapter()
     storage = Storage(factory: self)
-    network = Network(factory: self)
+    let options = options ?? SuperwallOptions()
+    network = Network(
+      options: options,
+      factory: self
+    )
 
     paywallRequestManager = PaywallRequestManager(
       storeKitManager: storeKitManager,
@@ -67,7 +71,6 @@ final class DependencyContainer {
       paywallRequestManager: paywallRequestManager
     )
 
-    let options = options ?? SuperwallOptions()
     api = Api(networkEnvironment: options.networkEnvironment)
     attributionPoster = AttributionPoster(
       collectAdServicesAttribution: options.collectAdServicesAttribution,

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.10.1
+3.10.2
 """

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -206,13 +206,13 @@ extension Endpoint where
   Kind == EndpointKinds.Superwall,
   Response == Config {
   static func config(
-    maxRetry: Int?,
+    maxRetry: Int,
     apiKey: String
   ) -> Self {
     let queryItems = [URLQueryItem(name: "pk", value: apiKey)]
 
     return Endpoint(
-      retryCount: maxRetry ?? 6,
+      retryCount: maxRetry,
       components: Components(
         host: .base,
         path: Api.version1 + "static_config",
@@ -258,10 +258,10 @@ extension Endpoint where
   Kind == EndpointKinds.Superwall,
   Response == GeoWrapper {
   static func geo(
-    maxRetry: Int?
+    maxRetry: Int
   ) -> Self {
     return Endpoint(
-      retryCount: maxRetry ?? 6,
+      retryCount: maxRetry,
       components: Components(
         host: .geo,
         path: Api.version1 + "geo"

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -12,12 +12,15 @@ import Combine
 class Network {
   private let urlSession: CustomURLSession
   private let factory: ApiFactory
+  private let options: SuperwallOptions
   private var applicationStateSubject: CurrentValueSubject<UIApplication.State, Never> = .init(.background)
 
   init(
     urlSession: CustomURLSession? = nil,
+    options: SuperwallOptions,
     factory: ApiFactory
   ) {
+    self.options = options
     self.urlSession = urlSession ?? CustomURLSession(factory: factory)
     self.factory = factory
 
@@ -147,7 +150,7 @@ class Network {
       let requestId = UUID().uuidString
       var config = try await urlSession.request(
         .config(
-          maxRetry: maxRetry,
+          maxRetry: maxRetry ?? options.maxConfigRetryCount,
           apiKey: factory.storage.apiKey
         ),
         data: SuperwallRequestData(
@@ -190,7 +193,7 @@ class Network {
     do {
       try await appInForeground(injectedApplicationStatePublisher)
       let geoWrapper = try await urlSession.request(
-        .geo(maxRetry: maxRetry),
+        .geo(maxRetry: maxRetry ?? options.maxConfigRetryCount),
         data: SuperwallRequestData(factory: factory)
       )
       return geoWrapper.info

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.10.1"
+    s.version      = "3.10.2"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Tests/SuperwallKitTests/Analytics/Session Events/SessionEventsManagerTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Session Events/SessionEventsManagerTests.swift
@@ -17,7 +17,10 @@ final class SessionEventsManagerTests: XCTestCase {
       internalCachedTransactions: []
     )
     let dependencyContainer = DependencyContainer()
-    let network = NetworkMock(factory: dependencyContainer)
+    let network = NetworkMock(
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     _ = SessionEventsManager(
       queue: SessionEventsQueue(
         storage: storage,
@@ -45,7 +48,10 @@ final class SessionEventsManagerTests: XCTestCase {
     let configManager = dependencyContainer.configManager!
     configManager.configState.send(.retrieved(.stub()))
 
-    let network = NetworkMock(factory: dependencyContainer)
+    let network = NetworkMock(
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     _ = SessionEventsManager(
       queue: SessionEventsQueue(
         storage: storage,

--- a/Tests/SuperwallKitTests/Config/ConfigManagerTests.swift
+++ b/Tests/SuperwallKitTests/Config/ConfigManagerTests.swift
@@ -13,7 +13,10 @@ import XCTest
 final class ConfigManagerTests: XCTestCase {
   func test_refreshConfiguration() async {
     let dependencyContainer = DependencyContainer()
-    let network = NetworkMock(factory: dependencyContainer)
+    let network = NetworkMock(
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     let newConfig: Config = .stub()
       .setting(\.buildId, to: "123")
     network.configReturnValue = .success(newConfig)
@@ -72,7 +75,10 @@ final class ConfigManagerTests: XCTestCase {
       variant: variant
     )
     let dependencyContainer = DependencyContainer()
-    let network = NetworkMock(factory: dependencyContainer)
+    let network = NetworkMock(
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     let storage = StorageMock()
     let configManager = ConfigManager(
       options: SuperwallOptions(),
@@ -98,7 +104,10 @@ final class ConfigManagerTests: XCTestCase {
 
   func test_loadAssignments_noConfig() async {
     let dependencyContainer = DependencyContainer()
-    let network = NetworkMock(factory: dependencyContainer)
+    let network = NetworkMock(
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     let storage = StorageMock()
     let configManager = ConfigManager(
       options: SuperwallOptions(),
@@ -125,7 +134,10 @@ final class ConfigManagerTests: XCTestCase {
 
   func test_loadAssignments_noTriggers() async {
     let dependencyContainer = DependencyContainer()
-    let network = NetworkMock(factory: dependencyContainer)
+    let network = NetworkMock(
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     let storage = StorageMock()
     let configManager = ConfigManager(
       options: SuperwallOptions(),
@@ -147,7 +159,10 @@ final class ConfigManagerTests: XCTestCase {
 
   func test_loadAssignments_saveAssignmentsFromServer() async {
     let dependencyContainer = DependencyContainer()
-    let network = NetworkMock(factory: dependencyContainer)
+    let network = NetworkMock(
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     let storage = StorageMock()
     let configManager = ConfigManager(
       options: SuperwallOptions(),

--- a/Tests/SuperwallKitTests/Network/NetworkTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkTests.swift
@@ -19,8 +19,12 @@ final class NetworkTests: XCTestCase {
   ) {
     _ = Task {
       let dependencyContainer = DependencyContainer()
-      let network = Network(urlSession: urlSession, factory: dependencyContainer)
-      
+      let network = Network(
+        urlSession: urlSession,
+        options: SuperwallOptions(),
+        factory: dependencyContainer
+      )
+
       _ = try? await network.getConfig(
         injectedApplicationStatePublisher: injectedApplicationStatePublisher,
         isRetryingCallback: { _ in }
@@ -52,7 +56,11 @@ final class NetworkTests: XCTestCase {
   func test_config_inForeground() async {
     let dependencyContainer = DependencyContainer()
     let urlSession = CustomURLSessionMock(factory: dependencyContainer)
-    let network = Network(urlSession: urlSession, factory: dependencyContainer)
+    let network = Network(
+      urlSession: urlSession,
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     let publisher = CurrentValueSubject<UIApplication.State, Never>(.active)
       .eraseToAnyPublisher()
 
@@ -66,7 +74,11 @@ final class NetworkTests: XCTestCase {
   func test_config_inBackgroundThenForeground() async {
     let dependencyContainer = DependencyContainer()
     let urlSession = CustomURLSessionMock(factory: dependencyContainer)
-    let network = Network(urlSession: urlSession, factory: dependencyContainer)
+    let network = Network(
+      urlSession: urlSession,
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     let publisher = [UIApplication.State.background, UIApplication.State.active]
       .publisher
       .eraseToAnyPublisher()

--- a/Tests/SuperwallKitTests/Storage/StorageTests.swift
+++ b/Tests/SuperwallKitTests/Storage/StorageTests.swift
@@ -13,7 +13,10 @@ class StorageTests: XCTestCase {
   func test_saveConfirmedAssignments() {
     let dependencyContainer = DependencyContainer()
     let storage = Storage(factory: dependencyContainer)
-    let network = NetworkMock(factory: dependencyContainer)
+    let network = NetworkMock(
+      options: SuperwallOptions(),
+      factory: dependencyContainer
+    )
     let configManager = ConfigManager(
       options: SuperwallOptions(),
       storeKitManager: dependencyContainer.storeKitManager,


### PR DESCRIPTION
## Changes in this pull request

- Adds `maxConfigRetryCount` as a `SuperwallOption`. Use this to determine the number of times the SDK will attempt to get the Superwall configuration after a network failure before it times out.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
