### PR TITLE
feature/shimmer-load-events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 3.11.2
+
+### Enhancements
+
+- Adds `shimmerView_start` and `shimmerView_complete` events. The `shimmerView_complete` event contains a `visible_duration` parameter which indicates how long the shimmer view was visible after paywall open, if at all.
+
 ## 3.11.1
 
 ### Fixes

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -819,4 +819,36 @@ enum InternalSuperwallEvent {
       }
     }
   }
+
+  struct ShimmerLoad: TrackableSuperwallEvent {
+    enum State {
+      case start
+      case complete
+    }
+    let state: State
+    let paywallId: String
+    var loadDuration: Double?
+    var visibleDuration: Double?
+    var superwallEvent: SuperwallEvent {
+      switch state {
+      case .start:
+        return .shimmerViewStart
+      case .complete:
+        return .shimmerViewComplete
+      }
+    }
+    let audienceFilterParams: [String: Any] = [:]
+    func getSuperwallParameters() async -> [String: Any] {
+      var params: [String: Any] = [
+        "paywall_id": paywallId
+      ]
+
+      if state == .complete {
+        params += [
+          "visible_duration": visibleDuration ?? 0.0
+        ]
+      }
+      return params
+    }
+  }
 }

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/TrackingLogic.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/TrackingLogic.swift
@@ -112,6 +112,10 @@ enum TrackingLogic {
       }
     }
 
+    if let event = event as? InternalSuperwallEvent.ShimmerLoad {
+      return !disableVerboseEvents
+    }
+
     if let event = event as? InternalSuperwallEvent.PaywallProductsLoad {
       switch event.state {
       case .start, .complete:

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
@@ -194,6 +194,12 @@ public enum SuperwallEvent {
   /// When the AdServices token request finishes.
   case adServicesTokenRequestComplete(token: String)
 
+  /// When the shimmer view starts to show.
+  case shimmerViewStart
+
+  /// When the shimmer view stops showing.
+  case shimmerViewComplete
+
   var canImplicitlyTriggerPaywall: Bool {
     switch self {
     case .appInstall,
@@ -341,6 +347,10 @@ extension SuperwallEvent {
       return .init(objcEvent: .adServicesTokenRequestFail)
     case .adServicesTokenRequestComplete:
       return .init(objcEvent: .adServicesTokenRequestComplete)
+    case .shimmerViewStart:
+      return .init(objcEvent: .shimmerViewStart)
+    case .shimmerViewComplete:
+      return .init(objcEvent: .shimmerViewComplete)
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
@@ -181,6 +181,12 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// When the AdServices token request finishes.
   case adServicesTokenRequestComplete
 
+  /// When the shimmer view starts to show.
+  case shimmerViewStart
+
+  /// When the shimmer view stops showing.
+  case shimmerViewComplete
+
   public init(event: SuperwallEvent) {
     self = event.backingData.objcEvent
   }
@@ -293,6 +299,10 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "adServicesTokenRequest_fail"
     case .adServicesTokenRequestComplete:
       return "adServicesTokenRequest_complete"
+    case .shimmerViewStart:
+      return "shimmerView_start"
+    case .shimmerViewComplete:
+      return "shimmerView_complete"
     }
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -64,12 +64,13 @@ struct Paywall: Codable {
       products = Self.makeProducts(from: productItems)
     }
   }
+  // MARK: - Added by client
 
   var responseLoadingInfo: LoadingInfo
   var webviewLoadingInfo: LoadingInfo
+  var shimmerLoadingInfo: LoadingInfo
   var productsLoadingInfo: LoadingInfo
 
-  // MARK: - Added by client
   /// An array of the ids of paywall products.
   ///
   /// This is set on init and whenever products are updated.
@@ -151,6 +152,9 @@ struct Paywall: Codable {
     case productsLoadStartTime
     case productsLoadCompleteTime
     case productsLoadFailTime
+
+    case shimmerLoadStartTime
+    case shimmerLoadCompleteTime
   }
 
   init(from decoder: Decoder) throws {
@@ -218,6 +222,13 @@ struct Paywall: Codable {
       startAt: webviewLoadStartTime,
       endAt: webviewLoadCompleteTime,
       failAt: webviewLoadFailTime
+    )
+
+    let shimmerLoadStartTime = try values.decodeIfPresent(Date.self, forKey: .shimmerLoadStartTime)
+    let shimmerLoadCompleteTime = try values.decodeIfPresent(Date.self, forKey: .shimmerLoadCompleteTime)
+    shimmerLoadingInfo = LoadingInfo(
+      startAt: shimmerLoadStartTime,
+      endAt: shimmerLoadCompleteTime
     )
 
     let productsLoadStartTime = try values.decodeIfPresent(Date.self, forKey: .productsLoadStartTime)
@@ -347,6 +358,7 @@ struct Paywall: Codable {
     responseLoadingInfo: LoadingInfo,
     webviewLoadingInfo: LoadingInfo,
     productsLoadingInfo: LoadingInfo,
+    shimmerLoadingInfo: LoadingInfo,
     paywalljsVersion: String,
     productVariables: [ProductVariable]? = [],
     isFreeTrialAvailable: Bool = false,
@@ -377,6 +389,7 @@ struct Paywall: Codable {
     self.responseLoadingInfo = responseLoadingInfo
     self.webviewLoadingInfo = webviewLoadingInfo
     self.productsLoadingInfo = productsLoadingInfo
+    self.shimmerLoadingInfo = shimmerLoadingInfo
     self.paywalljsVersion = paywalljsVersion
     self.productVariables = productVariables
     self.isFreeTrialAvailable = isFreeTrialAvailable
@@ -411,6 +424,8 @@ struct Paywall: Codable {
       productsLoadStartTime: productsLoadingInfo.startAt,
       productsLoadFailTime: productsLoadingInfo.failAt,
       productsLoadCompleteTime: productsLoadingInfo.endAt,
+      shimmerLoadStartTime: shimmerLoadingInfo.startAt,
+      shimmerLoadCompleteTime: shimmerLoadingInfo.endAt,
       experiment: experiment,
       paywalljsVersion: paywalljsVersion,
       isFreeTrialAvailable: isFreeTrialAvailable,
@@ -470,6 +485,7 @@ extension Paywall: Stubbable {
       responseLoadingInfo: .init(),
       webviewLoadingInfo: .init(),
       productsLoadingInfo: .init(),
+      shimmerLoadingInfo: .init(),
       paywalljsVersion: ""
     )
   }

--- a/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
@@ -108,6 +108,12 @@ public final class PaywallInfo: NSObject {
   /// The time it took to load the paywall products.
   public let productsLoadDuration: TimeInterval?
 
+  /// An iso date string indicating when the shimmer view began loading.
+  public let shimmerLoadStartTime: String?
+
+  /// An iso date string indicating when the shimmer view finished loading.
+  public let shimmerLoadCompleteTime: String?
+
   /// The paywall.js version installed on the paywall website.
   public let paywalljsVersion: String?
 
@@ -154,6 +160,8 @@ public final class PaywallInfo: NSObject {
     productsLoadStartTime: Date?,
     productsLoadFailTime: Date?,
     productsLoadCompleteTime: Date?,
+    shimmerLoadStartTime: Date?,
+    shimmerLoadCompleteTime: Date?,
     experiment: Experiment?,
     paywalljsVersion: String?,
     isFreeTrialAvailable: Bool,
@@ -226,6 +234,10 @@ public final class PaywallInfo: NSObject {
     } else {
       self.productsLoadDuration = nil
     }
+
+    self.shimmerLoadStartTime = shimmerLoadStartTime?.isoString ?? ""
+    self.shimmerLoadCompleteTime = shimmerLoadCompleteTime?.isoString ?? ""
+
     self.closeReason = closeReason
   }
 
@@ -252,6 +264,8 @@ public final class PaywallInfo: NSObject {
       "paywall_products_load_complete_time": productsLoadCompleteTime as Any,
       "paywall_products_load_fail_time": productsLoadFailTime as Any,
       "paywall_products_load_duration": productsLoadDuration as Any,
+      "shimmerView_load_complete_time": shimmerLoadCompleteTime as Any,
+      "shimmerView_load_start_time": shimmerLoadStartTime as Any,
       // TODO: Remove in v4:
       "trigger_session_id": "" as Any,
       "experiment_id": experiment?.id as Any,
@@ -352,6 +366,8 @@ extension PaywallInfo: Stubbable {
       productsLoadStartTime: nil,
       productsLoadFailTime: nil,
       productsLoadCompleteTime: nil,
+      shimmerLoadStartTime: nil,
+      shimmerLoadCompleteTime: nil,
       experiment: nil,
       paywalljsVersion: nil,
       isFreeTrialAvailable: false,
@@ -391,6 +407,8 @@ extension PaywallInfo: Stubbable {
       productsLoadStartTime: nil,
       productsLoadFailTime: nil,
       productsLoadCompleteTime: nil,
+      shimmerLoadStartTime: nil,
+      shimmerLoadCompleteTime: nil,
       experiment: .init(
         id: "0",
         groupId: "0",

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -161,6 +161,8 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   /// paywall presentation.
   private var unsavedOccurrence: TriggerRuleOccurrence?
 
+  private var lastOpen: Date?
+
   private unowned let factory: TriggerFactory
   private unowned let storage: Storage
   private unowned let deviceHelper: DeviceHelper
@@ -245,6 +247,9 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   }
 
   nonisolated private func trackOpen() async {
+    await MainActor.run {
+      lastOpen = Date()
+    }
     await storage.trackPaywallOpen()
     await webView.messageHandler.handle(.paywallOpen)
     let trackedEvent = await InternalSuperwallEvent.PaywallOpen(paywallInfo: info)
@@ -252,6 +257,9 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   }
 
   nonisolated private func trackClose() async {
+    await MainActor.run {
+      lastOpen = nil
+    }
     let trackedEvent = await InternalSuperwallEvent.PaywallClose(
       paywallInfo: info,
       surveyPresentationResult: surveyPresentationResult
@@ -368,6 +376,29 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
           completion: { _ in
             self.shimmerView?.removeFromSuperview()
             self.shimmerView = nil
+            Task.detached { [weak self] in
+              guard let self = self else {
+                return
+              }
+              let shimmerEndDate = Date()
+              await MainActor.run {
+                self.paywall.shimmerLoadingInfo.endAt = shimmerEndDate
+              }
+
+              let visibleDuration: Double = await MainActor.run {
+                if let lastOpen = self.lastOpen {
+                  return max(0, shimmerEndDate.timeIntervalSince1970 - lastOpen.timeIntervalSince1970)
+                } else {
+                  return 0.0
+                }
+              }
+              let shimmerComplete = await InternalSuperwallEvent.ShimmerLoad(
+                state: .complete,
+                paywallId: self.paywall.identifier,
+                visibleDuration: visibleDuration
+              )
+              await Superwall.shared.track(shimmerComplete)
+            }
           }
         )
       }
@@ -397,6 +428,15 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
       shimmerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
     ])
     self.shimmerView = shimmerView
+    Task {
+      paywall.shimmerLoadingInfo.startAt = Date()
+
+      let shimmerStart = InternalSuperwallEvent.ShimmerLoad(
+        state: .start,
+        paywallId: paywall.identifier
+      )
+      await Superwall.shared.track(shimmerStart)
+    }
   }
 
   private func addLoadingView() {


### PR DESCRIPTION
## Changes in this pull request

- Adds `shimmerView_start` and `shimmerView_complete` events. The `shimmerView_complete` event contains a `visible_duration` parameter which indicates how long the shimmer view was visible after paywall open, if at all.
- Adds `shimmerView_load_complete_time` and `shimmerView_load_start_time` to `PaywallInfo`.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
