### PR TITLE
Replaces UTC Date Formatter with the ISO one

### DIFF
--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -311,12 +311,7 @@ class DeviceHelper {
   }()
 
   private let utcDateTimeFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.calendar = Calendar(identifier: .iso8601)
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.timeZone = TimeZone(secondsFromGMT: 0)
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-    return formatter
+    return String.rfc3339DateFormatter
   }()
 
   private var localDateString: String {


### PR DESCRIPTION
## Changes in this pull request

- This changes the formatter used for `device.utcDateTime` When we read the current `device.utcDateTime` in JS in a paywall, we don't have a `Z` at the end which indicates UTC timezone so the paywall interprets it as a local time instead of UTC. This fixes that issue b/c the  `rfc3339DateFormatter` returns `2024-11-18T23:03:23Z` with the Z


![CleanShot 2024-11-18 at 15 06 47@2x](https://github.com/user-attachments/assets/43c7208b-fb8f-45a3-a163-61c6852ddfb7)


### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
