### PR TITLE
Changes null to Null and defaults to JSON in PassableValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.0.1
+
+### Fixes
+
+- Fixes a bug where unsupported value types as user attributes or placement parameters would cause a `noAudienceMatch`
+
 ## 4.0.0
 
 ### Breaking Changes

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.0.0
+4.0.1
 """

--- a/Sources/SuperwallKit/Paywall/Presentation/Audience Logic/Expression Evaluator/EvaluationContext.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Audience Logic/Expression Evaluator/EvaluationContext.swift
@@ -136,6 +136,6 @@ func toPassableValue(from anyValue: Any) -> PassableValue {
   case let value as PassableValue:
     return value
   default:
-    return .null
+    return toPassableValue(from: JSON(anyValue))
   }
 }

--- a/Sources/SuperwallKit/Paywall/Presentation/Audience Logic/Expression Evaluator/PassableValue.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Audience Logic/Expression Evaluator/PassableValue.swift
@@ -74,7 +74,7 @@ indirect enum PassableValue: Codable {
     case "timestamp":
       let timestampValue = try container.decode(Int64.self, forKey: .value)
       self = .timestamp(timestampValue)
-    case "null":
+    case "Null":
       self = .null
     default:
       throw DecodingError.typeMismatch(
@@ -125,7 +125,7 @@ indirect enum PassableValue: Codable {
       try container.encode("timestamp", forKey: .type)
       try container.encode(value, forKey: .value)
     case .null:
-      try container.encode("null", forKey: .type)
+      try container.encode("Null", forKey: .type)
       try container.encodeNil(forKey: .value)
     }
   }

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Audience Logic/ExpressionEvaluator/CELEvaluatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Audience Logic/ExpressionEvaluator/CELEvaluatorTests.swift
@@ -186,4 +186,22 @@ final class CELEvaluatorTests: XCTestCase {
     )
     XCTAssertEqual(result, .match(audience: rule))
   }
+  func testEvaluateExpression_passingInDecimal() async {
+    let dependencyContainer = DependencyContainer()
+    dependencyContainer.storage.reset()
+    let evaluator = CELEvaluator(
+      storage: dependencyContainer.storage,
+      factory: dependencyContainer
+    )
+    let value = Decimal(1.0)
+    dependencyContainer.identityManager.mergeUserAttributes(["a": value])
+    let rule: TriggerRule = .stub()
+      .setting(\.expression, to: "user.a == 1.0")
+    let result = await evaluator.evaluateExpression(
+      fromAudienceFilter: rule,
+      placementData: PlacementData(name: "ss", parameters: [:], createdAt: Date())
+    )
+
+    XCTAssertEqual(result, .match(audience: rule))
+  }
 }


### PR DESCRIPTION
## Changes in this pull request

- Previously if we were unable to serialize a value using most basic types. Ex: `CGFloat` we'd serialize the value to an invalid input causing superscript to fail to parse. Now we're serializing it using the default json encoding which mirrors the behavior in the paywall editor. 

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
