### PR TITLE
4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
-## 4.0.2
+## 4.0.3
 
 ### Enhancements
 

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
@@ -131,6 +131,9 @@ extension SuperwallDelegate {
 
   public func handleSuperwallEvent(withInfo eventInfo: SuperwallEventInfo) {}
 
+  @available(*, deprecated, renamed: "handleSuperwallEvent(withInfo:)")
+  public func handleSuperwallPlacement(withInfo placementInfo: SuperwallPlacementInfo) {}
+
   public func handleLog(
     level: String,
     scope: String,

--- a/Sources/SuperwallKit/Graveyard/SuperwallGraveyard.swift
+++ b/Sources/SuperwallKit/Graveyard/SuperwallGraveyard.swift
@@ -141,12 +141,6 @@ extension Superwall {
   }
 }
 
-extension SuperwallDelegate {
-  @MainActor
-  @available(*, deprecated, renamed: "handleSuperwallEvent(withInfo:)")
-  func handleSuperwallPlacement(withInfo placementInfo: SuperwallPlacementInfo) {}
-}
-
 @available(*, unavailable, renamed: "ProductStore")
 public enum Store: Int {
   case appStore

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.0.2
+4.0.3
 """

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.0.2"
+  s.version      = "4.0.3"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- Adds `$storekitVersion`, `$maxConfigRetryCount`, and `$shouldObservePurchases` to the `config_attributes` event.
- Updates Superscript to 0.1.18.
- Confirms all paywall assignments locally to reduce the amount of preloading of paywalls on each cold app open.
- Migrates documents used for user and app data out of the documents folder and into the application support folder.
- If the SDK is using StoreKit 2 and not using a purchase controller, a refunded purchase is no longer considered active and therefore does not give the user an active entitlement.

### Fixes

- Deprecates the naming of `handleSuperwallPlacement(withInfo:)` back to `handleSuperwallEvent(withInfo:)`.
- Deprecates `SuperwallPlacement` back to `SuperwallEvent`.
- Deprecates `SuperwallPlacementInfo` back to `SuperwallEventInfo`.

Includes hotfix for `handleSuperwallPlacement`.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
