### PR TITLE
4.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.0.6
+
+### Fixes
+
+- Prevents all `purchase(_:)` overrides from being able to be called when the `shouldObservePurchases` `SuperwallOption` is `true`.
+
 ## 4.0.5
 
 ### Fixes

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.0.5
+4.0.6
 """

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -331,10 +331,17 @@ public final class Superwall: NSObject, ObservableObject {
               await self.dependencyContainer.delegateAdapter.subscriptionStatusDidChange(
                 from: oldStatus, to: newStatus)
               let event = InternalSuperwallEvent.SubscriptionStatusDidChange(status: newStatus)
-              await Superwall.shared.track(event)
+              await self.track(event)
+            }
+            Task {
+              let deviceAttributes = await self.dependencyContainer.makeSessionDeviceAttributes()
+              let deviceAttributesPlacement = InternalSuperwallEvent.DeviceAttributes(
+                deviceAttributes: deviceAttributes)
+              await self.track(deviceAttributesPlacement)
             }
           }
-        ))
+        )
+      )
   }
 
   /// Sets ``subscriptionStatus`` to an`unknown` state.

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -708,7 +708,7 @@ public final class Superwall: NSObject, ObservableObject {
 
   // MARK: - External Purchasing
 
-  /// Initiates a purchase of a `SKProduct`.
+  /// Initiates a purchase of a `StoreProduct`.
   ///
   /// Use this function to purchase a ``StoreProduct``, regardless of whether you
   /// have a paywall or not. Superwall will handle the purchase with `StoreKit`
@@ -720,6 +720,15 @@ public final class Superwall: NSObject, ObservableObject {
   /// - Note: You only need to finish the transaction after this if you're providing a ``PurchaseController``
   /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
   public func purchase(_ product: StoreProduct) async -> PurchaseResult {
+    if options.shouldObservePurchases {
+      Logger.debug(
+        logLevel: .error,
+        scope: .superwallCore,
+        message: "You cannot make purchases using Superwall.shared.purchase(_:) while the "
+          + "SuperwallOption shouldObservePurchases is set to true."
+      )
+      return .cancelled
+    }
     return await dependencyContainer.transactionManager.purchase(.purchaseFunc(product))
   }
 
@@ -761,6 +770,15 @@ public final class Superwall: NSObject, ObservableObject {
   /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
   @available(iOS 15.0, *)
   public func purchase(_ product: StoreKit.Product) async -> PurchaseResult {
+    if options.shouldObservePurchases {
+      Logger.debug(
+        logLevel: .error,
+        scope: .superwallCore,
+        message: "You cannot make purchases using Superwall.shared.purchase(_:) while the "
+          + "SuperwallOption shouldObservePurchases is set to true."
+      )
+      return .cancelled
+    }
     let storeProduct = StoreProduct(sk2Product: product)
     return await dependencyContainer.transactionManager.purchase(.purchaseFunc(storeProduct))
   }

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -708,7 +708,7 @@ public final class Superwall: NSObject, ObservableObject {
 
   // MARK: - External Purchasing
 
-  /// Initiates a purchase of a `StoreProduct`.
+  /// Initiates a purchase of a ``StoreProduct``.
   ///
   /// Use this function to purchase a ``StoreProduct``, regardless of whether you
   /// have a paywall or not. Superwall will handle the purchase with `StoreKit`
@@ -719,6 +719,8 @@ public final class Superwall: NSObject, ObservableObject {
   /// - Returns: A ``PurchaseResult``.
   /// - Note: You only need to finish the transaction after this if you're providing a ``PurchaseController``
   /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
+  /// - Warning: You cannot use this function while also setting ``SuperwallOptions/shouldObservePurchases``
+  /// to `true`.
   public func purchase(_ product: StoreProduct) async -> PurchaseResult {
     if options.shouldObservePurchases {
       Logger.debug(
@@ -743,6 +745,8 @@ public final class Superwall: NSObject, ObservableObject {
   /// - Returns: A ``PurchaseResult``.
   /// - Note: You only need to finish the transaction after this if you're providing a ``PurchaseController``
   /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
+  /// - Warning: You cannot use this function while also setting ``SuperwallOptions/shouldObservePurchases``
+  /// to `true`.
   public func purchase(_ product: SKProduct) async -> PurchaseResult {
     if options.shouldObservePurchases {
       Logger.debug(
@@ -783,19 +787,21 @@ public final class Superwall: NSObject, ObservableObject {
     return await dependencyContainer.transactionManager.purchase(.purchaseFunc(storeProduct))
   }
 
-  /// Initiates a purchase of a `SKProduct`.
+  /// Initiates a purchase of a ``StoreProduct``.
   ///
-  /// Use this function to purchase any `SKProduct`, regardless of whether you
+  /// Use this function to purchase any ``StoreProduct``, regardless of whether you
   /// have a paywall or not. Superwall will handle the purchase with `StoreKit`
   /// and return the ``PurchaseResult``. You'll see the data associated with the
   /// purchase on the Superwall dashboard.
   ///
   /// - Parameters:
-  ///   - product: The `SKProduct` you wish to purchase.
+  ///   - product: The ``StoreProduct`` you wish to purchase.
   ///   - completion: A completion block that is called when the purchase completes.
   ///   This accepts a ``PurchaseResult``.
   /// - Note: You only need to finish the transaction after this if you're providing a ``PurchaseController``
   /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
+  /// - Warning: You cannot use this function while also setting ``SuperwallOptions/shouldObservePurchases``
+  ///  to `true`.
   public func purchase(
     _ product: StoreProduct,
     completion: @escaping (PurchaseResult) -> Void
@@ -808,9 +814,9 @@ public final class Superwall: NSObject, ObservableObject {
     }
   }
 
-  /// Initiates a purchase of a `SKProduct`.
+  /// Initiates a purchase of a StoreKit 2 `Product`.
   ///
-  /// Use this function to purchase any `SKProduct`, regardless of whether you
+  /// Use this function to purchase any `Product`, regardless of whether you
   /// have a paywall or not. Superwall will handle the purchase with `StoreKit`
   /// and return the ``PurchaseResult``. You'll see the data associated with the
   /// purchase on the Superwall dashboard.
@@ -821,6 +827,8 @@ public final class Superwall: NSObject, ObservableObject {
   ///   This accepts a ``PurchaseResult``.
   /// - Note: You only need to finish the transaction after this if you're providing a ``PurchaseController``
   /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
+  /// - Warning: You cannot use this function while also setting ``SuperwallOptions/shouldObservePurchases``
+  /// to `true`.
   @available(iOS 15.0, *)
   public func purchase(
     _ product: StoreKit.Product,
@@ -847,6 +855,8 @@ public final class Superwall: NSObject, ObservableObject {
   ///   This accepts a ``PurchaseResult``.
   /// - Note: You only need to finish the transaction after this if you're providing a ``PurchaseController``
   /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
+  /// - Warning: You cannot use this function while also setting ``SuperwallOptions/shouldObservePurchases``
+  /// to `true`.
   public func purchase(
     _ product: SKProduct,
     completion: @escaping (PurchaseResult) -> Void
@@ -872,31 +882,8 @@ public final class Superwall: NSObject, ObservableObject {
   ///   This accepts a ``PurchaseResult``.
   /// - Note: You only need to finish the transaction after this if you're providing a ``PurchaseController``
   /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
-  @available(swift, obsoleted: 1.0)
-  @available(iOS 15.0, *)
-  public func purchase(
-    _ product: StoreKit.Product,
-    completion: @escaping (PurchaseResultObjc) -> Void
-  ) {
-    purchase(product) { result in
-      let objcResult = result.toObjc()
-      completion(objcResult)
-    }
-  }
-
-  /// Objective-C-only method. Initiates a purchase of a `SKProduct`.
-  ///
-  /// Use this function to purchase any `SKProduct`, regardless of whether you
-  /// have a paywall or not. Superwall will handle the purchase with `StoreKit`
-  /// and return the ``PurchaseResult``. You'll see the data associated with the
-  /// purchase on the Superwall dashboard.
-  ///
-  /// - Parameters:
-  ///   - product: The `SKProduct` you wish to purchase.
-  ///   - completion: A completion block that is called when the purchase completes.
-  ///   This accepts a ``PurchaseResult``.
-  /// - Note: You only need to finish the transaction after this if you're providing a ``PurchaseController``
-  /// when configuring the SDK. Otherwise ``Superwall`` will handle this for you.
+  /// - Warning: You cannot use this function while also setting ``SuperwallOptions/shouldObservePurchases``
+  /// to `true`.
   @available(swift, obsoleted: 1.0)
   public func purchase(
     _ product: SKProduct,

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.0.5"
+  s.version      = "4.0.6"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

### Fixes

- Prevents all `purchase(_:)` overrides from being able to be called when the `shouldObservePurchases` `SuperwallOption` is `true`.
- Removes unusable Objective-C function that references an SK2 product.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
