### PR TITLE
4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.2.1
+
+### Enhancements
+
+- Adds the `PaywallOption` `shouldShowWebRestorationAlert`, which can be set to `false` to suppress the alert prompting users to restore their purchase via the web.
+
+### Fixes
+
+- Fixes issue where the redeeming of web entitlements may have been incorrectly counted as a restoration.
+- Fixes issue where the web checkout endpoint was being called on identify even if you hadn't enabled web checkout.
+
 ## 4.2.0
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fixes issue where the redeeming of web entitlements may have been incorrectly counted as a restoration.
-- Fixes issue where the web checkout endpoint was being called on identify even if you hadn't enabled web checkout.
+- Fixes issue where the web checkout redemption endpoint was being called on identify even if you hadn't enabled web checkout.
 
 ## 4.2.0
 

--- a/Sources/SuperwallKit/Config/Models/Config.swift
+++ b/Sources/SuperwallKit/Config/Models/Config.swift
@@ -37,6 +37,14 @@ struct Config: Codable, Equatable {
       case restoreAccessURL = "restoreAccessUrl"
     }
 
+    init(
+      entitlementsMaxAge: Seconds,
+      restoreAccessURL: URL
+    ) {
+      self.entitlementsMaxAge = entitlementsMaxAge
+      self.restoreAccessURL = restoreAccessURL
+    }
+
     init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
       let entitlementsMaxAgeMs = try values.decode(Milliseconds.self, forKey: .entitlementsMaxAgeMs)

--- a/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
@@ -50,6 +50,10 @@ public final class PaywallOptions: NSObject, Encodable {
   /// Defines the messaging of the alert presented to the user when restoring a transaction fails.
   public var restoreFailed = RestoreFailed()
 
+  /// Shows an alert asking the user if they'd like to try to restore on the web, if you have added web checkout on the
+  /// Superwall dashboard. Defaults to `true`.
+  public var shouldShowWebRestorationAlert = true
+
   @objc(SWKNotificationPermissionsDenied)
   @objcMembers
   public final class NotificationPermissionsDenied: NSObject, Encodable {

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -127,7 +127,12 @@ public final class SuperwallOptions: NSObject, Encodable {
     }
 
     var enrichmentHost: String {
-      "enrichment-api.superwall.dev"
+      switch self {
+      case .developer:
+        return "enrichment-api.superwall.dev"
+      default:
+        return "enrichment-api.superwall.com"
+      }
     }
 
     var adServicesHost: String {

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -584,3 +584,9 @@ extension DependencyContainer: RestoreAccessFactory {
     return configManager.config?.web2appConfig?.restoreAccessURL
   }
 }
+
+extension DependencyContainer: ConfigStateFactory {
+  func makeConfigState() -> CurrentValueSubject<ConfigState, any Error> {
+    return configManager.configState
+  }
+}

--- a/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
+++ b/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
@@ -172,3 +172,7 @@ protocol WebEntitlementFactory: AnyObject {
 protocol RestoreAccessFactory: AnyObject {
   func makeRestoreAccessURL() -> URL?
 }
+
+protocol ConfigStateFactory: AnyObject {
+  func makeConfigState() -> CurrentValueSubject<ConfigState, any Error>
+}

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.2.0
+4.2.1
 """

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -737,9 +737,6 @@ public final class Superwall: NSObject, ObservableObject {
     dependencyContainer.identityManager.reset(duringIdentify: duringIdentify)
     dependencyContainer.storage.reset()
 
-    // Cleared the user-web entitlements. now need to update active ones based on that
-    dependencyContainer.entitlementsInfo
-
     dependencyContainer.paywallManager.resetCache()
     presentationItems.reset()
     dependencyContainer.configManager.reset()

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.2.0"
+  s.version      = "4.2.1"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Tests/SuperwallKitTests/Web/WebEntitlementRedeemerTests.swift
+++ b/Tests/SuperwallKitTests/Web/WebEntitlementRedeemerTests.swift
@@ -7,6 +7,7 @@
 
 import Testing
 @testable import SuperwallKit
+import Foundation
 
 struct WebEntitlementRedeemerTests {
   let dependencyContainer = DependencyContainer()
@@ -54,7 +55,17 @@ struct WebEntitlementRedeemerTests {
       .setting(\.entitlements, to: entitlements)
       .setting(\.results, to: [result])
 
-    await redeemer.redeem(.code("TESTCODE"))
+    let config = Config
+      .stub()
+      .setting(
+        \.web2appConfig,
+         to: .init(entitlementsMaxAge: 60, restoreAccessURL: URL("https://google.com")!)
+      )
+
+    await redeemer.redeem(
+      .code("TESTCODE"),
+      injectedConfig: config
+    )
 
     #expect(mockStorage.saveCount == 2)
     #expect(superwall.entitlements.active == entitlements)
@@ -125,7 +136,17 @@ struct WebEntitlementRedeemerTests {
       .setting(\.entitlements, to: entitlements)
       .setting(\.results, to: [result])
 
-    await redeemer.redeem(.code("TESTCODE"))
+    let config = Config
+      .stub()
+      .setting(
+        \.web2appConfig,
+         to: .init(entitlementsMaxAge: 60, restoreAccessURL: URL("https://google.com")!)
+      )
+
+    await redeemer.redeem(
+      .code("TESTCODE"),
+      injectedConfig: config
+    )
 
     #expect(mockStorage.saveCount == 2)
     #expect(superwall.entitlements.active == entitlements)
@@ -217,7 +238,17 @@ struct WebEntitlementRedeemerTests {
       .setting(\.entitlements, to: entitlements)
       .setting(\.results, to: [result])
 
-    await redeemer.redeem(.code("TESTCODE"))
+    let config = Config
+      .stub()
+      .setting(
+        \.web2appConfig,
+         to: .init(entitlementsMaxAge: 60, restoreAccessURL: URL("https://google.com")!)
+      )
+
+    await redeemer.redeem(
+      .code("TESTCODE"),
+      injectedConfig: config
+    )
 
     #expect(mockStorage.saveCount == 2)
     #expect(superwall.entitlements.active == entitlements)
@@ -307,7 +338,19 @@ struct WebEntitlementRedeemerTests {
     )
     let error = NetworkError.notAuthenticated
     mockNetwork.redeemError = error
-    await redeemer.redeem(.code("TESTCODE"))
+
+    let config = Config
+      .stub()
+      .setting(
+        \.web2appConfig,
+         to: .init(entitlementsMaxAge: 60, restoreAccessURL: URL("https://google.com")!)
+      )
+
+    await redeemer.redeem(
+      .code("TESTCODE"),
+      injectedConfig: config
+    )
+
     try? await Task.sleep(for: .milliseconds(300))
     #expect(mockStorage.saveCount == 0)
     #expect(superwall.entitlements.active.isEmpty)


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- Adds the `PaywallOption` `shouldShowWebRestorationAlert`, which can be set to `false` to suppress the alert prompting users to restore their purchase via the web.

### Fixes

- Fixes issue where the redeeming of web entitlements may have been incorrectly counted as a restoration.
- Fixes issue where the web checkout redemption endpoint was being called on identify even if you hadn't enabled web checkout.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
