### PR TITLE
4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.3.0
+
+### Enhancements
+
+- Adds a `SuperwallOption` named `enableExperimentalDeviceVariables`. When set to `true`, this enables additional device-level variables: `latestSubscriptionPeriodType`, `latestSubscriptionState`, and `latestSubscriptionWillAutoRenew`. These properties provide information about the most recent StoreKit 2 subscription on the device and can be used in audience filters. Note that due to their experimental nature, they are subject to change in future updates.
+
 ## 4.2.2
 
 ### Fixes

--- a/Examples/Basic/Basic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Basic/Basic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/superwall/Superscript-iOS",
         "state": {
           "branch": null,
-          "revision": "9ecdb97d84e94cdde3bfa63401903ec764a8f414",
-          "version": "0.1.17"
+          "revision": "384c66775f5fdde3b27858d016eb285fae6b1d7d",
+          "version": "0.2.4"
         }
       }
     ]

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -199,6 +199,9 @@ public final class SuperwallOptions: NSObject, Encodable {
   /// Set this to `true` to forward events from the Game Controller to the Paywall via ``Superwall/gamepadValueChanged(gamepad:element:)``.
   public var isGameControllerEnabled = false
 
+  /// Enables experimental device variables. These are subject to change. Defaults to `false`.
+  public var enableExperimentalDeviceVariables = false
+
   /// Determines the number of times the SDK will attempt to get the Superwall configuration after a network
   /// failure before it times out. Defaults to 6.
   ///
@@ -244,6 +247,7 @@ public final class SuperwallOptions: NSObject, Encodable {
     case storeKitVersion
     case maxConfigRetryCount
     case shouldObservePurchases
+    case enableExperimentalDeviceVariables
   }
 
   public override init() {
@@ -277,6 +281,7 @@ public final class SuperwallOptions: NSObject, Encodable {
     try container.encode(storeKitVersion.description, forKey: .storeKitVersion)
     try container.encode(maxConfigRetryCount, forKey: .maxConfigRetryCount)
     try container.encode(shouldObservePurchases, forKey: .shouldObservePurchases)
+    try container.encode(enableExperimentalDeviceVariables, forKey: .enableExperimentalDeviceVariables)
   }
 
   func toDictionary() -> [String: Any] {

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.2.2
+4.3.0
 """

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -3,7 +3,7 @@
 //
 //  Created by Jake Mor on 8/10/21.
 //
-// swiftlint:disable type_body_length file_length
+// swiftlint:disable type_body_length file_length function_body_length
 
 import UIKit
 import Foundation
@@ -509,11 +509,18 @@ class DeviceHelper {
     )
 
     var deviceDictionary = template.toDictionary()
-    let enrichmentDict = enrichment?.device.dictionaryValue ?? [:]
 
+    let enrichmentDict = enrichment?.device.dictionaryValue ?? [:]
     // Merge in enrichment dictionary, giving priority to
     // the existing values.
     deviceDictionary.merge(enrichmentDict) { current, _ in current }
+
+
+    if Superwall.shared.options.enableExperimentalDeviceVariables {
+      let properties = await receiptManager.getExperimentalDeviceProperties()
+      deviceDictionary.merge(properties) { current, _ in current }
+    }
+
     return deviceDictionary
   }
 

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Yusuf Tör on 24/03/2022.
 //
@@ -62,6 +62,29 @@ actor ReceiptManager: NSObject {
 
   func getTransactionReceipts() async -> [TransactionReceipt] {
     await manager.transactionReceipts
+  }
+
+  func getExperimentalDeviceProperties() async -> [String: Any] {
+    async let periodType = manager.latestSubscriptionPeriodType?.rawValue
+    async let state = manager.latestSubscriptionState?.rawValue
+    async let willAutoRenew = manager.latestSubscriptionWillAutoRenew
+
+    let (unwrappedPeriodType, unwrappedState, unwrappedWillAutoRenew) = await (periodType, state, willAutoRenew)
+
+    var values: [String: Any] = [:]
+
+    if let periodType = unwrappedPeriodType {
+      values["latestSubscriptionPeriodType"] = periodType
+    }
+
+    if let state = unwrappedState {
+      values["latestSubscriptionState"] = state
+    }
+
+    if let willAutoRenew = unwrappedWillAutoRenew {
+      values["latestSubscriptionWillAutoRenew"] = willAutoRenew
+    }
+    return values
   }
 
   /// Loads purchased products from the receipt, storing the purchased subscription group identifiers,

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK1ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK1ReceiptManager.swift
@@ -12,6 +12,11 @@ final class SK1ReceiptManager: ReceiptManagerType {
   var purchasedSubscriptionGroupIds: Set<String>?
   var purchases: Set<Purchase> = []
 
+  // Unused for now:
+  var latestSubscriptionPeriodType: LatestSubscription.PeriodType?
+  var latestSubscriptionWillAutoRenew: Bool?
+  var latestSubscriptionState: LatestSubscription.State?
+
   /// This is unused in SK1
   let transactionReceipts: [TransactionReceipt] = []
 

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yusuf Tör on 19/09/2024.
 //
+// swiftlint:disable function_body_length
 
 import Foundation
 import StoreKit
@@ -11,10 +12,32 @@ import StoreKit
 protocol ReceiptManagerType: AnyObject {
   var purchases: Set<Purchase> { get async }
   var transactionReceipts: [TransactionReceipt] { get async }
+  var latestSubscriptionPeriodType: LatestSubscription.PeriodType? { get async }
+  var latestSubscriptionWillAutoRenew: Bool? { get async }
+  var latestSubscriptionState: LatestSubscription.State? { get async }
 
   func loadIntroOfferEligibility(forProducts storeProducts: Set<StoreProduct>) async
   func loadPurchases() async -> Set<Purchase>
   func isEligibleForIntroOffer(_ storeProduct: StoreProduct) async -> Bool
+}
+
+enum LatestSubscription {
+  enum PeriodType: String {
+    case trial
+    case code
+    case subscription
+    case promotional
+    case winback
+    case revoked
+  }
+
+  enum State: String {
+    case inGracePeriod
+    case subscribed
+    case expired
+    case inBillingRetryPeriod
+    case revoked
+  }
 }
 
 @available(iOS 15.0, *)
@@ -22,6 +45,9 @@ actor SK2ReceiptManager: ReceiptManagerType {
   private var sk2IntroOfferEligibility: [String: Bool] = [:]
   var purchases: Set<Purchase> = []
   var transactionReceipts: [TransactionReceipt] = []
+  var latestSubscriptionPeriodType: LatestSubscription.PeriodType?
+  var latestSubscriptionWillAutoRenew: Bool?
+  var latestSubscriptionState: LatestSubscription.State?
 
   func loadIntroOfferEligibility(forProducts storeProducts: Set<StoreProduct>) async {
     for storeProduct in storeProducts {
@@ -38,6 +64,18 @@ actor SK2ReceiptManager: ReceiptManagerType {
     for await verificationResult in Transaction.all {
       switch verificationResult {
       case .verified(let transaction):
+        if transaction.productType == .autoRenewable {
+          let status = await transaction.subscriptionStatus
+          if case let .verified(renewalInfo) = status?.renewalInfo {
+            if #available(iOS 17.2, *) {
+              updatePeriodType(from: transaction)
+            }
+            latestSubscriptionWillAutoRenew = renewalInfo.willAutoRenew == true
+          }
+
+          updateLatestSubscriptionState(from: status)
+        }
+
         // Store the first transaction receipt for each original txn ID.
         let originalTransactionId = verificationResult.underlyingTransaction.originalID
         if originalTransactionId == transaction.id,
@@ -89,8 +127,44 @@ actor SK2ReceiptManager: ReceiptManagerType {
         )
       }
     }
+
     self.purchases = purchases
     return purchases
+  }
+
+  @available(iOS 17.2, *)
+  private func updatePeriodType(from transaction: Transaction) {
+    switch transaction.offer?.type {
+    case .introductory:
+      latestSubscriptionPeriodType = .trial
+    case .code:
+      latestSubscriptionPeriodType = .code
+    case .promotional:
+      latestSubscriptionPeriodType = .promotional
+    case .winBack:
+      latestSubscriptionPeriodType = .winback
+    case .none:
+      latestSubscriptionPeriodType = .subscription
+    default:
+      break
+    }
+  }
+
+  private func updateLatestSubscriptionState(from status: StoreKit.Product.SubscriptionInfo.Status?) {
+    switch status?.state {
+    case .inGracePeriod:
+      latestSubscriptionState = .inGracePeriod
+    case .subscribed:
+      latestSubscriptionState = .subscribed
+    case .expired:
+      latestSubscriptionState = .expired
+    case .inBillingRetryPeriod:
+      latestSubscriptionState = .inBillingRetryPeriod
+    case .revoked:
+      latestSubscriptionState = .revoked
+    default:
+      break
+    }
   }
 
   func isEligibleForIntroOffer(_ storeProduct: StoreProduct) async -> Bool {

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.2.2"
+  s.version      = "4.3.0"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- Adds a `SuperwallOption` named `enableExperimentalDeviceVariables`. When set to `true`, this enables additional device-level variables: `latestSubscriptionPeriodType`, `latestSubscriptionState`, and `latestSubscriptionWillAutoRenew`. These properties provide information about the most recent StoreKit 2 subscription on the device and can be used in audience filters. Note that due to their experimental nature, they are subject to change in future updates.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
