### PR TITLE
4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
-## 4.3.1
+## 4.3.2
 
 ### Fixes
 
 - Prevents the blocking of paywall presentation if the enrichment request fails.
 - Fixes an issue where an app extension accessing Superwall wouldn't work.
 - Sometimes transactions weren't being retrieved by our SDK after a purchase so we've made this process more robust.
+- Fixes issue with compiler failing to build for CocoaPods on older Xcode versions.
 
 ## 4.3.0
 

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.3.1
+4.3.2
 """

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift
@@ -67,9 +67,11 @@ actor SK2ReceiptManager: ReceiptManagerType {
         if transaction.productType == .autoRenewable {
           let status = await transaction.subscriptionStatus
           if case let .verified(renewalInfo) = status?.renewalInfo {
+            #if compiler(>=5.9.2)
             if #available(iOS 17.2, *) {
               updatePeriodType(from: transaction)
             }
+            #endif
             latestSubscriptionWillAutoRenew = renewalInfo.willAutoRenew == true
           }
 

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.3.1"
+  s.version      = "4.3.2"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

- Fix issue with period type failing on old Xcode versions. The winBack type was back deployed and didn't work on old versions of Xcode so CocoaPods was failing to validate. How silly.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
