### PR TITLE
4.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.3.9
+
+### Fixes
+
+- Fixes issue with a paywall not closing if you had a survey attached to a paywall that fires after purchasing and a `survey_response` implicit trigger.
+
 ## 4.3.8
 
 ### Fixes

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
@@ -121,7 +121,7 @@ extension Superwall {
       return logErrors(from: request, error)
     }
 
-    let triggeringOutcome = TrackingLogic.canTriggerPaywall(
+    let triggeringOutcome = await TrackingLogic.canTriggerPaywall(
       placement,
       triggers: Set(dependencyContainer.configManager.triggersByPlacementName.keys),
       paywallViewController: paywallViewController
@@ -134,19 +134,6 @@ extension Superwall {
       await dismiss()
     case .closePaywallThenTriggerPaywall:
       guard let lastPresentationItems = presentationItems.last else {
-        return
-      }
-
-      // Make sure the result of presenting will be a paywall, otherwise do not proceed.
-      // This is important to stop the paywall from being skipped and firing the feature
-      // block when it shouldn't. This has to be done only to those triggers that reassign
-      // the statePublisher. Others like app_launch are fine to skip and users are relying
-      // on paywallPresentationRequest for those.
-      let presentationResult = await internallyGetPresentationResult(
-        forPlacement: placement,
-        requestType: .handleImplicitTrigger
-      )
-      guard case .paywall = presentationResult else {
         return
       }
       await dismissForNextPaywall()

--- a/Sources/SuperwallKit/Models/Web2App/Redeemable.swift
+++ b/Sources/SuperwallKit/Models/Web2App/Redeemable.swift
@@ -7,7 +7,7 @@
 
 struct Redeemable: Codable, Hashable {
   let code: String
-  let isFirstRedemption: Bool
+  let isFirstRedemption: Bool?
 
   private enum CodingKeys: String, CodingKey {
     case code

--- a/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
@@ -182,7 +182,7 @@ final class SurveyManager {
         )
         await Superwall.shared.track(surveyResponse)
 
-        let outcome = TrackingLogic.canTriggerPaywall(
+        let outcome = await TrackingLogic.canTriggerPaywall(
           surveyResponse,
           triggers: factory.makeTriggers(),
           paywallViewController: paywallViewController

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/ExperimentTemplate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/ExperimentTemplate.swift
@@ -1,0 +1,21 @@
+//
+//  ExperimentTemplate.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 09/05/2025.
+//
+
+struct ExperimentTemplate: Codable {
+  var eventName = "experiment"
+
+  var experimentId: String
+  var variantId: String
+  var campaignId: String
+
+  enum CodingKeys: String, CodingKey {
+    case eventName = "event_name"
+    case experimentId
+    case variantId
+    case campaignId
+  }
+}

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/FreeTrialTemplate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/FreeTrialTemplate.swift
@@ -17,11 +17,3 @@ struct FreeTrialTemplate: Codable {
     case prefix
   }
 }
-
-struct ExperimentTemplate: Codable {
-  var eventName = "experiment"
-
-  var experimentId: String
-  var variantId: String
-  var campaignId: String
-}

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -164,7 +164,11 @@ public final class Superwall: NSObject, ObservableObject {
     switch status {
     case .active(let entitlements):
       let allEntitlements = entitlements.union(webEntitlements)
-      superwall.subscriptionStatus = .active(allEntitlements)
+      if allEntitlements.isEmpty {
+        superwall.subscriptionStatus = .inactive
+      } else {
+        superwall.subscriptionStatus = .active(allEntitlements)
+      }
     case .inactive:
       if webEntitlements.isEmpty {
         superwall.subscriptionStatus = .inactive


### PR DESCRIPTION

## Changes in this pull request

- If a `survey_response` implicit trigger was set to show for users who are unsubscribed and there was a survey after purchase, the paywall wouldn't close.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
