### PR TITLE
4.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ## 4.3.10
 
+### Enhancements
+
+- Adds `networkDecoding_fail` event to help with debugging if a decoding error happens.
+
 ### Fixes
 
 - Fixes issue where the configuration completion block could take a long time to complete if the user had a lot of transactions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.3.10
+
+### Fixes
+
+- Fixes issue where the configuration completion block could take a long time to complete if the user had a lot of transactions.
+
 ## 4.3.9
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fixes issue where the configuration completion block could take a long time to complete if the user had a lot of transactions.
+- Fixes issue where `didDismissPaywall(withInfo:)` and the `onDismiss` paywall presentation handler would be called before the presenting window was destroyed.
 
 ## 4.3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Adds `networkDecoding_fail` event to help with debugging if a decoding error happens.
+- Adds `state` to the `PaywallInfo` object. This is set on dismiss of the paywall and can be used to access state variables set in the editor.
 
 ### Fixes
 

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -974,4 +974,18 @@ enum InternalSuperwallEvent {
       }
     }
   }
+
+  struct NetworkDecodingFail: TrackableSuperwallEvent {
+    let superwallEvent: SuperwallEvent = .networkDecodingFail
+    let requestURLString: String
+    let responseString: String
+    var audienceFilterParams: [String: Any] = [:]
+
+    func getSuperwallParameters() async -> [String: Any] {
+      return [
+        "request_url": requestURLString,
+        "response": responseString
+      ]
+    }
+  }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEvent.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yusuf Tör on 21/04/2022.
 //
+// swiftlint:disable file_length
 
 import Foundation
 

--- a/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEvent.swift
@@ -225,6 +225,9 @@ public enum SuperwallEvent {
   /// When the enrichment request fails.
   case enrichmentFail
 
+  /// When a response from the network fails to decode.
+  case networkDecodingFail
+
   var canImplicitlyTriggerPaywall: Bool {
     switch self {
     case .appInstall,
@@ -388,6 +391,8 @@ extension SuperwallEvent {
       return .init(objcEvent: .enrichmentStart)
     case .enrichmentComplete:
       return .init(objcEvent: .enrichmentComplete)
+    case .networkDecodingFail:
+      return .init(objcEvent: .networkDecodingFail)
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEventObjc.swift
@@ -205,6 +205,9 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// When the enrichment request fails.
   case enrichmentFail
 
+  /// When a response from the network fails to decode.
+  case networkDecodingFail
+
   public init(event: SuperwallEvent) {
     self = event.backingData.objcEvent
   }
@@ -333,6 +336,8 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "enrichment_fail"
     case .enrichmentComplete:
       return "enrichment_complete"
+    case .networkDecodingFail:
+      return "networkDecoding_fail"
     }
   }
 }

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.3.9
+4.3.10
 """

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -108,6 +108,9 @@ struct Paywall: Codable {
   /// paywall into a web archive.
   let manifest: ArchiveManifest?
 
+  /// The state of the paywall, updated on paywall did dismiss.
+  var state: [String: Any] = [:]
+
   /// Indicates whether the manifest should be used.
   var isUsingManifest: Bool {
     guard let manifest = manifest else {
@@ -412,7 +415,8 @@ struct Paywall: Codable {
       computedPropertyRequests: computedPropertyRequests,
       surveys: surveys,
       presentation: presentation,
-      isScrollEnabled: isScrollEnabled
+      isScrollEnabled: isScrollEnabled,
+      state: state
     )
   }
 

--- a/Sources/SuperwallKit/Network/Custom URL Session/CustomURLSession.swift
+++ b/Sources/SuperwallKit/Network/Custom URL Session/CustomURLSession.swift
@@ -95,6 +95,11 @@ class CustomURLSession {
       Response.self,
       from: data
     ) else {
+      let networkDecodingFail = InternalSuperwallEvent.NetworkDecodingFail(
+        requestURLString: request.url?.absoluteString ?? "",
+        responseString: String(data: data, encoding: .utf8) ?? ""
+      )
+      await Superwall.shared.track(networkDecodingFail)
       Logger.debug(
         logLevel: .error,
         scope: .network,

--- a/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
@@ -128,6 +128,9 @@ public final class PaywallInfo: NSObject {
   /// Indicates whether scrolling of the webview is enabled.
   public let isScrollEnabled: Bool
 
+  /// The state of the paywall, updated on paywall did dismiss.
+  public let state: [String: Any]
+
   init(
     databaseId: String,
     identifier: String,
@@ -159,7 +162,8 @@ public final class PaywallInfo: NSObject {
     computedPropertyRequests: [ComputedPropertyRequest],
     surveys: [Survey],
     presentation: PaywallPresentationInfo,
-    isScrollEnabled: Bool
+    isScrollEnabled: Bool,
+    state: [String: Any]
   ) {
     self.databaseId = databaseId
     self.identifier = identifier
@@ -226,6 +230,7 @@ public final class PaywallInfo: NSObject {
 
     self.closeReason = closeReason
     self.isScrollEnabled = isScrollEnabled
+    self.state = state
   }
 
   func placementParams(
@@ -368,7 +373,8 @@ extension PaywallInfo: Stubbable {
         style: .none,
         delay: 0
       ),
-      isScrollEnabled: true
+      isScrollEnabled: true,
+      state: [:]
     )
   }
 
@@ -416,7 +422,8 @@ extension PaywallInfo: Stubbable {
         style: .none,
         delay: 0
       ),
-      isScrollEnabled: true
+      isScrollEnabled: true,
+      state: [:]
     )
   }
 }

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -951,23 +951,7 @@ extension PaywallViewController {
     let state = await webView.messageHandler.getState()
     paywall.state = state
 
-    Superwall.shared.dependencyContainer.delegateAdapter.didDismissPaywall(withInfo: info)
-
     let result = paywallResult ?? .declined
-    paywallStateSubject?.send(.dismissed(info, result))
-
-    if !didCallDelegate {
-      delegate?.didFinish(
-        paywall: self,
-        result: result,
-        shouldDismiss: false
-      )
-    }
-
-    if paywall.closeReason.stateShouldComplete {
-      paywallStateSubject?.send(completion: .finished)
-      paywallStateSubject = nil
-    }
 
     // Reset state
     Superwall.shared.destroyPresentingWindow()
@@ -985,6 +969,23 @@ extension PaywallViewController {
 
     dismissCompletionBlock?()
     dismissCompletionBlock = nil
+
+    paywallStateSubject?.send(.dismissed(info, result))
+
+    if !didCallDelegate {
+      delegate?.didFinish(
+        paywall: self,
+        result: result,
+        shouldDismiss: false
+      )
+    }
+
+    if paywall.closeReason.stateShouldComplete {
+      paywallStateSubject?.send(completion: .finished)
+      paywallStateSubject = nil
+    }
+
+    Superwall.shared.dependencyContainer.delegateAdapter.didDismissPaywall(withInfo: info)
   }
 }
 

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -834,6 +834,7 @@ extension PaywallViewController {
     if isSafariVCPresented {
       return
     }
+
     willDismiss()
   }
 
@@ -855,8 +856,9 @@ extension PaywallViewController {
     }
 
     resetPresentationPreparations()
-
-    didDismiss()
+    Task {
+      await didDismiss()
+    }
   }
 
   private func resetPresentationPreparations() {
@@ -939,12 +941,15 @@ extension PaywallViewController {
     Superwall.shared.dependencyContainer.delegateAdapter.willDismissPaywall(withInfo: info)
   }
 
-  private func didDismiss() {
+  private func didDismiss() async {
     // Reset spinner
     let isShowingSpinner = loadingState == .loadingPurchase || loadingState == .manualLoading
     if isShowingSpinner {
       self.loadingState = .ready
     }
+
+    let state = await webView.messageHandler.getState()
+    paywall.state = state
 
     Superwall.shared.dependencyContainer.delegateAdapter.didDismissPaywall(withInfo: info)
 

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
@@ -212,6 +212,33 @@ final class PaywallMessageHandler: WebEventDelegate {
     }
   }
 
+  func getState() async -> [String: Any] {
+    let messageScript = """
+    window.app.getAllState();
+    """
+
+    Logger.debug(
+      logLevel: .debug,
+      scope: .paywallViewController,
+      message: "Getting state",
+      info: ["message": messageScript]
+    )
+
+    do {
+      let result = try await delegate?.webView.evaluateJavaScript(messageScript) as? [String: Any]
+      return result ?? [:]
+    } catch {
+      Logger.debug(
+        logLevel: .error,
+        scope: .paywallViewController,
+        message: "Error Evaluating JS",
+        info: ["message": messageScript],
+        error: error
+      )
+      return [:]
+    }
+  }
+
   /// Passes in the HTML substitutions, templates and other scripts to make the webview
   /// feel native.
   nonisolated private func didLoadWebView(

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Yusuf Tör on 19/09/2024.
 //
-// swiftlint:disable function_body_length
+// swiftlint:disable function_body_length cyclomatic_complexity
 
 import Foundation
 import StoreKit

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.3.9"
+  s.version      = "4.3.10"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- Adds `networkDecoding_fail` event to help with debugging if a decoding error happens.
- Adds `state` to the `PaywallInfo` object. This is set on dismiss of the paywall and can be used to access state variables set in the editor.

### Fixes

- Fixes issue where the configuration completion block could take a long time to complete if the user had a lot of transactions.
- Fixes issue where `didDismissPaywall(withInfo:)` and the `onDismiss` paywall presentation handler would be called before the presenting window was destroyed.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
