### PR TITLE
feature/multiple-scenes-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fix for old versions of Xcode not building due to not supporting `.winBack` transaction offer types.
+- Fixes an issue where the paywall could be presented from the wrong scene in multi-window apps.
 
 ## 4.4.1
 

--- a/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
@@ -16,6 +16,12 @@ extension UIApplication {
       return windowScene.windows.first { $0.isKeyWindow } ?? windowScene.windows.first
     }
 
+    // Then try to find a key window in the foreground inactive scene
+    if let windowScene = UIApplication.shared.connectedScenes
+      .first(where: { $0.activationState == .foregroundInactive }) as? UIWindowScene {
+      return windowScene.windows.first { $0.isKeyWindow } ?? windowScene.windows.first
+    }
+
     // Fallback: search across all scenes for a key window
     let windows = UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
     return windows.first { $0.isKeyWindow } ?? windows.first

--- a/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
@@ -10,11 +10,14 @@ import UIKit
 
 extension UIApplication {
   var activeWindow: UIWindow? {
-    guard let windowScene = UIApplication.shared.connectedScenes
-      .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else {
-        return nil
+    // First, try to find a key window in the foreground active scene
+    if let windowScene = UIApplication.shared.connectedScenes
+      .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+      return windowScene.windows.first { $0.isKeyWindow } ?? windowScene.windows.first
     }
 
-    return windowScene.windows.first { $0.isKeyWindow } ?? windowScene.windows.first
+    // Fallback: search across all scenes for a key window
+    let windows = UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+    return windows.first { $0.isKeyWindow } ?? windows.first
   }
 }

--- a/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
@@ -10,7 +10,11 @@ import UIKit
 
 extension UIApplication {
   var activeWindow: UIWindow? {
-    let windows = UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-    return windows.first { $0.isKeyWindow } ?? windows.first
+    guard let windowScene = UIApplication.shared.connectedScenes
+      .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else {
+        return nil
+    }
+
+    return windowScene.windows.first { $0.isKeyWindow } ?? windowScene.windows.first
   }
 }


### PR DESCRIPTION
## Changes in this pull request

- Prioritises foregroundActive scenes, then foregroundInactive scenes before falling back to the old active window selection.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
