### PR TITLE
feature/allow-for-app-extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.5.2
+
+### Fixes
+
+- Replace `UIApplication.shared` with `sharedApplication` accessed via KVC so that SuperwallKit can be used in app extensions.
+
 ## 4.5.1
 
 ### Fixes

--- a/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/RevenueCat/purchases-ios.git",
         "state": {
           "branch": null,
-          "revision": "2f43b88b893880848983af9b885185e20850a1df",
-          "version": "5.28.0"
+          "revision": "cdfe7100fc8cca4a655a9c0f1d34e1fcbc40edd0",
+          "version": "5.28.1"
         }
       },
       {

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.5.1
+4.5.2
 """

--- a/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
@@ -10,20 +10,23 @@ import UIKit
 
 extension UIApplication {
   var activeWindow: UIWindow? {
+    guard let sharedApplication = UIApplication.sharedApplication else {
+      return nil
+    }
     // First, try to find a key window in the foreground active scene
-    if let windowScene = UIApplication.shared.connectedScenes
+    if let windowScene = sharedApplication.connectedScenes
       .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
       return windowScene.windows.first { $0.isKeyWindow } ?? windowScene.windows.first
     }
 
     // Then try to find a key window in the foreground inactive scene
-    if let windowScene = UIApplication.shared.connectedScenes
+    if let windowScene = sharedApplication.connectedScenes
       .first(where: { $0.activationState == .foregroundInactive }) as? UIWindowScene {
       return windowScene.windows.first { $0.isKeyWindow } ?? windowScene.windows.first
     }
 
     // Fallback: search across all scenes for a key window
-    let windows = UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+    let windows = sharedApplication.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
     return windows.first { $0.isKeyWindow } ?? windows.first
   }
 }

--- a/Sources/SuperwallKit/Misc/Extensions/UIApplication+Shared.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/UIApplication+Shared.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 16/06/2025.
+//
+
+import UIKit
+
+extension UIApplication {
+  /// Uses KVC to get the `sharedApplication.
+  ///
+  /// This is because `UIApplication.shared` isn't available in extensions.
+  static var sharedApplication: UIApplication? {
+    return UIApplication.value(forKey: "sharedApplication") as? UIApplication
+  }
+}

--- a/Sources/SuperwallKit/Misc/Extensions/UIViewController/UIViewController+TopVc.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/UIViewController/UIViewController+TopVc.swift
@@ -9,7 +9,10 @@ import UIKit
 
 extension UIViewController {
   static var topMostViewController: UIViewController? {
-    var topViewController: UIViewController? = UIApplication.shared.activeWindow?.rootViewController
+    guard let sharedApplication = UIApplication.sharedApplication else {
+      return nil
+    }
+    var topViewController: UIViewController? = sharedApplication.activeWindow?.rootViewController
     while let presentedViewController = topViewController?.presentedViewController {
       topViewController = presentedViewController
     }

--- a/Sources/SuperwallKit/Misc/Extensions/UIWindow/UIWindow+Landscape.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/UIWindow/UIWindow+Landscape.swift
@@ -9,7 +9,10 @@ import UIKit
 
 extension UIWindow {
   static var isLandscape: Bool {
-    return UIApplication.shared.windows
+    guard let sharedApplication = UIApplication.sharedApplication else {
+      return false
+    }
+    return sharedApplication.windows
       .first?
       .windowScene?
       .interfaceOrientation

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -46,7 +46,10 @@ class Network {
   @objc
   @MainActor
   private func applicationStateDidChange() {
-    applicationStateSubject.send(UIApplication.shared.applicationState)
+    guard let sharedApplication = UIApplication.sharedApplication else {
+      return
+    }
+    applicationStateSubject.send(sharedApplication.applicationState)
   }
 
   func sendEvents(events: EventsRequest) async {

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal/Operators/GetPresenter.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal/Operators/GetPresenter.swift
@@ -123,7 +123,10 @@ extension Superwall {
     guard presentationItems.window == nil else {
       return
     }
-    let activeWindow = UIApplication.shared.activeWindow
+    guard let sharedApplication = UIApplication.sharedApplication else {
+      return
+    }
+    let activeWindow = sharedApplication.activeWindow
     var presentingWindow: UIWindow?
 
     if let windowScene = activeWindow?.windowScene {

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -691,7 +691,10 @@ extension PaywallViewController: PaywallMessageHandlerDelegate {
   }
 
   func presentSafariInApp(_ url: URL) {
-    guard UIApplication.shared.canOpenURL(url) else {
+    guard let sharedApplication = UIApplication.sharedApplication else {
+      return
+    }
+    guard sharedApplication.canOpenURL(url) else {
       Logger.debug(
         logLevel: .warn,
         scope: .paywallViewController,
@@ -708,7 +711,10 @@ extension PaywallViewController: PaywallMessageHandlerDelegate {
   }
 
   func presentSafariExternal(_ url: URL) {
-    UIApplication.shared.open(url)
+    guard let sharedApplication = UIApplication.sharedApplication else {
+      return
+    }
+    sharedApplication.open(url)
   }
 
   func openDeepLink(_ url: URL) {
@@ -717,7 +723,10 @@ extension PaywallViewController: PaywallMessageHandlerDelegate {
       closeReason: .systemLogic
     ) { [weak self] in
       self?.eventDidOccur(.openedDeepLink(url: url))
-      UIApplication.shared.open(url)
+      guard let sharedApplication = UIApplication.sharedApplication else {
+        return
+      }
+      sharedApplication.open(url)
     }
   }
 }

--- a/Sources/SuperwallKit/StoreKit/Transactions/Notifications/NotificationScheduler.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Notifications/NotificationScheduler.swift
@@ -48,7 +48,10 @@ enum NotificationScheduler {
               closeActionTitle: notificationPermissionsDenied.closeButtonTitle,
               action: {
                 if let url = URL(string: UIApplication.openSettingsURLString) {
-                  UIApplication.shared.open(url)
+                  guard let sharedApplication = UIApplication.sharedApplication else {
+                    return continuation.resume()
+                  }
+                  sharedApplication.open(url)
                 }
                 continuation.resume()
               },

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/StoreKit 2/ProductPurchaserSK2.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/StoreKit 2/ProductPurchaserSK2.swift
@@ -96,7 +96,10 @@ final class ProductPurchaserSK2: Purchasing {
       let result: StoreKit.Product.PurchaseResult
 
       #if os(visionOS)
-      guard let scene = await UIApplication.shared.connectedScenes.first else {
+      guard let sharedApplication = UIApplication.sharedApplication else {
+        return .cancelled
+      }
+      guard let scene = await sharedApplication.connectedScenes.first else {
         return .cancelled
       }
       result = try await product.purchase(confirmIn: scene, options: options)

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
@@ -245,7 +245,11 @@ final class TransactionManager {
             message: hasEntitlements ? hasSubsText : noSubsText,
             actionTitle: "Yes",
             closeActionTitle: "Cancel",
-            action: { UIApplication.shared.open(restoreUrl) }
+            action: {
+              guard let sharedApplication = UIApplication.sharedApplication else {
+                return
+              }
+              sharedApplication.open(restoreUrl) }
           )
           return .webRestore
         }

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.5.1"
+  s.version      = "4.5.2"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

- Replace `UIApplication.shared` with `sharedApplication` accessed via KVC so that SuperwallKit can be used in app extensions.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
