### PR TITLE
Added localised successful purchase pop up for web checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Adds the `PaywallOption` `overrideProductsByName`, which can be used to globally override products on any paywall that have a given name. This can also be set after configure has been called by setting `Superwall.shared.overrideProductsByName`.
-- Adds the `PaywallOption` `shouldShowWebPurchaseConfirmationAlert`, which shows a localized alert confirming a successful purchase via web checkout.
+- Adds the `PaywallOption` `shouldShowWebPurchaseConfirmationAlert`, which shows a localized alert confirming a successful purchase via web checkout. Defaults to `true`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Adds the `PaywallOption` `overrideProductsByName`, which can be used to globally override products on any paywall that have a given name. This can also be set after configure has been called by setting `Superwall.shared.overrideProductsByName`.
+- Adds the `PaywallOption` `shouldShowWebPurchaseConfirmationAlert`, which shows a localized alert confirming a successful purchase via web checkout.
 
 ### Fixes
 

--- a/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/RevenueCat/purchases-ios.git",
         "state": {
           "branch": null,
-          "revision": "cdfe7100fc8cca4a655a9c0f1d34e1fcbc40edd0",
-          "version": "5.28.1"
+          "revision": "9cb74af9c5e9b4e9c22a511d8df4481fa7e3de16",
+          "version": "5.32.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "SuperwallKit",
+  defaultLocalization: "en",
   platforms: [
     .iOS(.v13),
     .macOS(.v10_12),
@@ -31,6 +32,7 @@ let package = Package(
       exclude: ["Resources/BundleHelper.swift"],
       resources: [
         .process("Resources/Certificates"),
+        .process("Resources/Localizations"),
         .copy("Resources/PrivacyInfo.xcprivacy")
       ]
     ),

--- a/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
@@ -121,6 +121,9 @@ public final class PaywallOptions: NSObject, Encodable {
   /// This assumes that your products have the names "primary" and "tertiary" in the Paywall Editor.
   public var overrideProductsByName: [String: String]? = [:]
 
+  /// Shows an alert confirming a successful purchase via web checkout. Defaults to `true`.
+  public var shouldShowWebPurchaseConfirmationAlert = true
+
   /// Defines the different types of views that can appear behind Apple's payment sheet during a transaction.
   @objc(SWKTransactionBackgroundView)
   public enum TransactionBackgroundView: Int, Encodable, CustomStringConvertible, Sendable {
@@ -161,6 +164,8 @@ public final class PaywallOptions: NSObject, Encodable {
     case shouldPreload
     case automaticallyDismiss
     case transactionBackgroundView
+    case overrideProductsByName
+    case shouldShowWebPurchaseConfirmationAlert
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -171,5 +176,7 @@ public final class PaywallOptions: NSObject, Encodable {
     try container.encode(shouldShowPurchaseFailureAlert, forKey: .shouldShowPurchaseFailureAlert)
     try container.encode(shouldPreload, forKey: .shouldPreload)
     try container.encode(automaticallyDismiss, forKey: .automaticallyDismiss)
+    try container.encode(overrideProductsByName, forKey: .overrideProductsByName)
+    try container.encode(shouldShowWebPurchaseConfirmationAlert, forKey: .shouldShowWebPurchaseConfirmationAlert)
   }
 }

--- a/Sources/SuperwallKit/Debug/Localizations/LocalizationLogic.swift
+++ b/Sources/SuperwallKit/Debug/Localizations/LocalizationLogic.swift
@@ -78,4 +78,34 @@ enum LocalizationLogic {
 
     return groupings
   }
+
+  /// - Returns: the `Bundle` associated with the given locale if found
+  /// Defaults to `Bundle.module` and the preferred locale of the device.
+  ///
+  /// `SwiftUI.Text` uses `EnvironmentValues.locale` and therefore
+  /// can be mocked in tests.
+  /// However, for views that load strings, this allows specifying a custom `Locale`.
+  /// Example:
+  /// ```swift
+  /// let text = LocalizationLogic
+  ///   .localizedBundle(locale)
+  ///   .localizedString(
+  ///     forKey: "string",
+  ///     value: nil,
+  ///     table: nil
+  ///   )
+  /// ```
+  static func localizedBundle(_ locale: Locale? = nil) -> Bundle {
+    let preferredLocaleIdentifier = Superwall.shared.dependencyContainer.deviceHelper.preferredLocaleIdentifier
+    let locale = locale ?? Locale(identifier: preferredLocaleIdentifier)
+    let containerBundle: Bundle = .module
+
+    let preferredLocale = Bundle.preferredLocalizations(
+      from: containerBundle.localizations,
+      forPreferences: [locale.identifier]
+    ).first
+
+    let path = preferredLocale.flatMap { containerBundle.path(forResource: $0, ofType: "lproj") }
+    return path.flatMap(Bundle.init(path:)) ?? containerBundle
+  }
 }

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -193,7 +193,7 @@ extension DependencyContainer: TransactionManagerFactory {
 // MARK: - CacheFactory
 extension DependencyContainer: CacheFactory {
   func makeCache() -> PaywallViewControllerCache {
-    return PaywallViewControllerCache(deviceLocaleString: deviceHelper.locale)
+    return PaywallViewControllerCache(deviceLocaleString: deviceHelper.localeIdentifier)
   }
 }
 
@@ -209,7 +209,7 @@ extension DependencyContainer: DeviceHelperFactory {
   func makeDeviceInfo() -> DeviceInfo {
     return DeviceInfo(
       appInstalledAtString: deviceHelper.appInstalledAtString,
-      locale: deviceHelper.locale
+      locale: deviceHelper.localeIdentifier
     )
   }
 
@@ -373,7 +373,7 @@ extension DependencyContainer: ApiFactory {
       "X-App-Version": deviceHelper.appVersion,
       "X-OS-Version": deviceHelper.osVersion,
       "X-Device-Model": deviceHelper.model,
-      "X-Device-Locale": deviceHelper.locale,
+      "X-Device-Locale": deviceHelper.localeIdentifier,
       "X-Device-Language-Code": deviceHelper.languageCode,
       "X-Device-Currency-Code": deviceHelper.currencyCode,
       "X-Device-Currency-Symbol": deviceHelper.currencySymbol,

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -14,14 +14,14 @@ import CoreTelephony
 import StoreKit
 
 class DeviceHelper {
-  var locale: String {
+  var localeIdentifier: String {
     let localeIdentifier = factory.makeLocaleIdentifier()
     return localeIdentifier ?? Locale.autoupdatingCurrent.identifier
   }
 
-  var preferredLocale: String {
+  var preferredLocaleIdentifier: String {
     guard let preferredIdentifier = Locale.preferredLanguages.first else {
-      return locale
+      return localeIdentifier
     }
     return Locale(identifier: preferredIdentifier).identifier
   }
@@ -515,8 +515,8 @@ class DeviceHelper {
       appVersionPadded: appVersionPadded,
       osVersion: osVersion,
       deviceModel: model,
-      deviceLocale: locale,
-      preferredLocale: preferredLocale,
+      deviceLocale: localeIdentifier,
+      preferredLocale: preferredLocaleIdentifier,
       deviceLanguageCode: languageCode,
       preferredLanguageCode: preferredLanguageCode,
       regionCode: regionCode,

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -94,7 +94,7 @@ class Network {
           appUserId: factory.identityManager.userId,
           apiKey: factory.storage.apiKey,
           config: factory.configManager.config,
-          locale: factory.deviceHelper.locale
+          locale: factory.deviceHelper.localeIdentifier
         ),
         data: SuperwallRequestData(factory: factory)
       )

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -4,7 +4,7 @@
 //
 //  Created by brian on 7/21/21.
 //
-// swiftlint:disable file_length type_body_length disable_print
+// swiftlint:disable file_length type_body_length
 
 import Combine
 import SafariServices

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -4,7 +4,7 @@
 //
 //  Created by brian on 7/21/21.
 //
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length disable_print
 
 import Combine
 import SafariServices
@@ -186,7 +186,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     self.paywallArchiveManager = paywallArchiveManager
     self.cacheKey = PaywallCacheLogic.key(
       identifier: paywall.identifier,
-      locale: deviceHelper.locale
+      locale: deviceHelper.localeIdentifier
     )
     self.deviceHelper = deviceHelper
     self.eventDelegate = eventDelegate

--- a/Sources/SuperwallKit/Resources/Localizations/ar.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/ar.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "تم الإعداد.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "تمت عملية الشراء بنجاح.";
+
+/* Alert action button */
+"purchase_success_action_title" = "حسناً";

--- a/Sources/SuperwallKit/Resources/Localizations/ca.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/ca.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Tot a punt.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "La teva compra ha estat reeixida.";
+
+/* Alert action button */
+"purchase_success_action_title" = "D'acord";

--- a/Sources/SuperwallKit/Resources/Localizations/cs.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/cs.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Vše připraveno.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Váš nákup byl úspěšný.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/da.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/da.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Alt er klar.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Dit køb blev gennemført.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/de.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Alles bereit.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Ihr Kauf war erfolgreich.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/el.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/el.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Ετοιμάστηκε.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Η αγορά σας πραγματοποιήθηκε με επιτυχία.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/en.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "You're all set.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Your purchase was successful.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/en_AU.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/en_AU.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "You're all set.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Your purchase was successful.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/en_GB.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/en_GB.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "You're all set.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Your purchase was successful.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/es.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/es.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Todo listo.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Su compra fue exitosa.";
+
+/* Alert action button */
+"purchase_success_action_title" = "Aceptar";

--- a/Sources/SuperwallKit/Resources/Localizations/es_419.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/es_419.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Todo listo.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Tu compra fue exitosa.";
+
+/* Alert action button */
+"purchase_success_action_title" = "Aceptar";

--- a/Sources/SuperwallKit/Resources/Localizations/fi.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/fi.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Kaikki valmista.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Ostosi onnistui.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/fr.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Tout est prêt.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Votre achat a été effectué avec succès.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/fr_CA.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/fr_CA.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Tout est prêt.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Votre achat a été complété avec succès.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/he.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/he.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "הכל מוכן.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "הקנייה בוצעה בהצלחה.";
+
+/* Alert action button */
+"purchase_success_action_title" = "אישור";

--- a/Sources/SuperwallKit/Resources/Localizations/hi.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/hi.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "सब तैयार है।";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "आपकी खरीद सफल रही।";
+
+/* Alert action button */
+"purchase_success_action_title" = "ठीक है";

--- a/Sources/SuperwallKit/Resources/Localizations/hr.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/hr.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Sve je spremno.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Kupnja je bila uspješna.";
+
+/* Alert action button */
+"purchase_success_action_title" = "U redu";

--- a/Sources/SuperwallKit/Resources/Localizations/hu.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/hu.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Minden készen áll.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "A vásárlás sikeresen megtörtént.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/id.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/id.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Semua sudah siap.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Pembelian Anda berhasil.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/it.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Tutto pronto.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Il tuo acquisto è stato completato con successo.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/ja.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "準備ができました。";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "購入が正常に完了しました。";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/ko.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "준비가 완료되었습니다.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "구매가 성공적으로 완료되었습니다.";
+
+/* Alert action button */
+"purchase_success_action_title" = "확인";

--- a/Sources/SuperwallKit/Resources/Localizations/ms.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/ms.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Segala-galanya sudah siap.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Pembelian anda berjaya.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/nb.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/nb.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Alt er klart.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Kjøpet ditt var vellykket.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/nl.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/nl.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Alles klaar.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Uw aankoop is gelukt.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/nn.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/nn.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Alt er klart.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Kjøpet ditt var vellykka.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/pl.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/pl.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Gotowe.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Twój zakup powiódł się.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/pt.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/pt.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Tudo pronto.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Sua compra foi bem-sucedida.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/pt_BR.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/pt_BR.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Tudo pronto.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Sua compra foi concluída com sucesso.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/pt_PT.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/pt_PT.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Tudo pronto.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "A sua compra foi bem-sucedida.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/ro.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/ro.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Totul este gata.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Achiziția dvs. a fost finalizată cu succes.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/ru.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Готово.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Ваш платеж прошёл успешно.";
+
+/* Alert action button */
+"purchase_success_action_title" = "ОК";

--- a/Sources/SuperwallKit/Resources/Localizations/sk.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/sk.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Všetko pripravené.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Váš nákup bol úspešný.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/sl.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/sl.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Vse je pripravljeno.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Vaš nakup je bil uspešen.";
+
+/* Alert action button */
+"purchase_success_action_title" = "V redu";

--- a/Sources/SuperwallKit/Resources/Localizations/sv.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/sv.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Allt är klart.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Ditt köp lyckades.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/th.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/th.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "พร้อมแล้ว.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "การซื้อของคุณเสร็จสมบูรณ์เรียบร้อยแล้ว.";
+
+/* Alert action button */
+"purchase_success_action_title" = "ตกลง";

--- a/Sources/SuperwallKit/Resources/Localizations/tr.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/tr.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Her şey hazır.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Satın alma işleminiz başarıyla tamamlandı.";
+
+/* Alert action button */
+"purchase_success_action_title" = "Tamam";

--- a/Sources/SuperwallKit/Resources/Localizations/uk.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/uk.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Готово.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Ваша покупка пройшла успішно.";
+
+/* Alert action button */
+"purchase_success_action_title" = "ОК";

--- a/Sources/SuperwallKit/Resources/Localizations/vi.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/vi.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "Mọi thứ đã sẵn sàng.";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "Giao dịch mua của bạn đã thành công.";
+
+/* Alert action button */
+"purchase_success_action_title" = "OK";

--- a/Sources/SuperwallKit/Resources/Localizations/zh_Hans.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/zh_Hans.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "一切就绪。";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "您的购买已成功完成。";
+
+/* Alert action button */
+"purchase_success_action_title" = "确定";

--- a/Sources/SuperwallKit/Resources/Localizations/zh_Hant.lproj/Localizable.strings
+++ b/Sources/SuperwallKit/Resources/Localizations/zh_Hant.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Purchase-success alert title */
+"purchase_success_title" = "一切就緒。";
+
+/* Purchase-success alert message */
+"purchase_success_message" = "您的購買已成功完成。";
+
+/* Alert action button */
+"purchase_success_action_title" = "確定";

--- a/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
+++ b/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Yusuf Tör on 12/03/2025.
 //
-// swiftlint:disable function_body_length cyclomatic_complexity type_body_length
+// swiftlint:disable function_body_length cyclomatic_complexity type_body_length trailing_closure
 
 import UIKit
 import Foundation
@@ -192,7 +192,6 @@ actor WebEntitlementRedeemer {
           await superwall.track(trackedEvent)
 
           await paywallVc.webView.messageHandler.handle(.restoreComplete)
-
         } else {
           await trackRestorationFailure(
             paywallViewController: paywallVc,
@@ -213,13 +212,12 @@ actor WebEntitlementRedeemer {
       // then close the paywall.
       if case let .code(code) = type {
         if let codeResult = response.results.first(where: { $0.code == code }) {
-
           let superwallOptions = factory.makeSuperwallOptions()
           let showConfirmation = superwallOptions.paywalls.shouldShowWebPurchaseConfirmationAlert
 
           func afterRedeem() async {
             if let paywallVc = superwall.paywallViewController,
-               paywallEntitlements.subtracting(allEntitlements).isEmpty {
+              paywallEntitlements.subtracting(allEntitlements).isEmpty {
               if superwallOptions.paywalls.automaticallyDismiss {
                 await superwall.dismiss(paywallVc, result: .restored)
               }

--- a/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
+++ b/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
@@ -79,6 +79,7 @@ actor WebEntitlementRedeemer {
     _ type: RedeemType,
     injectedConfig: Config? = nil
   ) async {
+    // Await for config or use injected config.
     var config = injectedConfig
 
     if config == nil {
@@ -91,71 +92,75 @@ actor WebEntitlementRedeemer {
     guard let config = config else {
       return
     }
+    // Make sure web2app is enabled
     if config.web2appConfig == nil {
       return
     }
 
-
+    // Prepare data to redeem
     let superwall = superwall ?? Superwall.shared
     let latestRedeemResponse = storage.get(LatestRedeemResponse.self)
 
-    do {
-      var allCodes = latestRedeemResponse?.allCodes ?? []
+    var allCodes = latestRedeemResponse?.allCodes ?? []
 
-      switch type {
-      case .code(let code):
-        // If redeeming a code, add it to list of existing codes,
-        // marking as first redemption or not.
-        var isFirstRedemption = true
+    switch type {
+    case .code(let code):
+      // If redeeming a code, add it to list of existing codes,
+      // marking as first redemption or not.
+      var isFirstRedemption = true
 
-        if !allCodes.isEmpty {
-          // If we have codes, isFirstRedemption is false if we already have the code
-          isFirstRedemption = !allCodes.contains { $0.code == code }
-        }
+      if !allCodes.isEmpty {
+        // If we have codes, isFirstRedemption is false if we already have the code
+        isFirstRedemption = !allCodes.contains { $0.code == code }
+      }
 
-        let redeemable = Redeemable(
-          code: code,
-          isFirstRedemption: isFirstRedemption
+      let redeemable = Redeemable(
+        code: code,
+        isFirstRedemption: isFirstRedemption
+      )
+      allCodes.insert(redeemable)
+
+      if let paywallVc = superwall.paywallViewController {
+        let trackedEvent = await InternalSuperwallEvent.Restore(
+          state: .start,
+          paywallInfo: paywallVc.info
         )
-        allCodes.insert(redeemable)
-
-        if let paywallVc = superwall.paywallViewController {
-          let trackedEvent = await InternalSuperwallEvent.Restore(
-            state: .start,
-            paywallInfo: paywallVc.info
-          )
-          await superwall.track(trackedEvent)
-        }
-      case .existingCodes:
-        break
+        await superwall.track(trackedEvent)
       }
+    case .existingCodes:
+      break
+    }
 
-      let request = await RedeemRequest(
-        deviceId: factory.makeDeviceId(),
-        appUserId: factory.makeAppUserId(),
-        aliasId: factory.makeAliasId(),
-        codes: allCodes,
-        receipts: receiptManager.getTransactionReceipts(),
-        appTransactionId: ReceiptManager.appTransactionId
-      )
+    // Create request to redeem
+    let request = await RedeemRequest(
+      deviceId: factory.makeDeviceId(),
+      appUserId: factory.makeAppUserId(),
+      aliasId: factory.makeAliasId(),
+      codes: allCodes,
+      receipts: receiptManager.getTransactionReceipts(),
+      appTransactionId: ReceiptManager.appTransactionId
+    )
 
-      let startEvent = InternalSuperwallEvent.Redemption(
-        state: .start,
-        type: type
-      )
-      await superwall.track(startEvent)
+    let startEvent = InternalSuperwallEvent.Redemption(
+      state: .start,
+      type: type
+    )
+    await superwall.track(startEvent)
 
-      switch type {
-      case .code:
-        await MainActor.run {
-          superwall.paywallViewController?.loadingState = .manualLoading
-          superwall.paywallViewController?.closeSafari()
-        }
-        await delegate.willRedeemLink()
-      case .existingCodes:
-        break
+    // Close safari if open and show spinner, then call delegate
+    switch type {
+    case .code:
+      await MainActor.run {
+        superwall.paywallViewController?.loadingState = .manualLoading
+        superwall.paywallViewController?.closeSafari()
       }
+      await delegate.willRedeemLink()
+    case .existingCodes:
+      break
+    }
 
+    do {
+      // Redeem
       let response = try await network.redeemEntitlements(request: request)
 
       storage.save(Date(), forType: LastWebEntitlementsFetchDate.self)
@@ -166,20 +171,19 @@ actor WebEntitlementRedeemer {
       )
       await superwall.track(completeEvent)
 
-      // Sets the subscription status internally if no external PurchaseController
       let deviceEntitlements = entitlementsInfo.activeDeviceEntitlements
       let allEntitlements = deviceEntitlements.union(response.entitlements)
 
+      // Get entitlements of products from paywall.
+      var paywallEntitlements: Set<Entitlement> = []
       if case .code = type,
         let paywallVc = superwall.paywallViewController {
-        // Get entitlements of products from paywall.
-        var paywallEntitlements: Set<Entitlement> = []
         for id in await paywallVc.info.productIds {
           paywallEntitlements.formUnion(Superwall.shared.entitlements.byProductId(id))
         }
 
         // If the restored entitlements cover the paywall entitlements,
-        // track successful restore.
+        // track successful restore
         if paywallEntitlements.subtracting(allEntitlements).isEmpty {
           let trackedEvent = await InternalSuperwallEvent.Restore(
             state: .complete,
@@ -189,10 +193,6 @@ actor WebEntitlementRedeemer {
 
           await paywallVc.webView.messageHandler.handle(.restoreComplete)
 
-          let superwallOptions = factory.makeSuperwallOptions()
-          if superwallOptions.paywalls.automaticallyDismiss {
-            await superwall.dismiss(paywallVc, result: .restored)
-          }
         } else {
           await trackRestorationFailure(
             paywallViewController: paywallVc,
@@ -209,13 +209,64 @@ actor WebEntitlementRedeemer {
         superwall: superwall
       )
 
-      // Call the delegate if user try to redeem a code
+      // Call the delegate if user try to redeem a code,
+      // then close the paywall.
       if case let .code(code) = type {
         if let codeResult = response.results.first(where: { $0.code == code }) {
-          await MainActor.run {
-            superwall.paywallViewController?.loadingState = .ready
+
+          let superwallOptions = factory.makeSuperwallOptions()
+          let showConfirmation = superwallOptions.paywalls.shouldShowWebPurchaseConfirmationAlert
+
+          func afterRedeem() async {
+            if let paywallVc = superwall.paywallViewController,
+               paywallEntitlements.subtracting(allEntitlements).isEmpty {
+              if superwallOptions.paywalls.automaticallyDismiss {
+                await superwall.dismiss(paywallVc, result: .restored)
+              }
+            }
+
+            await MainActor.run {
+              superwall.paywallViewController?.loadingState = .ready
+            }
+            await self.delegate.didRedeemLink(result: codeResult)
           }
-          await delegate.didRedeemLink(result: codeResult)
+
+          if showConfirmation {
+            let title = LocalizationLogic
+              .localizedBundle()
+              .localizedString(
+                forKey: "purchase_success_title",
+                value: nil,
+                table: nil
+              )
+            let message = LocalizationLogic
+              .localizedBundle()
+              .localizedString(
+                forKey: "purchase_success_message",
+                value: nil,
+                table: nil
+              )
+            let closeActionTitle = LocalizationLogic
+              .localizedBundle()
+              .localizedString(
+                forKey: "purchase_success_action_title",
+                value: nil,
+                table: nil
+              )
+
+            await superwall.paywallViewController?.presentAlert(
+              title: title,
+              message: message,
+              closeActionTitle: closeActionTitle,
+              onClose: {
+                Task {
+                  await afterRedeem()
+                }
+              }
+            )
+          } else {
+            await afterRedeem()
+          }
         }
       }
     } catch {
@@ -224,7 +275,6 @@ actor WebEntitlementRedeemer {
         type: type
       )
       await superwall.track(event)
-
 
       // Call the delegate if user try to redeem a code
       if case let .code(code) = type {

--- a/Tests/SuperwallKitTests/Network/DeviceHelperMock.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperMock.swift
@@ -11,7 +11,7 @@ import Foundation
 final class DeviceHelperMock: DeviceHelper {
   var internalLocale: String?
 
-  override var locale: String {
-    return internalLocale ?? super.locale
+  override var localeIdentifier: String {
+    return internalLocale ?? super.localeIdentifier
   }
 }

--- a/Tests/SuperwallKitTests/Paywall/Manager/PaywallViewControllerCacheTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Manager/PaywallViewControllerCacheTests.swift
@@ -15,7 +15,7 @@ class PaywallViewControllerCacheTests: XCTestCase {
   func testSaveAndRetrievePaywall() throws {
     // Given
     let dependencyContainer = DependencyContainer()
-    let locale = dependencyContainer.deviceHelper.locale
+    let locale = dependencyContainer.deviceHelper.localeIdentifier
     let paywallCache = PaywallViewControllerCache(deviceLocaleString: locale)
     let id = "myid"
     let key = PaywallCacheLogic.key(identifier: id, locale: locale)
@@ -40,7 +40,7 @@ class PaywallViewControllerCacheTests: XCTestCase {
   func testSaveAndRemovePaywall_withId() {
     // Given
     let dependencyContainer = DependencyContainer()
-    let locale = dependencyContainer.deviceHelper.locale
+    let locale = dependencyContainer.deviceHelper.localeIdentifier
     let paywallCache = PaywallViewControllerCache(deviceLocaleString: locale)
     let id = "myid"
     let key = PaywallCacheLogic.key(identifier: id, locale: locale)
@@ -71,7 +71,7 @@ class PaywallViewControllerCacheTests: XCTestCase {
   func testClearCache() {
     // Given
     let dependencyContainer = DependencyContainer()
-    let locale = dependencyContainer.deviceHelper.locale
+    let locale = dependencyContainer.deviceHelper.localeIdentifier
     let paywallCache = PaywallViewControllerCache(deviceLocaleString: locale)
     let paywallId1 = "id1"
     let key1 = PaywallCacheLogic.key(identifier: paywallId1, locale: locale)

--- a/Tests/SuperwallKitTests/Web/WebEntitlementRedeemerTests.swift
+++ b/Tests/SuperwallKitTests/Web/WebEntitlementRedeemerTests.swift
@@ -26,8 +26,13 @@ struct WebEntitlementRedeemerTests {
 
     // No existing redeem response, so is first redemption of code.
     let mockStorage = StorageMock(internalRedeemResponse: nil)
+
+    // Disable the popup
+    let options = dependencyContainer.makeSuperwallOptions()
+    options.paywalls.shouldShowWebPurchaseConfirmationAlert = false
+
     let mockNetwork = NetworkMock(
-      options: dependencyContainer.makeSuperwallOptions(),
+      options: options,
       factory: dependencyContainer
     )
 
@@ -102,8 +107,13 @@ struct WebEntitlementRedeemerTests {
 
     // No existing redeem response, so is first redemption of code.
     let mockStorage = StorageMock(internalRedeemResponse: existingResponse)
+
+    // Disable the popup
+    let options = dependencyContainer.makeSuperwallOptions()
+    options.paywalls.shouldShowWebPurchaseConfirmationAlert = false
+
     let mockNetwork = NetworkMock(
-      options: dependencyContainer.makeSuperwallOptions(),
+      options: options,
       factory: dependencyContainer
     )
     let mockDelegate = MockSuperwallDelegate()
@@ -204,8 +214,12 @@ struct WebEntitlementRedeemerTests {
 
     // No existing redeem response, so is first redemption of code.
     let mockStorage = StorageMock(internalRedeemResponse: existingResponse)
+    // Disable the popup
+    let options = dependencyContainer.makeSuperwallOptions()
+    options.paywalls.shouldShowWebPurchaseConfirmationAlert = false
+
     let mockNetwork = NetworkMock(
-      options: dependencyContainer.makeSuperwallOptions(),
+      options: options,
       factory: dependencyContainer
     )
     let mockDelegate = MockSuperwallDelegate()


### PR DESCRIPTION
## Changes in this pull request

- Adds the `PaywallOption` `shouldShowWebPurchaseConfirmationAlert`, which shows a localized alert confirming a successful purchase via web checkout.
- Updates RC version

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
