### PR TITLE
Add handler for paywall will dismiss

### DIFF
--- a/Sources/SuperwallKit/Debug/DebugViewController.swift
+++ b/Sources/SuperwallKit/Debug/DebugViewController.swift
@@ -474,7 +474,7 @@ final class DebugViewController: UIViewController {
           let playButton = UIImage(named: "SuperwallKit_play_button", in: Bundle.module, compatibleWith: nil)!
           self.bottomButton.setImage(playButton, for: .normal)
           self.activityIndicator.stopAnimating()
-        case .dismissed:
+        case .dismissed, .willDismiss:
           break
         case .presentationError(let error):
           Logger.debug(

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal/Presentation State/PaywallState.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal/Presentation State/PaywallState.swift
@@ -59,6 +59,9 @@ public enum PaywallState {
   /// A paywall may have been configured to show, but did not due to an `Error`.
   case presentationError(Error)
 
+  /// The paywall will be dismissed. Contains a ``PaywallInfo`` object with more information about the presented paywall and a ``PaywallResult`` object containing the paywall dismissal reason.
+  case willDismiss(PaywallInfo, PaywallResult)
+
   /// The paywall was dismissed. Contains a ``PaywallInfo`` object with more information about the presented paywall and a ``PaywallResult`` object containing the paywall dismissal reason.
   case dismissed(PaywallInfo, PaywallResult)
 

--- a/Sources/SuperwallKit/Paywall/Presentation/PaywallPresentationHandler.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PaywallPresentationHandler.swift
@@ -14,6 +14,9 @@ public final class PaywallPresentationHandler: NSObject {
   /// A block called when the paywall did present.
   var onPresentHandler: ((PaywallInfo) -> Void)?
 
+  /// A block called when the paywall will dismiss.
+  var onWillDismissHandler: ((PaywallInfo, PaywallResult) -> Void)?
+
   /// A block called when the paywall did dismiss.
   var onDismissHandler: ((PaywallInfo, PaywallResult) -> Void)?
 
@@ -45,6 +48,14 @@ public final class PaywallPresentationHandler: NSObject {
   /// the dismissed paywall.
   public func onDismiss(_ handler: @escaping (PaywallInfo, PaywallResult) -> Void) {
     self.onDismissHandler = handler
+  }
+
+  /// Sets the handler that will be called when the paywall will be dismissed.
+  ///
+  /// - Parameter handler: A block that accepts a ``PaywallInfo`` and ``PaywallResult`` object associated with
+  /// the dismissing paywall.
+  public func onWillDismiss(_ handler: @escaping (PaywallInfo, PaywallResult) -> Void) {
+    self.onWillDismissHandler = handler
   }
 
   /// Sets the handler that will be called when a paywall is skipped, but no error has occurred.

--- a/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
@@ -131,6 +131,8 @@ extension Superwall {
             switch state {
             case .presented(let paywallInfo):
               handler?.onPresentHandler?(paywallInfo)
+            case let .willDismiss(paywallInfo, paywallResult):
+                handler?.onWillDismissHandler?(paywallInfo, paywallResult)
             case let .dismissed(paywallInfo, paywallResult):
               if let handler = handler?.onDismissHandler {
                 handler(paywallInfo, paywallResult)

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -1210,6 +1210,9 @@ extension PaywallViewController {
   }
 
   private func willDismiss() {
+    let result = paywallResult ?? .declined
+    paywallStateSubject?.send(.willDismiss(info, result))
+
     Superwall.shared.presentationItems.paywallInfo = info
     Superwall.shared.dependencyContainer.delegateAdapter.willDismissPaywall(withInfo: info)
   }


### PR DESCRIPTION
## Changes in this pull request

- Added new method `willDismiss` for `PaywallPresentationHandler`.  Works similar to `didDismiss`, but is being called earlier. It is needed for more flexible control over presentation lifecycle.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
