### PR TITLE
fix(device): read UIKit traits on the main thread and cache them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Fixes network requests that can never succeed, such as those with an invalid API key, taking up to a minute to fail instead of failing straight away. Timeouts and server errors still retry as before.
 - Fixes failed network requests being reported as a decoding error rather than the HTTP error that actually occurred.
 - Fixes issue where the paywall debugger wouldn't work for accounts with many paywalls.
+- Fixes Main Thread Checker warnings caused by reading the device's interface style and text size from a background thread.
 
 ## 4.16.1
 

--- a/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift
@@ -29,4 +29,25 @@ extension UIApplication {
     let windows = sharedApplication.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
     return windows.first { $0.isKeyWindow } ?? windows.first
   }
+
+  /// The scene behind ``activeWindow``, using the same activation-state priority.
+  ///
+  /// Preferred over the window for trait observation: a window's
+  /// `overrideUserInterfaceStyle` doesn't propagate up to its scene, so the scene's
+  /// `userInterfaceStyle` follows the system the way `UIScreen.main` does. It also
+  /// outlives the individual windows it hosts.
+  var activeWindowScene: UIWindowScene? {
+    guard let sharedApplication = UIApplication.sharedApplication else {
+      return nil
+    }
+    if let windowScene = sharedApplication.connectedScenes
+      .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+      return windowScene
+    }
+    if let windowScene = sharedApplication.connectedScenes
+      .first(where: { $0.activationState == .foregroundInactive }) as? UIWindowScene {
+      return windowScene
+    }
+    return sharedApplication.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+  }
 }

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -234,9 +234,11 @@ class DeviceHelper {
   /// availability.
   private var traitChangeRegistration: Any?
 
-  /// The scene the registration was made against, held weakly so its deallocation is
-  /// detectable. UIKit tears a registration down with the object that created it, so
-  /// a non-nil token whose scene has gone is stale, not live.
+  /// The scene the registration was made against, held weakly. A registration goes
+  /// stale two ways: UIKit tears it down when its scene deallocates, and a
+  /// multi-window host can keep the scene alive in the background while another
+  /// becomes active — where trait updates are deferred, so flips the user can see
+  /// never fire it. Both show up as this no longer matching the active scene.
   private weak var observedTraitScene: UIWindowScene?
 
   /// The current traits.
@@ -267,7 +269,7 @@ class DeviceHelper {
       uiTraits = DeviceHelper.makeUITraits()
       return
     }
-    guard !$isRefreshingUITraits.testAndSetTrue() else {
+    if $isRefreshingUITraits.testAndSetTrue() {
       return
     }
     DispatchQueue.main.async { [weak self] in
@@ -287,7 +289,7 @@ class DeviceHelper {
   ///
   /// Registration needs a scene, which may not exist yet when `DeviceHelper` is
   /// created, so this also runs on activation and re-arms if the observed scene has
-  /// since gone away.
+  /// since gone away or stopped being the active one.
   ///
   /// iOS 17+ only. Earlier releases read live on every access instead, rather than
   /// injecting a view into the host's window to reach `traitCollectionDidChange`.
@@ -305,12 +307,18 @@ class DeviceHelper {
   @available(iOS 17.0, *)
   @MainActor
   private func performTraitChangeRegistration() {
-    // Already armed against a scene that still exists.
-    if traitChangeRegistration != nil && observedTraitScene != nil {
-      return
-    }
     guard let scene = UIApplication.sharedApplication?.activeWindowScene else {
       return
+    }
+    // Already armed against the scene that's currently active.
+    if traitChangeRegistration != nil && observedTraitScene === scene {
+      return
+    }
+    // The observed scene either died or ceded activity to this one. Moving the
+    // registration rather than adding a second keeps it single: one live token,
+    // fired by the scene the user is looking at.
+    if let staleRegistration = traitChangeRegistration as? UITraitChangeRegistration {
+      observedTraitScene?.unregisterForTraitChanges(staleRegistration)
     }
     observedTraitScene = scene
     traitChangeRegistration = scene.registerForTraitChanges(

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -190,10 +190,93 @@ class DeviceHelper {
     if let interfaceStyleOverride = interfaceStyleOverride {
       return interfaceStyleOverride.description
     }
+    return uiTraits.interfaceStyle
+  }
+
+  var fontSize: Int {
+    return uiTraits.fontSize
+  }
+
+  var fontScale: Double {
+    return uiTraits.fontScale
+  }
+
+  var preferredContentSizeCategory: String {
+    return uiTraits.preferredContentSizeCategory
+  }
+
+  /// Trait-derived values, cached from the main thread.
+  ///
+  /// `UIApplication.preferredContentSizeCategory`, `UIScreen.traitCollection` and
+  /// `UIFontMetrics` are main-thread-only, but these are read from background
+  /// contexts such as `getTemplateDevice()`. They're read on the main thread and
+  /// cached, then refreshed whenever the traits change.
+  @DispatchQueueBacked
+  private var uiTraits: UITraits
+
+  private var traitObservers: [NSObjectProtocol] = []
+
+  private struct UITraits {
+    let interfaceStyle: String
+    let fontSize: Int
+    let fontScale: Double
+    let preferredContentSizeCategory: String
+
+    /// The values used when UIKit traits aren't available, e.g. on visionOS.
+    static let unavailable = UITraits(
+      interfaceStyle: "Unknown",
+      fontSize: 16,
+      fontScale: 1.0,
+      preferredContentSizeCategory: "unspecified"
+    )
+  }
+
+  private static func makeUITraits() -> UITraits {
     #if os(visionOS)
-    return "Unknown"
+    return .unavailable
     #else
-    let style = UIScreen.main.traitCollection.userInterfaceStyle
+    let read = { () -> UITraits in
+      let category = UIApplication.sharedApplication?.preferredContentSizeCategory
+        ?? UIScreen.main.traitCollection.preferredContentSizeCategory
+      let scaledValue = UIFontMetrics.default.scaledValue(for: 16.0)
+
+      return UITraits(
+        interfaceStyle: interfaceStyleToken(
+          for: UIScreen.main.traitCollection.userInterfaceStyle
+        ),
+        fontSize: Int(scaledValue.rounded()),
+        fontScale: ((scaledValue / 16.0) * 100).rounded() / 100,
+        preferredContentSizeCategory: contentSizeCategoryToken(for: category)
+      )
+    }
+    return Thread.isMainThread ? read() : DispatchQueue.main.sync(execute: read)
+    #endif
+  }
+
+  /// Refreshes the cached traits when the user changes their text size, or when the
+  /// app becomes active after an appearance change. Both notifications are posted on
+  /// the main thread.
+  private func observeUITraitChanges() {
+    #if !os(visionOS)
+    let names: [Notification.Name] = [
+      UIContentSizeCategory.didChangeNotification,
+      UIApplication.didBecomeActiveNotification
+    ]
+    traitObservers = names.map { name in
+      NotificationCenter.default.addObserver(
+        forName: name,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        self?.uiTraits = DeviceHelper.makeUITraits()
+      }
+    }
+    #endif
+  }
+
+  /// Maps a `UIUserInterfaceStyle` to the fixed dashboard token string used by
+  /// backend audience filters. These tokens are a backend contract and must not change.
+  static func interfaceStyleToken(for style: UIUserInterfaceStyle) -> String {
     switch style {
     case .unspecified:
       return "Unspecified"
@@ -204,34 +287,6 @@ class DeviceHelper {
     default:
       return "Unknown"
     }
-    #endif
-	}
-
-  var fontSize: Int {
-    #if os(visionOS)
-    return 16
-    #else
-    return Int(UIFontMetrics.default.scaledValue(for: 16.0).rounded())
-    #endif
-  }
-
-  var fontScale: Double {
-    #if os(visionOS)
-    return 1.0
-    #else
-    let scale = UIFontMetrics.default.scaledValue(for: 16.0) / 16.0
-    return (scale * 100).rounded() / 100
-    #endif
-  }
-
-  var preferredContentSizeCategory: String {
-    #if os(visionOS)
-    return "unspecified"
-    #else
-    let category = UIApplication.sharedApplication?.preferredContentSizeCategory
-      ?? UIScreen.main.traitCollection.preferredContentSizeCategory
-    return Self.contentSizeCategoryToken(for: category)
-    #endif
   }
 
   /// Maps a `UIContentSizeCategory` to the fixed dashboard token string used by
@@ -596,6 +651,15 @@ class DeviceHelper {
     self.screenWidth = screenMetrics.width
     self.screenHeight = screenMetrics.height
     self.devicePixelRatio = screenMetrics.scale
+
+    self.uiTraits = Self.makeUITraits()
+    observeUITraitChanges()
+  }
+
+  deinit {
+    for observer in traitObservers {
+      NotificationCenter.default.removeObserver(observer)
+    }
   }
 
   func getEnrichment(

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -279,9 +279,8 @@ class DeviceHelper {
   /// created, so this also runs on activation and re-arms if the observed scene has
   /// since gone away.
   ///
-  /// iOS 17+ only. Earlier versions deliberately fall back to the notifications and
-  /// refresh-on-read rather than injecting a view into the host's window to reach
-  /// `traitCollectionDidChange`, leaving them correct after one read.
+  /// iOS 17+ only. Earlier releases read live on every access instead, rather than
+  /// injecting a view into the host's window to reach `traitCollectionDidChange`.
   private func registerForTraitChanges() {
     #if !os(visionOS)
     Task { @MainActor [weak self] in

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -190,19 +190,19 @@ class DeviceHelper {
     if let interfaceStyleOverride = interfaceStyleOverride {
       return interfaceStyleOverride.description
     }
-    return uiTraits.interfaceStyle
+    return currentUITraits.interfaceStyle
   }
 
   var fontSize: Int {
-    return uiTraits.fontSize
+    return currentUITraits.fontSize
   }
 
   var fontScale: Double {
-    return uiTraits.fontScale
+    return currentUITraits.fontScale
   }
 
   var preferredContentSizeCategory: String {
-    return uiTraits.preferredContentSizeCategory
+    return currentUITraits.preferredContentSizeCategory
   }
 
   /// Trait-derived values, cached from the main thread.
@@ -210,11 +210,40 @@ class DeviceHelper {
   /// `UIApplication.preferredContentSizeCategory`, `UIScreen.traitCollection` and
   /// `UIFontMetrics` are main-thread-only, but these are read from background
   /// contexts such as `getTemplateDevice()`. They're read on the main thread and
-  /// cached, then refreshed whenever the traits change.
+  /// cached, then refreshed on trait-change notifications and on read.
   @DispatchQueueBacked
   private var uiTraits: UITraits
 
+  /// Set while a refresh of ``uiTraits`` is already scheduled, so a burst of reads
+  /// queues one main-thread hop rather than one per read.
+  @DispatchQueueBacked
+  private var isRefreshingUITraits = false
+
   private var traitObservers: [NSObjectProtocol] = []
+
+  /// The cached traits, scheduling a refresh so the next read is current.
+  ///
+  /// The notifications alone miss a system appearance change that lands while the
+  /// app stays active — the automatic light/dark switch at sunset — which would
+  /// leave the cache reporting the wrong token until the next foreground. Reads
+  /// happen off the main thread and can't block on it, so the refresh is
+  /// asynchronous: the cache trails a change by one read instead of indefinitely.
+  private var currentUITraits: UITraits {
+    refreshUITraits()
+    return uiTraits
+  }
+
+  private func refreshUITraits() {
+    #if !os(visionOS)
+    guard !$isRefreshingUITraits.testAndSetTrue() else {
+      return
+    }
+    DispatchQueue.main.async { [weak self] in
+      self?.uiTraits = DeviceHelper.makeUITraits()
+      self?.isRefreshingUITraits = false
+    }
+    #endif
+  }
 
   private struct UITraits {
     let interfaceStyle: String

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -221,13 +221,16 @@ class DeviceHelper {
 
   private var traitObservers: [NSObjectProtocol] = []
 
-  /// The cached traits, scheduling a refresh so the next read is current.
+  /// The `UITraitChangeRegistration` from ``registerForTraitChanges()``, held so it
+  /// can be reused across activations. Typed `Any?` because the protocol is iOS 17+
+  /// and a stored property can't be gated on availability.
+  private var traitChangeRegistration: Any?
+
+  /// The cached traits, refreshed so reads stay current.
   ///
-  /// The notifications alone miss a system appearance change that lands while the
-  /// app stays active — the automatic light/dark switch at sunset — which would
-  /// leave the cache reporting the wrong token until the next foreground. Reads
-  /// happen off the main thread and can't block on it, so the refresh is
-  /// asynchronous: the cache trails a change by one read instead of indefinitely.
+  /// On the main thread the refresh is inline, so the caller sees the live value.
+  /// Off it, the refresh is scheduled and the caller sees the previous value —
+  /// a backstop for the window the trait hook can't cover, not the primary path.
   private var currentUITraits: UITraits {
     refreshUITraits()
     return uiTraits
@@ -235,6 +238,12 @@ class DeviceHelper {
 
   private func refreshUITraits() {
     #if !os(visionOS)
+    // The wrapper's setter and getter share one serial queue, so this write is
+    // ordered ahead of `currentUITraits`' read and the caller sees it.
+    if Thread.isMainThread {
+      uiTraits = DeviceHelper.makeUITraits()
+      return
+    }
     guard !$isRefreshingUITraits.testAndSetTrue() else {
       return
     }
@@ -244,6 +253,44 @@ class DeviceHelper {
     }
     #endif
   }
+
+  /// Updates the cache at the moment the appearance or text size flips.
+  ///
+  /// There is no notification for `userInterfaceStyle`, so a system appearance
+  /// change while the app stays active — automatic light/dark at sunset — reaches
+  /// us only through a trait hook. Without this the cache reports the previous
+  /// token to `X-Device-Interface-Style` and to audience filters until something
+  /// else refreshes it.
+  ///
+  /// Registration needs a window, which may not exist yet when `DeviceHelper` is
+  /// created, so this also runs on activation and no-ops once registered.
+  private func registerForTraitChanges() {
+    #if !os(visionOS)
+    Task { @MainActor [weak self] in
+      if #available(iOS 17.0, *) {
+        self?.performTraitChangeRegistration()
+      }
+    }
+    #endif
+  }
+
+  #if !os(visionOS)
+  @available(iOS 17.0, *)
+  @MainActor
+  private func performTraitChangeRegistration() {
+    guard
+      traitChangeRegistration == nil,
+      let window = UIApplication.sharedApplication?.activeWindow
+    else {
+      return
+    }
+    traitChangeRegistration = window.registerForTraitChanges(
+      [UITraitUserInterfaceStyle.self, UITraitPreferredContentSizeCategory.self]
+    ) { [weak self] (_: UITraitEnvironment, _: UITraitCollection) in
+      self?.uiTraits = DeviceHelper.makeUITraits()
+    }
+  }
+  #endif
 
   private struct UITraits {
     let interfaceStyle: String
@@ -285,6 +332,9 @@ class DeviceHelper {
   /// Refreshes the cached traits when the user changes their text size, or when the
   /// app becomes active after an appearance change. Both notifications are posted on
   /// the main thread.
+  ///
+  /// Activation also retries ``registerForTraitChanges()``, since a window is more
+  /// likely to exist by then than when `DeviceHelper` was created.
   private func observeUITraitChanges() {
     #if !os(visionOS)
     let names: [Notification.Name] = [
@@ -298,6 +348,7 @@ class DeviceHelper {
         queue: .main
       ) { [weak self] _ in
         self?.uiTraits = DeviceHelper.makeUITraits()
+        self?.registerForTraitChanges()
       }
     }
     #endif
@@ -683,6 +734,7 @@ class DeviceHelper {
 
     self.uiTraits = Self.makeUITraits()
     observeUITraitChanges()
+    registerForTraitChanges()
   }
 
   deinit {

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -186,6 +186,14 @@ class DeviceHelper {
 
   var interfaceStyleOverride: InterfaceStyle?
 
+  /// Backs `X-Device-Interface-Style`. `getTemplateDevice()` resolves the override
+  /// the same way against its own trait snapshot — change one and change the other,
+  /// or the template and the header disagree on a backend-contract field.
+  ///
+  /// Not folded into a shared `interfaceStyle(from:)` helper on purpose: passing
+  /// `currentUITraits` would evaluate it eagerly, and below iOS 17 that read is a
+  /// blocking main-queue hop — one per network request whenever an override is set.
+  /// The early return here avoids it.
   var interfaceStyle: String {
     if let interfaceStyleOverride = interfaceStyleOverride {
       return interfaceStyleOverride.description
@@ -800,6 +808,9 @@ class DeviceHelper {
     // Snapshot once. The four trait-derived fields below each go through
     // `currentUITraits`, which before iOS 17 reads live behind a blocking
     // main-queue hop, so reading them separately would make four of those per call.
+    // Taking the snapshot means `interfaceStyle` below resolves the override
+    // inline rather than going through ``interfaceStyle``, so the two resolve it
+    // the same way by hand — keep them in step.
     let traits = currentUITraits
 
     let template = DeviceTemplate(

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -231,12 +231,20 @@ class DeviceHelper {
   /// a non-nil token whose scene has gone is stale, not live.
   private weak var observedTraitScene: UIWindowScene?
 
-  /// The cached traits, refreshed so reads stay current.
+  /// The current traits.
   ///
-  /// On the main thread the refresh is inline, so the caller sees the live value.
-  /// Off it, the refresh is scheduled and the caller sees the previous value —
-  /// a backstop for the window the trait hook can't cover, not the primary path.
+  /// Before iOS 17 there is no trait hook, so nothing invalidates the cache when the
+  /// appearance flips while the app stays active. These values were read live on
+  /// every access before caching was introduced, and serving a stale one would
+  /// regress `X-Device-Interface-Style` and the audience filters keyed on it — so
+  /// those versions read live. `makeUITraits()` makes the main-thread hop itself.
+  ///
+  /// From iOS 17 the hook keeps the cache current, and the scheduled refresh covers
+  /// the gap between launch and registration.
   private var currentUITraits: UITraits {
+    guard #available(iOS 17.0, *) else {
+      return DeviceHelper.makeUITraits()
+    }
     refreshUITraits()
     return uiTraits
   }

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -221,10 +221,15 @@ class DeviceHelper {
 
   private var traitObservers: [NSObjectProtocol] = []
 
-  /// The `UITraitChangeRegistration` from ``registerForTraitChanges()``, held so it
-  /// can be reused across activations. Typed `Any?` because the protocol is iOS 17+
-  /// and a stored property can't be gated on availability.
+  /// The `UITraitChangeRegistration` from ``registerForTraitChanges()``. Typed `Any?`
+  /// because the protocol is iOS 17+ and a stored property can't be gated on
+  /// availability.
   private var traitChangeRegistration: Any?
+
+  /// The scene the registration was made against, held weakly so its deallocation is
+  /// detectable. UIKit tears a registration down with the object that created it, so
+  /// a non-nil token whose scene has gone is stale, not live.
+  private weak var observedTraitScene: UIWindowScene?
 
   /// The cached traits, refreshed so reads stay current.
   ///
@@ -262,8 +267,9 @@ class DeviceHelper {
   /// token to `X-Device-Interface-Style` and to audience filters until something
   /// else refreshes it.
   ///
-  /// Registration needs a window, which may not exist yet when `DeviceHelper` is
-  /// created, so this also runs on activation and no-ops once registered.
+  /// Registration needs a scene, which may not exist yet when `DeviceHelper` is
+  /// created, so this also runs on activation and re-arms if the observed scene has
+  /// since gone away.
   private func registerForTraitChanges() {
     #if !os(visionOS)
     Task { @MainActor [weak self] in
@@ -278,13 +284,15 @@ class DeviceHelper {
   @available(iOS 17.0, *)
   @MainActor
   private func performTraitChangeRegistration() {
-    guard
-      traitChangeRegistration == nil,
-      let window = UIApplication.sharedApplication?.activeWindow
-    else {
+    // Already armed against a scene that still exists.
+    if traitChangeRegistration != nil && observedTraitScene != nil {
       return
     }
-    traitChangeRegistration = window.registerForTraitChanges(
+    guard let scene = UIApplication.sharedApplication?.activeWindowScene else {
+      return
+    }
+    observedTraitScene = scene
+    traitChangeRegistration = scene.registerForTraitChanges(
       [UITraitUserInterfaceStyle.self, UITraitPreferredContentSizeCategory.self]
     ) { [weak self] (_: UITraitEnvironment, _: UITraitCollection) in
       self?.uiTraits = DeviceHelper.makeUITraits()

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -270,6 +270,10 @@ class DeviceHelper {
   /// Registration needs a scene, which may not exist yet when `DeviceHelper` is
   /// created, so this also runs on activation and re-arms if the observed scene has
   /// since gone away.
+  ///
+  /// iOS 17+ only. Earlier versions deliberately fall back to the notifications and
+  /// refresh-on-read rather than injecting a view into the host's window to reach
+  /// `traitCollectionDidChange`, leaving them correct after one read.
   private func registerForTraitChanges() {
     #if !os(visionOS)
     Task { @MainActor [weak self] in

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -237,7 +237,9 @@ class DeviceHelper {
   /// appearance flips while the app stays active. These values were read live on
   /// every access before caching was introduced, and serving a stale one would
   /// regress `X-Device-Interface-Style` and the audience filters keyed on it — so
-  /// those versions read live. `makeUITraits()` makes the main-thread hop itself.
+  /// those versions read live. `makeUITraits()` makes the main-thread hop itself, and
+  /// off the main thread that hop *blocks* the caller until the main queue drains.
+  /// Read this once and reuse the snapshot rather than touching it per field.
   ///
   /// From iOS 17 the hook keeps the cache current, and the scheduled refresh covers
   /// the gap between launch and registration.
@@ -795,6 +797,11 @@ class DeviceHelper {
     let identityInfo = await factory.makeIdentityInfo()
     let aliases = [identityInfo.aliasId]
 
+    // Snapshot once. The four trait-derived fields below each go through
+    // `currentUITraits`, which before iOS 17 reads live behind a blocking
+    // main-queue hop, so reading them separately would make four of those per call.
+    let traits = currentUITraits
+
     let template = DeviceTemplate(
       publicApiKey: storage.apiKey,
       platform: isMac ? "macOS" : "iOS",
@@ -816,10 +823,10 @@ class DeviceHelper {
       interfaceType: interfaceType,
       timezoneOffset: Int(TimeZone.current.secondsFromGMT()),
       radioType: radioType,
-      interfaceStyle: interfaceStyle,
-      fontSize: fontSize,
-      fontScale: fontScale,
-      preferredContentSizeCategory: preferredContentSizeCategory,
+      interfaceStyle: interfaceStyleOverride?.description ?? traits.interfaceStyle,
+      fontSize: traits.fontSize,
+      fontScale: traits.fontScale,
+      preferredContentSizeCategory: traits.preferredContentSizeCategory,
       isLowPowerModeEnabled: isLowPowerModeEnabled == "true",
       isApplePayAvailable: true,
       bundleId: bundleId,

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -106,11 +106,25 @@ struct DeviceHelperTests {
       )
     }.value
 
+    // Compared against the live UIKit values, not just non-empty: the placeholder
+    // `UITraits.unavailable` would satisfy any weaker assertion.
+    let expected = await MainActor.run { () -> (String, Int, Double, String) in
+      let category = UIApplication.sharedApplication?.preferredContentSizeCategory
+        ?? UIScreen.main.traitCollection.preferredContentSizeCategory
+      let scaledValue = Double(UIFontMetrics.default.scaledValue(for: 16.0))
+      return (
+        DeviceHelper.interfaceStyleToken(for: UIScreen.main.traitCollection.userInterfaceStyle),
+        Int(scaledValue.rounded()),
+        ((scaledValue / 16.0) * 100).rounded() / 100,
+        DeviceHelper.contentSizeCategoryToken(for: category)
+      )
+    }
+
     #expect(traits.isMainThread == false)
-    #expect(traits.interfaceStyle.isEmpty == false)
-    #expect(traits.fontSize > 0)
-    #expect(traits.fontScale > 0)
-    #expect(traits.contentSizeCategory.isEmpty == false)
+    #expect(traits.interfaceStyle == expected.0)
+    #expect(traits.fontSize == expected.1)
+    #expect(traits.fontScale == expected.2)
+    #expect(traits.contentSizeCategory == expected.3)
   }
 
   /// The cached traits must hold the device's real values, not placeholders.

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -177,12 +177,15 @@ struct DeviceHelperTests {
     #expect(deviceHelper.preferredContentSizeCategory == expected.2)
   }
 
-  /// The template takes its four trait fields from one `currentUITraits` snapshot
-  /// rather than four separate reads, so before iOS 17 a template costs one blocking
-  /// main-queue hop instead of four. That inlines the `interfaceStyleOverride`
-  /// short-circuit the `interfaceStyle` property used to apply, so pin that the
-  /// override still wins and the other three fields still come from the device.
-  @Test func templateDevice_usesOneTraitSnapshotAndKeepsTheInterfaceStyleOverride() async {
+  /// Taking the four trait fields from one `currentUITraits` snapshot inlined the
+  /// `interfaceStyleOverride` short-circuit that the `interfaceStyle` property used
+  /// to apply, so pin that the override still wins and the other three fields still
+  /// come from the device.
+  ///
+  /// The snapshot itself isn't pinned here — nothing observable distinguishes one
+  /// read from four, since `makeUITraits()` is private and its hop count can't be
+  /// counted from a test. That property rests on the comments at both call sites.
+  @Test func templateDevice_keepsTheInterfaceStyleOverrideAndFillsTheRestFromTheDevice() async {
     let dependencyContainer = DependencyContainer()
     let deviceHelper: DeviceHelper = dependencyContainer.deviceHelper
 

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -176,4 +176,47 @@ struct DeviceHelperTests {
     #expect(deviceHelper.fontSize == expected.1)
     #expect(deviceHelper.preferredContentSizeCategory == expected.2)
   }
+
+  /// The template takes its four trait fields from one `currentUITraits` snapshot
+  /// rather than four separate reads, so before iOS 17 a template costs one blocking
+  /// main-queue hop instead of four. That inlines the `interfaceStyleOverride`
+  /// short-circuit the `interfaceStyle` property used to apply, so pin that the
+  /// override still wins and the other three fields still come from the device.
+  @Test func templateDevice_usesOneTraitSnapshotAndKeepsTheInterfaceStyleOverride() async {
+    let dependencyContainer = DependencyContainer()
+    let deviceHelper: DeviceHelper = dependencyContainer.deviceHelper
+
+    let expected = await MainActor.run { () -> (style: String, fontSize: Int, fontScale: Double, category: String) in
+      let category = UIApplication.sharedApplication?.preferredContentSizeCategory
+        ?? UIScreen.main.traitCollection.preferredContentSizeCategory
+      let scaledValue = Double(UIFontMetrics.default.scaledValue(for: 16.0))
+      return (
+        DeviceHelper.interfaceStyleToken(for: UIScreen.main.traitCollection.userInterfaceStyle),
+        Int(scaledValue.rounded()),
+        ((scaledValue / 16.0) * 100).rounded() / 100,
+        DeviceHelper.contentSizeCategoryToken(for: category)
+      )
+    }
+
+    // No override: every field mirrors the device.
+    let template = await deviceHelper.getTemplateDevice()
+    #expect(template["interfaceStyle"] as? String == expected.style)
+    #expect(template["fontSize"] as? Int == expected.fontSize)
+    // Cast both sides to `Double`: comparing against the `[String: Any]` value
+    // directly can resolve to SwiftyJSON's `NSNumber ==`.
+    #expect(template["fontScale"] as? Double == Double(expected.fontScale))
+    #expect(template["preferredContentSizeCategory"] as? String == expected.category)
+
+    // Override set: it wins for `interfaceStyle` alone, and the snapshot still
+    // supplies the other three.
+    deviceHelper.interfaceStyleOverride = .dark
+    let overridden = await deviceHelper.getTemplateDevice()
+    #expect(overridden["interfaceStyle"] as? String == "Dark")
+    #expect(overridden["interfaceStyleMode"] as? String == "manual")
+    #expect(overridden["fontSize"] as? Int == expected.fontSize)
+    #expect(overridden["fontScale"] as? Double == Double(expected.fontScale))
+    #expect(overridden["preferredContentSizeCategory"] as? String == expected.category)
+
+    deviceHelper.interfaceStyleOverride = nil
+  }
 }

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -80,4 +80,53 @@ struct DeviceHelperTests {
     #expect(DeviceHelper.contentSizeCategoryToken(for: .unspecified) == "unspecified")
     #expect(DeviceHelper.contentSizeCategoryToken(for: UIContentSizeCategory(rawValue: "someUnknownValue")) == "unspecified")
   }
+
+  // These tokens are a backend/audience-filter contract and must not change.
+  @Test func interfaceStyleToken_mapsEveryStyle() {
+    #expect(DeviceHelper.interfaceStyleToken(for: .unspecified) == "Unspecified")
+    #expect(DeviceHelper.interfaceStyleToken(for: .light) == "Light")
+    #expect(DeviceHelper.interfaceStyleToken(for: .dark) == "Dark")
+    #expect(DeviceHelper.interfaceStyleToken(for: UIUserInterfaceStyle(rawValue: 99)!) == "Unknown")
+  }
+
+  /// Reading these used to touch main-thread-only UIKit APIs, tripping
+  /// "UIApplication.preferredContentSizeCategory must be used from main thread only"
+  /// when the device template was built on a background thread.
+  @Test func traits_areReadableOffTheMainThread() async {
+    let dependencyContainer = DependencyContainer()
+    let deviceHelper: DeviceHelper = dependencyContainer.deviceHelper
+
+    let traits = await Task.detached { () -> (isMainThread: Bool, interfaceStyle: String, fontSize: Int, fontScale: Double, contentSizeCategory: String) in
+      return (
+        Thread.isMainThread,
+        deviceHelper.interfaceStyle,
+        deviceHelper.fontSize,
+        deviceHelper.fontScale,
+        deviceHelper.preferredContentSizeCategory
+      )
+    }.value
+
+    #expect(traits.isMainThread == false)
+    #expect(traits.interfaceStyle.isEmpty == false)
+    #expect(traits.fontSize > 0)
+    #expect(traits.fontScale > 0)
+    #expect(traits.contentSizeCategory.isEmpty == false)
+  }
+
+  /// The cached traits must hold the device's real values, not placeholders.
+  @MainActor
+  @Test func traits_matchTheCurrentTraitValues() {
+    let dependencyContainer = DependencyContainer()
+    let deviceHelper: DeviceHelper = dependencyContainer.deviceHelper
+    let category = UIApplication.sharedApplication?.preferredContentSizeCategory
+      ?? UIScreen.main.traitCollection.preferredContentSizeCategory
+
+    #expect(deviceHelper.preferredContentSizeCategory == DeviceHelper.contentSizeCategoryToken(for: category))
+    #expect(deviceHelper.interfaceStyle == DeviceHelper.interfaceStyleToken(for: UIScreen.main.traitCollection.userInterfaceStyle))
+    let scaledValue = Double(UIFontMetrics.default.scaledValue(for: 16.0))
+    let expectedScale: Double = ((scaledValue / 16.0) * 100).rounded() / 100
+
+    #expect(deviceHelper.fontSize == Int(scaledValue.rounded()))
+    #expect(deviceHelper.fontScale == expectedScale)
+  }
 }

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -201,6 +201,10 @@ struct DeviceHelperTests {
     // No override: every field mirrors the device.
     let template = await deviceHelper.getTemplateDevice()
     #expect(template["interfaceStyle"] as? String == expected.style)
+    // The template resolves the override by hand instead of going through
+    // `interfaceStyle`, which is what `X-Device-Interface-Style` uses. Pin that the
+    // two agree so the duplicated precedence rule can't drift silently.
+    #expect(template["interfaceStyle"] as? String == deviceHelper.interfaceStyle)
     #expect(template["fontSize"] as? Int == expected.fontSize)
     // Cast both sides to `Double`: comparing against the `[String: Any]` value
     // directly can resolve to SwiftyJSON's `NSNumber ==`.
@@ -212,6 +216,7 @@ struct DeviceHelperTests {
     deviceHelper.interfaceStyleOverride = .dark
     let overridden = await deviceHelper.getTemplateDevice()
     #expect(overridden["interfaceStyle"] as? String == "Dark")
+    #expect(overridden["interfaceStyle"] as? String == deviceHelper.interfaceStyle)
     #expect(overridden["interfaceStyleMode"] as? String == "manual")
     #expect(overridden["fontSize"] as? Int == expected.fontSize)
     #expect(overridden["fontScale"] as? Double == Double(expected.fontScale))

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -129,4 +129,34 @@ struct DeviceHelperTests {
     #expect(deviceHelper.fontSize == Int(scaledValue.rounded()))
     #expect(deviceHelper.fontScale == expectedScale)
   }
+
+  /// A read schedules a main-thread refresh, so an appearance change landing while
+  /// the app stays active can't leave the cache reporting a stale token. The refresh
+  /// must survive repeated reads rather than blanking the cache.
+  @Test func traits_stayCorrectAfterRepeatedReadsTriggerRefreshes() async throws {
+    let dependencyContainer = DependencyContainer()
+    let deviceHelper: DeviceHelper = dependencyContainer.deviceHelper
+
+    for _ in 0..<5 {
+      _ = await Task.detached {
+        (deviceHelper.interfaceStyle, deviceHelper.fontSize, deviceHelper.preferredContentSizeCategory)
+      }.value
+      // Let the scheduled refresh land before reading again.
+      try await Task.sleep(nanoseconds: 50_000_000)
+    }
+
+    let expected = await MainActor.run { () -> (String, Int, String) in
+      let category = UIApplication.sharedApplication?.preferredContentSizeCategory
+        ?? UIScreen.main.traitCollection.preferredContentSizeCategory
+      return (
+        DeviceHelper.interfaceStyleToken(for: UIScreen.main.traitCollection.userInterfaceStyle),
+        Int(UIFontMetrics.default.scaledValue(for: 16.0).rounded()),
+        DeviceHelper.contentSizeCategoryToken(for: category)
+      )
+    }
+
+    #expect(deviceHelper.interfaceStyle == expected.0)
+    #expect(deviceHelper.fontSize == expected.1)
+    #expect(deviceHelper.preferredContentSizeCategory == expected.2)
+  }
 }

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -144,10 +144,12 @@ struct DeviceHelperTests {
     #expect(deviceHelper.fontScale == expectedScale)
   }
 
-  /// A read schedules a main-thread refresh, so an appearance change landing while
-  /// the app stays active can't leave the cache reporting a stale token. The refresh
-  /// must survive repeated reads rather than blanking the cache.
-  @Test func traits_stayCorrectAfterRepeatedReadsTriggerRefreshes() async throws {
+  /// Every read schedules a main-thread write to the cache, so a fault in the
+  /// refresh-on-read backstop would leave the cache blanked or stale rather than
+  /// holding the device's real values. Nothing here can change the device's traits,
+  /// so this pins that the writes keep the cache correct, not that a flip is picked
+  /// up — no in-process way exists to move `UIScreen.main`'s trait collection.
+  @Test func traits_stayCorrectAfterRepeatedReadsTriggerRefreshes() async {
     let dependencyContainer = DependencyContainer()
     let deviceHelper: DeviceHelper = dependencyContainer.deviceHelper
 
@@ -155,8 +157,9 @@ struct DeviceHelperTests {
       _ = await Task.detached {
         (deviceHelper.interfaceStyle, deviceHelper.fontSize, deviceHelper.preferredContentSizeCategory)
       }.value
-      // Let the scheduled refresh land before reading again.
-      try await Task.sleep(nanoseconds: 50_000_000)
+      // The refresh is enqueued on the main queue before this hop, so hopping to the
+      // main actor drains it deterministically instead of sleeping on it.
+      await MainActor.run {}
     }
 
     let expected = await MainActor.run { () -> (String, Int, String) in


### PR DESCRIPTION
## Changes in this pull request

- `interfaceStyle`, `fontSize`, `fontScale` and `preferredContentSizeCategory` read `UIScreen.traitCollection`, `UIFontMetrics` and `UIApplication.preferredContentSizeCategory` directly. Those APIs are main-thread only, but the getters are called from background contexts such as `getTemplateDevice()`, which trips the Main Thread Checker.
- Reads the four values once on the main thread into a cached `UITraits`, refreshed on `UIContentSizeCategory.didChangeNotification` and `UIApplication.didBecomeActiveNotification` so they still track the user changing their text size or appearance. Observers are removed in `deinit`.
- Extracts `interfaceStyleToken(for:)` next to the existing `contentSizeCategoryToken(for:)`, so both dashboard token mappings are directly testable — these strings are a backend audience-filter contract and must not drift.
- Adds three tests: exhaustive `interfaceStyleToken` mapping, reading all four traits off the main thread, and asserting the cache holds the device's real values rather than the visionOS placeholders.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

Unchecked boxes are not verified rather than not applicable — only the unit tests (896 passing on iPhone 17 Pro / iOS 26.5), the added tests, the changelog entry and swiftlint were actually run. The demo projects and UI tests weren't exercised. No public API changed, so no doc updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves UIKit trait reads onto the main thread and caches the resulting device metadata.
- Refreshes the cache for content-size, activation, and iOS 17 trait changes.
- Adds active-scene selection and lifecycle cleanup for observers.
- Extracts interface-style token mapping and adds background-read, cache, and override tests.
- Documents the Main Thread Checker fix in the changelog.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because appearance tracking can remain attached to an inactive scene, while the previously reported window-override path also remains unresolved.

DeviceHelper treats any still-existing observed scene as current, so activation cannot move trait registration to a newly active scene and later appearance changes there leave backend-facing traits stale. The earlier window-override issue also remains because the implementation intentionally observes a scene even though window overrides do not propagate to it.

**Files Needing Attention:** Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift; Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift | Adds synchronized UIKit trait caching and refresh registration, but the registration can remain bound to an old scene and window-level appearance changes remain unobserved. |
| Sources/SuperwallKit/Misc/Extensions/UIApplication+ActiveWindow.swift | Adds foreground-prioritized UIWindowScene selection used by trait registration. |
| Tests/SuperwallKitTests/Network/DeviceHelperTests.swift | Adds coverage for token mapping, off-main-thread access, cached values, repeated refreshes, and interface-style overrides. |
| CHANGELOG.md | Documents the Main Thread Checker warning fix. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift:309-311
**Registration stays on old scene**

When a multi-window host keeps the original `UIWindowScene` alive while another scene becomes foreground-active, this guard treats the old registration as current. Appearance changes in the new active scene then leave `uiTraits` stale, causing device attributes and request headers to report the previous Light or Dark token and select the wrong audience behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["test(device): name the template trait te..."](https://github.com/superwall/superwall-ios/commit/ba1f45e6468580b6d8485902931122dcb2cc9eef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48676272)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Networking Layer](https://app.greptile.com/superwall/-/custom-context/knowledge-base/superwall/superwall-ios/-/docs/networking-layer.md)

<!-- /greptile_comment -->