### PR TITLE
fix: accent color resetting to system blue when configuring from a SwiftUI App init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,9 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Fixes failed network requests being reported as a decoding error rather than the HTTP error that actually occurred.
 - Fixes issue where the paywall debugger wouldn't work for accounts with many paywalls.
 - Fixes Main Thread Checker warnings caused by reading the device's interface style and text size from a background thread.
-<<<<<<< Updated upstream
 - Prevents unused App Tracking Transparency support from triggering App Store Connect tracking warnings.
 - Stops Apple's microphone, location, and contacts class and selector names appearing in your app's binary when you don't use those permissions.
-=======
 - Fixes the app's accent color resetting to the system blue when configuring the SDK from a SwiftUI `App` initializer.
->>>>>>> Stashed changes
 
 ## 4.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Fixes failed network requests being reported as a decoding error rather than the HTTP error that actually occurred.
 - Fixes issue where the paywall debugger wouldn't work for accounts with many paywalls.
 - Fixes Main Thread Checker warnings caused by reading the device's interface style and text size from a background thread.
+<<<<<<< Updated upstream
 - Prevents unused App Tracking Transparency support from triggering App Store Connect tracking warnings.
 - Stops Apple's microphone, location, and contacts class and selector names appearing in your app's binary when you don't use those permissions.
+=======
+- Fixes the app's accent color resetting to the system blue when configuring the SDK from a SwiftUI `App` initializer.
+>>>>>>> Stashed changes
 
 ## 4.16.1
 

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -177,8 +177,12 @@ class DeviceHelper {
   /// application object — e.g. `configure` called from a SwiftUI `App.init` —
   /// makes UIKit build its trait system before the app's asset-catalog accent
   /// color is registered, permanently resetting the global tint to system blue.
-  /// Every UIKit read in this file must sit behind this check, and the check must
-  /// come first: even `UIFontMetrics.default.scaledValue(for:)` alone trips it.
+  /// Every appearance-adjacent read in this file — `UIScreen`, `UIFontMetrics`,
+  /// trait collections — must sit behind this check, and the check must come
+  /// first: even `UIFontMetrics.default.scaledValue(for:)` alone trips it. The
+  /// unguarded `UIDevice` reads at init (`model`, `vendorId`, `interfaceType`)
+  /// are exempt: they don't touch the trait system, and the sample-app repro
+  /// keeps its tint with them in place.
   ///
   /// A missing application object doesn't always mean that window, though: some
   /// processes never create one (unit-test runners, app extensions) yet can read

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -294,7 +294,7 @@ class DeviceHelper {
   /// contexts such as `getTemplateDevice()`. They're read on the main thread and
   /// cached, then refreshed on trait-change notifications and on read.
   ///
-  /// `nil` until a read is allowed to touch UIKit (see ``isUIKitReadSafe``),
+  /// `nil` while a read isn't yet allowed to touch UIKit (see ``isUIKitReadSafe``),
   /// which only happens when the SDK is configured before `UIApplicationMain` runs.
   @DispatchQueueBacked
   private var uiTraits: UITraits?

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -122,27 +122,91 @@ class DeviceHelper {
     TimeZone.current.secondsFromGMT()
   }
 
-  /// Screen metrics, cached once at init on the main thread.
+  /// Screen metrics, cached from the main thread.
   ///
   /// `UIScreen` / `UIWindowScene` are main-thread-only (and `UIScreen.main`
   /// is deprecated), but these are read from background contexts such as
-  /// `matchMMPInstall`. Reading once up front, on the main thread, keeps those
+  /// `matchMMPInstall`. Reading on the main thread and caching keeps those
   /// reads safe instead of touching main-thread-only UIKit off-thread.
-  let screenWidth: Int
-  let screenHeight: Int
-  let devicePixelRatio: Double
+  ///
+  /// `nil` until a read is allowed to touch UIKit (see ``isUIKitReadSafe``).
+  /// When the SDK is configured before `UIApplicationMain` runs, the init-time
+  /// read stays empty and the cache fills on first post-launch read or on app
+  /// activation instead.
+  @DispatchQueueBacked
+  private var screenMetrics: ScreenMetrics?
 
-  private struct ScreenMetrics {
+  var screenWidth: Int {
+    currentScreenMetrics.width
+  }
+
+  var screenHeight: Int {
+    currentScreenMetrics.height
+  }
+
+  var devicePixelRatio: Double {
+    currentScreenMetrics.scale
+  }
+
+  struct ScreenMetrics {
     let width: Int
     let height: Int
     let scale: Double
+
+    /// The values used when the screen can't be read: before the application
+    /// exists, and on visionOS where there is no screen.
+    static let placeholder = ScreenMetrics(width: 0, height: 0, scale: 1.0)
   }
 
-  private static func makeScreenMetrics() -> ScreenMetrics {
+  /// The cached metrics, filling the cache first when it's still empty.
+  private var currentScreenMetrics: ScreenMetrics {
+    if let cached = screenMetrics {
+      return cached
+    }
+    guard let metrics = Self.makeScreenMetrics() else {
+      return .placeholder
+    }
+    screenMetrics = metrics
+    return metrics
+  }
+
+  /// Whether UIKit's screen and trait APIs can be read without side effects.
+  ///
+  /// In an app, touching `UIScreen`, `UIFontMetrics`, or any other
+  /// appearance-adjacent UIKit API before `UIApplicationMain` has created the
+  /// application object — e.g. `configure` called from a SwiftUI `App.init` —
+  /// makes UIKit build its trait system before the app's asset-catalog accent
+  /// color is registered, permanently resetting the global tint to system blue.
+  /// Every UIKit read in this file must sit behind this check, and the check must
+  /// come first: even `UIFontMetrics.default.scaledValue(for:)` alone trips it.
+  ///
+  /// A missing application object doesn't always mean that window, though: some
+  /// processes never create one (unit-test runners, app extensions) yet can read
+  /// `UIScreen.main` freely, and waiting there would leave placeholder values
+  /// forever. Only app bundles run `UIApplicationMain`, so the bundle type
+  /// disambiguates.
+  static var isUIKitReadSafe: Bool {
+    if UIApplication.sharedApplication != nil {
+      return true
+    }
+    return Bundle.main.bundleURL.pathExtension != "app"
+  }
+
+  /// Reads the screen metrics, or `nil` when UIKit can't be touched yet.
+  ///
+  /// `isUIKitReadSafe` is injectable because tests can't recreate the
+  /// pre-`UIApplicationMain` state in-process; it runs inside the main-thread
+  /// closure so the KVC read never happens off-thread.
+  static func makeScreenMetrics(
+    isUIKitReadSafe: @escaping () -> Bool = { DeviceHelper.isUIKitReadSafe }
+  ) -> ScreenMetrics? {
     #if os(visionOS)
-    return ScreenMetrics(width: 0, height: 0, scale: 1.0)
+    return .placeholder
     #else
-    let read = { () -> ScreenMetrics in
+    let read = { () -> ScreenMetrics? in
+      guard isUIKitReadSafe() else {
+        return nil
+      }
       // Prefer the connected window scene's screen; fall back to the
       // deprecated `UIScreen.main` only when no scene is attached yet.
       let screen = UIApplication.sharedApplication?
@@ -219,8 +283,11 @@ class DeviceHelper {
   /// `UIFontMetrics` are main-thread-only, but these are read from background
   /// contexts such as `getTemplateDevice()`. They're read on the main thread and
   /// cached, then refreshed on trait-change notifications and on read.
+  ///
+  /// `nil` until a read is allowed to touch UIKit (see ``isUIKitReadSafe``),
+  /// which only happens when the SDK is configured before `UIApplicationMain` runs.
   @DispatchQueueBacked
-  private var uiTraits: UITraits
+  private var uiTraits: UITraits?
 
   /// Set while a refresh of ``uiTraits`` is already scheduled, so a burst of reads
   /// queues one main-thread hop rather than one per read.
@@ -255,10 +322,10 @@ class DeviceHelper {
   /// the gap between launch and registration.
   private var currentUITraits: UITraits {
     guard #available(iOS 17.0, *) else {
-      return DeviceHelper.makeUITraits()
+      return DeviceHelper.makeUITraits() ?? .unavailable
     }
     refreshUITraits()
-    return uiTraits
+    return uiTraits ?? .unavailable
   }
 
   private func refreshUITraits() {
@@ -266,14 +333,28 @@ class DeviceHelper {
     // The wrapper's setter and getter share one serial queue, so this write is
     // ordered ahead of `currentUITraits`' read and the caller sees it.
     if Thread.isMainThread {
-      uiTraits = DeviceHelper.makeUITraits()
+      if let traits = DeviceHelper.makeUITraits() {
+        uiTraits = traits
+      }
+      return
+    }
+    // An empty cache means init ran before `UIApplicationMain` created the
+    // application. Block on the first real read — `makeUITraits()` makes the
+    // main-thread hop itself — rather than scheduling it, so early off-main
+    // readers don't report placeholder values.
+    if uiTraits == nil {
+      if let traits = DeviceHelper.makeUITraits() {
+        uiTraits = traits
+      }
       return
     }
     if $isRefreshingUITraits.testAndSetTrue() {
       return
     }
     DispatchQueue.main.async { [weak self] in
-      self?.uiTraits = DeviceHelper.makeUITraits()
+      if let traits = DeviceHelper.makeUITraits() {
+        self?.uiTraits = traits
+      }
       self?.isRefreshingUITraits = false
     }
     #endif
@@ -324,12 +405,14 @@ class DeviceHelper {
     traitChangeRegistration = scene.registerForTraitChanges(
       [UITraitUserInterfaceStyle.self, UITraitPreferredContentSizeCategory.self]
     ) { [weak self] (_: UITraitEnvironment, _: UITraitCollection) in
-      self?.uiTraits = DeviceHelper.makeUITraits()
+      if let traits = DeviceHelper.makeUITraits() {
+        self?.uiTraits = traits
+      }
     }
   }
   #endif
 
-  private struct UITraits {
+  struct UITraits {
     let interfaceStyle: String
     let fontSize: Int
     let fontScale: Double
@@ -344,11 +427,21 @@ class DeviceHelper {
     )
   }
 
-  private static func makeUITraits() -> UITraits {
+  /// Reads the current traits, or `nil` when UIKit can't be touched yet.
+  ///
+  /// `isUIKitReadSafe` is injectable because tests can't recreate the
+  /// pre-`UIApplicationMain` state in-process; it runs inside the main-thread
+  /// closure so the KVC read never happens off-thread.
+  static func makeUITraits(
+    isUIKitReadSafe: @escaping () -> Bool = { DeviceHelper.isUIKitReadSafe }
+  ) -> UITraits? {
     #if os(visionOS)
     return .unavailable
     #else
-    let read = { () -> UITraits in
+    let read = { () -> UITraits? in
+      guard isUIKitReadSafe() else {
+        return nil
+      }
       let category = UIApplication.sharedApplication?.preferredContentSizeCategory
         ?? UIScreen.main.traitCollection.preferredContentSizeCategory
       let scaledValue = UIFontMetrics.default.scaledValue(for: 16.0)
@@ -371,7 +464,8 @@ class DeviceHelper {
   /// the main thread.
   ///
   /// Activation also retries ``registerForTraitChanges()``, since a window is more
-  /// likely to exist by then than when `DeviceHelper` was created.
+  /// likely to exist by then than when `DeviceHelper` was created, and fills the
+  /// screen-metrics cache when init ran too early to read the screen.
   private func observeUITraitChanges() {
     #if !os(visionOS)
     let names: [Notification.Name] = [
@@ -384,8 +478,17 @@ class DeviceHelper {
         object: nil,
         queue: .main
       ) { [weak self] _ in
-        self?.uiTraits = DeviceHelper.makeUITraits()
-        self?.registerForTraitChanges()
+        guard let self = self else {
+          return
+        }
+        if let traits = DeviceHelper.makeUITraits() {
+          self.uiTraits = traits
+        }
+        if self.screenMetrics == nil,
+          let metrics = DeviceHelper.makeScreenMetrics() {
+          self.screenMetrics = metrics
+        }
+        self.registerForTraitChanges()
       }
     }
     #endif
@@ -764,11 +867,9 @@ class DeviceHelper {
     self.sdkVersionPadded = Self.makePaddedVersion(using: sdkVersion)
     self.appVersionPadded = Self.makePaddedVersion(using: appVersion)
 
-    let screenMetrics = Self.makeScreenMetrics()
-    self.screenWidth = screenMetrics.width
-    self.screenHeight = screenMetrics.height
-    self.devicePixelRatio = screenMetrics.scale
-
+    // Both are `nil` when `configure` runs before `UIApplicationMain` — they
+    // fill on first post-launch read or on app activation.
+    self.screenMetrics = Self.makeScreenMetrics()
     self.uiTraits = Self.makeUITraits()
     observeUITraitChanges()
     registerForTraitChanges()

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -163,7 +163,7 @@ class DeviceHelper {
     if let cached = screenMetrics {
       return cached
     }
-    guard let metrics = Self.makeScreenMetrics() else {
+    guard let metrics = Self.makeScreenMetrics(isUIKitReadSafe: isUIKitReadSafe) else {
       return .placeholder
     }
     screenMetrics = metrics
@@ -195,6 +195,12 @@ class DeviceHelper {
     }
     return Bundle.main.bundleURL.pathExtension != "app"
   }
+
+  /// The instance's view of ``isUIKitReadSafe``, injected at init. Every
+  /// instance-level cache read and refresh consults this rather than the static,
+  /// so tests can hold a real instance in the pre-launch state and then release
+  /// it — the static's state can't be recreated in-process.
+  private let isUIKitReadSafe: () -> Bool
 
   /// Reads the screen metrics, or `nil` when UIKit can't be touched yet.
   ///
@@ -326,7 +332,7 @@ class DeviceHelper {
   /// the gap between launch and registration.
   private var currentUITraits: UITraits {
     guard #available(iOS 17.0, *) else {
-      return DeviceHelper.makeUITraits() ?? .unavailable
+      return DeviceHelper.makeUITraits(isUIKitReadSafe: isUIKitReadSafe) ?? .unavailable
     }
     refreshUITraits()
     return uiTraits ?? .unavailable
@@ -337,7 +343,7 @@ class DeviceHelper {
     // The wrapper's setter and getter share one serial queue, so this write is
     // ordered ahead of `currentUITraits`' read and the caller sees it.
     if Thread.isMainThread {
-      if let traits = DeviceHelper.makeUITraits() {
+      if let traits = DeviceHelper.makeUITraits(isUIKitReadSafe: isUIKitReadSafe) {
         uiTraits = traits
       }
       return
@@ -347,7 +353,7 @@ class DeviceHelper {
     // main-thread hop itself — rather than scheduling it, so early off-main
     // readers don't report placeholder values.
     if uiTraits == nil {
-      if let traits = DeviceHelper.makeUITraits() {
+      if let traits = DeviceHelper.makeUITraits(isUIKitReadSafe: isUIKitReadSafe) {
         uiTraits = traits
       }
       return
@@ -356,10 +362,13 @@ class DeviceHelper {
       return
     }
     DispatchQueue.main.async { [weak self] in
-      if let traits = DeviceHelper.makeUITraits() {
-        self?.uiTraits = traits
+      guard let self = self else {
+        return
       }
-      self?.isRefreshingUITraits = false
+      if let traits = DeviceHelper.makeUITraits(isUIKitReadSafe: self.isUIKitReadSafe) {
+        self.uiTraits = traits
+      }
+      self.isRefreshingUITraits = false
     }
     #endif
   }
@@ -409,8 +418,11 @@ class DeviceHelper {
     traitChangeRegistration = scene.registerForTraitChanges(
       [UITraitUserInterfaceStyle.self, UITraitPreferredContentSizeCategory.self]
     ) { [weak self] (_: UITraitEnvironment, _: UITraitCollection) in
-      if let traits = DeviceHelper.makeUITraits() {
-        self?.uiTraits = traits
+      guard let self = self else {
+        return
+      }
+      if let traits = DeviceHelper.makeUITraits(isUIKitReadSafe: self.isUIKitReadSafe) {
+        self.uiTraits = traits
       }
     }
   }
@@ -485,11 +497,11 @@ class DeviceHelper {
         guard let self = self else {
           return
         }
-        if let traits = DeviceHelper.makeUITraits() {
+        if let traits = DeviceHelper.makeUITraits(isUIKitReadSafe: self.isUIKitReadSafe) {
           self.uiTraits = traits
         }
         if self.screenMetrics == nil,
-          let metrics = DeviceHelper.makeScreenMetrics() {
+          let metrics = DeviceHelper.makeScreenMetrics(isUIKitReadSafe: self.isUIKitReadSafe) {
           self.screenMetrics = metrics
         }
         self.registerForTraitChanges()
@@ -859,7 +871,8 @@ class DeviceHelper {
     network: Network,
     entitlementsInfo: EntitlementsInfo,
     receiptManager: ReceiptManager,
-    factory: IdentityFactory & LocaleIdentifierFactory & WebEntitlementFactory
+    factory: IdentityFactory & LocaleIdentifierFactory & WebEntitlementFactory,
+    isUIKitReadSafe: @escaping () -> Bool = { DeviceHelper.isUIKitReadSafe }
   ) {
     self.storage = storage
     self.network = network
@@ -870,11 +883,12 @@ class DeviceHelper {
       reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, api.base.host)
     self.sdkVersionPadded = Self.makePaddedVersion(using: sdkVersion)
     self.appVersionPadded = Self.makePaddedVersion(using: appVersion)
+    self.isUIKitReadSafe = isUIKitReadSafe
 
     // Both are `nil` when `configure` runs before `UIApplicationMain` — they
     // fill on first post-launch read or on app activation.
-    self.screenMetrics = Self.makeScreenMetrics()
-    self.uiTraits = Self.makeUITraits()
+    self.screenMetrics = Self.makeScreenMetrics(isUIKitReadSafe: isUIKitReadSafe)
+    self.uiTraits = Self.makeUITraits(isUIKitReadSafe: isUIKitReadSafe)
     observeUITraitChanges()
     registerForTraitChanges()
   }

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -291,4 +291,130 @@ struct DeviceHelperTests {
     #expect(read.height == expected.height)
     #expect(read.scale == expected.scale)
   }
+
+  // MARK: - Instance-level self-healing
+
+  /// Flippable gate for the tests below, standing in for "the application doesn't
+  /// exist yet" / "launch has completed".
+  private final class Gate: @unchecked Sendable {
+    var isOpen: Bool
+    init(_ isOpen: Bool) {
+      self.isOpen = isOpen
+    }
+  }
+
+  /// Builds a `DeviceHelper` with an injected gate. The container is returned
+  /// alongside because the helper only holds its factory `unowned`.
+  private func makeDeviceHelper(
+    gate: Gate
+  ) -> (DeviceHelper, DependencyContainer) {
+    let dependencyContainer = DependencyContainer()
+    let deviceHelper = DeviceHelper(
+      api: dependencyContainer.api,
+      storage: dependencyContainer.storage,
+      network: dependencyContainer.network,
+      entitlementsInfo: dependencyContainer.entitlementsInfo,
+      receiptManager: dependencyContainer.receiptManager,
+      factory: dependencyContainer,
+      isUIKitReadSafe: { gate.isOpen }
+    )
+    return (deviceHelper, dependencyContainer)
+  }
+
+  private func expectedLiveValues() async -> (
+    width: Int, height: Int, scale: Double, style: String, category: String
+  ) {
+    await MainActor.run {
+      let screen = UIApplication.sharedApplication?
+        .connectedScenes
+        .compactMap { $0 as? UIWindowScene }
+        .first?
+        .screen ?? UIScreen.main
+      let category = UIApplication.sharedApplication?.preferredContentSizeCategory
+        ?? UIScreen.main.traitCollection.preferredContentSizeCategory
+      return (
+        Int(screen.bounds.width.rounded()),
+        Int(screen.bounds.height.rounded()),
+        Double(screen.scale),
+        DeviceHelper.interfaceStyleToken(for: UIScreen.main.traitCollection.userInterfaceStyle),
+        DeviceHelper.contentSizeCategoryToken(for: category)
+      )
+    }
+  }
+
+  /// While reads are disallowed, an instance must serve placeholders rather than
+  /// touch UIKit — the pre-launch state a `configure` in a SwiftUI `App.init`
+  /// puts the SDK in.
+  @Test func instance_whileReadsAreDisallowed_servesPlaceholders() {
+    let gate = Gate(false)
+    let (deviceHelper, dependencyContainer) = makeDeviceHelper(gate: gate)
+    _ = dependencyContainer
+
+    #expect(deviceHelper.screenWidth == 0)
+    #expect(deviceHelper.screenHeight == 0)
+    #expect(deviceHelper.devicePixelRatio == 1.0)
+    #expect(deviceHelper.interfaceStyle == "Unknown")
+    #expect(deviceHelper.fontSize == 16)
+    #expect(deviceHelper.preferredContentSizeCategory == "unspecified")
+  }
+
+  /// Once the gate opens, the next read must fill both caches with the device's
+  /// live values — not keep serving `.placeholder`/`.unavailable`. The traits are
+  /// read from off the main thread so the read exercises the blocking
+  /// empty-cache branch in `refreshUITraits()`, the path `getTemplateDevice()`
+  /// and the MMP match take after a too-early init.
+  @Test func instance_healsOnFirstAllowedRead() async {
+    let gate = Gate(false)
+    let (deviceHelper, dependencyContainer) = makeDeviceHelper(gate: gate)
+    _ = dependencyContainer
+    #expect(deviceHelper.screenWidth == 0)
+    #expect(deviceHelper.interfaceStyle == "Unknown")
+
+    gate.isOpen = true
+    let expected = await expectedLiveValues()
+
+    let read = await Task.detached { () -> (width: Int, height: Int, scale: Double, style: String, category: String) in
+      return (
+        deviceHelper.screenWidth,
+        deviceHelper.screenHeight,
+        deviceHelper.devicePixelRatio,
+        deviceHelper.interfaceStyle,
+        deviceHelper.preferredContentSizeCategory
+      )
+    }.value
+
+    #expect(read.width == expected.width)
+    #expect(read.height == expected.height)
+    #expect(read.scale == expected.scale)
+    #expect(read.style == expected.style)
+    #expect(read.category == expected.category)
+  }
+
+  /// The notification observer must fill both caches after a too-early init.
+  /// Posted as `UIContentSizeCategory.didChangeNotification`, which shares the
+  /// handler with `didBecomeActiveNotification` but doesn't wake the app-session
+  /// machinery of the containers other tests hold. Closing the gate again before
+  /// reading proves the values came from the notification's fill, not from the
+  /// read itself.
+  @MainActor
+  @Test func instance_fillsCachesOnNotification() async {
+    let gate = Gate(false)
+    let (deviceHelper, dependencyContainer) = makeDeviceHelper(gate: gate)
+    _ = dependencyContainer
+    #expect(deviceHelper.screenWidth == 0)
+
+    gate.isOpen = true
+    NotificationCenter.default.post(
+      name: UIContentSizeCategory.didChangeNotification,
+      object: nil
+    )
+    gate.isOpen = false
+
+    let expected = await expectedLiveValues()
+    #expect(deviceHelper.screenWidth == expected.width)
+    #expect(deviceHelper.screenHeight == expected.height)
+    #expect(deviceHelper.devicePixelRatio == expected.scale)
+    #expect(deviceHelper.interfaceStyle == expected.style)
+    #expect(deviceHelper.preferredContentSizeCategory == expected.category)
+  }
 }

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -250,7 +250,7 @@ struct DeviceHelperTests {
     #expect(DeviceHelper.isUIKitReadSafe)
   }
 
-  @Test func makeScreenMetrics_whenTheApplicationExists_readsTheScreen() {
+  @Test func makeScreenMetrics_whenReadsAreAllowed_readsTheScreen() {
     let metrics = DeviceHelper.makeScreenMetrics()
     #expect((metrics?.width ?? 0) > 0)
     #expect((metrics?.height ?? 0) > 0)

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -410,6 +410,18 @@ struct DeviceHelperTests {
     )
     gate.isOpen = false
 
+    // The observer is scheduled onto `OperationQueue.main`, not run inline on
+    // the posting thread, so wait — bounded — for its fill to land instead of
+    // relying on undocumented interleaving. Polling with the gate closed can't
+    // fill the caches itself, so the values asserted below can only have come
+    // from the observer.
+    for _ in 0..<200 {
+      if deviceHelper.screenWidth != 0 && deviceHelper.interfaceStyle != "Unknown" {
+        break
+      }
+      try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+
     let expected = await expectedLiveValues()
     #expect(deviceHelper.screenWidth == expected.width)
     #expect(deviceHelper.screenHeight == expected.height)

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -183,8 +183,8 @@ struct DeviceHelperTests {
   /// come from the device.
   ///
   /// The snapshot itself isn't pinned here — nothing observable distinguishes one
-  /// read from four, since `makeUITraits()` is private and its hop count can't be
-  /// counted from a test. That property rests on the comments at both call sites.
+  /// read from four, since `makeUITraits()`'s hop count can't be counted from a
+  /// test. That property rests on the comments at both call sites.
   @Test func templateDevice_keepsTheInterfaceStyleOverrideAndFillsTheRestFromTheDevice() async {
     let dependencyContainer = DependencyContainer()
     let deviceHelper: DeviceHelper = dependencyContainer.deviceHelper
@@ -226,5 +226,69 @@ struct DeviceHelperTests {
     #expect(overridden["preferredContentSizeCategory"] as? String == expected.category)
 
     deviceHelper.interfaceStyleOverride = nil
+  }
+
+  /// `configure` from a SwiftUI `App.init` runs before `UIApplicationMain` has
+  /// created the application object. Touching `UIScreen` or `UIFontMetrics` at
+  /// that point makes UIKit build its trait system before the app's accent color
+  /// is registered, permanently resetting the global tint to system blue (#493).
+  /// Both readers must return nothing rather than touch UIKit; the flag is
+  /// injected because the pre-launch state can't be recreated in-process.
+  @Test func makeScreenMetrics_beforeTheApplicationExists_readsNothing() {
+    #expect(DeviceHelper.makeScreenMetrics(isUIKitReadSafe: { false }) == nil)
+  }
+
+  @Test func makeUITraits_beforeTheApplicationExists_readsNothing() {
+    #expect(DeviceHelper.makeUITraits(isUIKitReadSafe: { false }) == nil)
+  }
+
+  /// This test runner has no `UIApplication` and never launches one, like an app
+  /// extension. Deferring UIKit reads there would leave the device attributes as
+  /// placeholders forever, so the gate must allow reads despite the missing
+  /// application object.
+  @Test func isUIKitReadSafe_withoutAnApplicationOutsideAnAppBundle_allowsReads() {
+    #expect(DeviceHelper.isUIKitReadSafe)
+  }
+
+  @Test func makeScreenMetrics_whenTheApplicationExists_readsTheScreen() {
+    let metrics = DeviceHelper.makeScreenMetrics()
+    #expect((metrics?.width ?? 0) > 0)
+    #expect((metrics?.height ?? 0) > 0)
+    #expect((metrics?.scale ?? 0) >= 1.0)
+  }
+
+  /// The screen metrics moved from init-time `let`s to a cache so a too-early
+  /// init can heal itself, so pin that reads still match the screen and stay
+  /// safe off the main thread, where `matchMMPInstall` reads them.
+  @Test func screenMetrics_matchTheScreenWhenReadOffTheMainThread() async {
+    let dependencyContainer = DependencyContainer()
+    let deviceHelper: DeviceHelper = dependencyContainer.deviceHelper
+
+    let expected = await MainActor.run { () -> (width: Int, height: Int, scale: Double) in
+      let screen = UIApplication.sharedApplication?
+        .connectedScenes
+        .compactMap { $0 as? UIWindowScene }
+        .first?
+        .screen ?? UIScreen.main
+      return (
+        Int(screen.bounds.width.rounded()),
+        Int(screen.bounds.height.rounded()),
+        Double(screen.scale)
+      )
+    }
+
+    let read = await Task.detached { () -> (isMainThread: Bool, width: Int, height: Int, scale: Double) in
+      return (
+        Thread.isMainThread,
+        deviceHelper.screenWidth,
+        deviceHelper.screenHeight,
+        deviceHelper.devicePixelRatio
+      )
+    }.value
+
+    #expect(read.isMainThread == false)
+    #expect(read.width == expected.width)
+    #expect(read.height == expected.height)
+    #expect(read.scale == expected.scale)
   }
 }

--- a/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperTests.swift
@@ -408,19 +408,19 @@ struct DeviceHelperTests {
       name: UIContentSizeCategory.didChangeNotification,
       object: nil
     )
-    gate.isOpen = false
-
-    // The observer is scheduled onto `OperationQueue.main`, not run inline on
-    // the posting thread, so wait — bounded — for its fill to land instead of
-    // relying on undocumented interleaving. Polling with the gate closed can't
-    // fill the caches itself, so the values asserted below can only have come
-    // from the observer.
-    for _ in 0..<200 {
-      if deviceHelper.screenWidth != 0 && deviceHelper.interfaceStyle != "Unknown" {
-        break
+    // The observer's fill consults the gate when its block *runs*, not when it
+    // was enqueued, so the gate has to stay open until the fill has landed.
+    // `OperationQueue.main` runs one operation at a time in enqueue order, so
+    // an operation added after the post can't run before the observer's block
+    // — and if delivery was inline, the fill already happened. Nothing reads
+    // the helper while the gate is open, so the fill stays the only possible
+    // writer and closing the gate before the assertions keeps the proof.
+    await withCheckedContinuation { continuation in
+      OperationQueue.main.addOperation {
+        continuation.resume()
       }
-      try? await Task.sleep(nanoseconds: 10_000_000)
     }
+    gate.isOpen = false
 
     let expected = await expectedLiveValues()
     #expect(deviceHelper.screenWidth == expected.width)


### PR DESCRIPTION
Fixes #493

## The bug

Calling `Superwall.configure` from a SwiftUI `App.init` reset the host app's accent color to system blue (most visibly on `TabView`/tab bar selected items).

The cause is not the paywall presenting window suggested in the issue — the repro uses an invalid API key, so that code never runs. `App.init` executes *before* `UIApplicationMain` creates the application object, and touching `UIScreen.main` — or even just `UIFontMetrics.default.scaledValue(for:)` — in that window makes UIKit build its trait system before the app's asset-catalog accent color (`NSAccentColorName`) is registered. The global tint then permanently falls back to system blue. `DeviceHelper.init`, which runs synchronously under `configure`, did both reads. The same calls made from `application(_:didFinishLaunchingWithOptions:)` are harmless, which is why UIKit apps never saw this.

Each of these was verified in isolation in a sample app with Superwall removed: `_ = UIScreen.main` alone in `App.init` reproduces the blue tint; the full `configure` in the app delegate does not.

## The fix

`DeviceHelper` now refuses to touch UIKit until it's safe, via a single gate (`isUIKitReadSafe`):

- The screen metrics and UI trait readers return `nil` instead of touching UIKit when an app process hasn't created its application object yet. Screen metrics move from init-time `let`s to a self-healing cache using the same `@DispatchQueueBacked` pattern as the traits.
- The caches fill on the first post-launch read or on app activation. Off-main readers (the MMP install match, `getTemplateDevice()`, network headers) block on the main-queue hop, which can't drain until launch completes — so they always see real values, never placeholders.
- Processes that never create a `UIApplication` (host-less unit-test runners, app extensions) legitimately read `UIScreen.main`, so the gate also checks the bundle type: only `.app` bundles run `UIApplicationMain`. Without this, device attributes would report placeholders forever in those environments.

## Verification

- Sample app from the issue, built against this branch with `configure` in `App.init`: selected tab renders the accent color exactly (sampled (255, 0, 255) for a magenta asset), and `getDeviceAttributes()` reports the device's live trait values.
- New tests pin the pre-launch nil behavior, the launched-state reads, the off-main screen-metrics path, and the test-runner/extension allowance.
- Full suite: 903 tests in 93 suites pass on iOS 26.5.

## Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents pre-launch UIKit trait initialization from resetting a SwiftUI host app’s accent color.
- Defers screen and trait reads until UIKit is safe to access.
- Adds self-healing caches populated after launch or activation.
- Adds tests for pre-launch, post-launch, background-thread, and host-less process behavior.
- Records the fix in the changelog without the previously reported conflict markers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds a single release-note bullet, and the previously reported conflict markers are no longer present. |
| Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift | Gates appearance-adjacent UIKit reads and lazily fills cached screen metrics and traits after application launch. |
| Tests/SuperwallKitTests/Network/DeviceHelperTests.swift | Adds coverage for blocked pre-launch reads, cache recovery, lifecycle refresh, and off-main screen access. |

<sub>Reviews (2): Last reviewed commit: ["test(device): cover the instance-level s..."](https://github.com/superwall/superwall-ios/commit/f417e0c724c79f040f18eebb397be2af49a494eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52584415)</sub>

**Context used:**

- Knowledge Base — [Networking Layer](https://app.greptile.com/superwall/-/custom-context/knowledge-base/superwall/superwall-ios/-/docs/networking-layer.md)

<!-- /greptile_comment -->