### PR TITLE
Fix build error on Xcode 26.0 from ambiguous CGFloat arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.16.3
+
+### Fixes
+
+- Fixes a build error when compiling the SDK with Xcode 26.0.
+
 ## 4.16.2
 
 ### Enhancements

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.16.2
+4.16.3
 """

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -491,7 +491,7 @@ class DeviceHelper {
           for: UIScreen.main.traitCollection.userInterfaceStyle
         ),
         fontSize: Int(scaledValue.rounded()),
-        fontScale: ((scaledValue / 16.0) * 100).rounded() / 100,
+        fontScale: ((Double(scaledValue) / 16.0) * 100).rounded() / 100,
         preferredContentSizeCategory: contentSizeCategoryToken(for: category)
       )
     }

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.16.2"
+  s.version      = "4.16.3"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Summary

A user reported that SuperwallKit 4.16.2 fails to build on Xcode 26.0 with:

- `DeviceHelper.swift:494: ambiguous use of operator '*'`
- `DeviceHelper.swift:498: cannot convert return expression of type '()' to return type 'DeviceHelper.UITraits?'`

The `fontScale` expression mixed a `CGFloat` (`UIFontMetrics.scaledValue(for:)`) with `Double`/`Int` literals, relying on the implicit `CGFloat`↔`Double` conversion. Xcode 26.0's type-checker can't rank the candidate solutions and reports the `*` as ambiguous; later toolchains (26.6) resolve it, which is why it wasn't reproducible locally. The second error is a cascade of the first: with the closure body poisoned, `DispatchQueue.main.sync(execute:)` falls back to the `() -> Void` overload.

Converting once with `Double(scaledValue)` removes the implicit conversion entirely, leaving every toolchain exactly one solution. Behavior is identical.

Bumps the version to 4.16.3.

## Testing

Not testable by a unit test: the bug is a compile-time type-checker failure on an older toolchain, not a behavior change — the expression produces identical values before and after. Verified by building the framework and running the full test suite (919 tests, 0 failures) on Xcode 26.6 / iOS 26.5 simulator.

## Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an Xcode 26.0 compilation ambiguity by explicitly converting the scaled font value to `Double`.
- Preserves the existing `fontScale` calculation and serialized value.
- Bumps the SDK and CocoaPods versions to 4.16.3.
- Adds the corresponding 4.16.3 changelog entry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The explicit conversion matches the destination model’s `Double` type, remains lossless on supported targets, and the version is consistently updated across all required release files.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift | Makes font-scale arithmetic unambiguously `Double` without changing its value or serialization contract. |
| Sources/SuperwallKit/Misc/Constants.swift | Updates the runtime-reported SDK version from 4.16.2 to 4.16.3. |
| SuperwallKit.podspec | Keeps the CocoaPods package version synchronized at 4.16.3. |
| CHANGELOG.md | Documents the Xcode 26.0 build fix in the new 4.16.3 release entry. |

<sub>Reviews (1): Last reviewed commit: ["fix: build error on Xcode 26.0 from ambi..."](https://github.com/superwall/superwall-ios/commit/69144b874596b0b5386465020a1b976a107943d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54687065)</sub>

<!-- /greptile_comment -->