### PR TITLE
4.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.16.3
+
+### Fixes
+
+- Fixes a build error when compiling the SDK with Xcode 26.0.
+
 ## 4.16.2
 
 ### Enhancements

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.16.2
+4.16.3
 """

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -491,7 +491,7 @@ class DeviceHelper {
           for: UIScreen.main.traitCollection.userInterfaceStyle
         ),
         fontSize: Int(scaledValue.rounded()),
-        fontScale: ((scaledValue / 16.0) * 100).rounded() / 100,
+        fontScale: ((Double(scaledValue) / 16.0) * 100).rounded() / 100,
         preferredContentSizeCategory: contentSizeCategoryToken(for: category)
       )
     }

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.16.2"
+  s.version      = "4.16.3"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

Promotes `develop` → `master` for the **4.16.3** patch release.

### Fixes
- Fixes a build error when compiling the SDK with Xcode 26.0. The `fontScale` device-attribute expression relied on Swift's implicit `CGFloat`↔`Double` conversion, which Xcode 26.0's type-checker rejects as ambiguous (later toolchains resolve it). The arithmetic is now explicitly `Double`. (#507)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch release makes the `fontScale` calculation explicit about converting UIKit’s `CGFloat` value to `Double`, resolving an Xcode 26.0 type-checking ambiguity without changing the calculated device attribute.

- Bumps the SDK and CocoaPods versions to 4.16.3.
- Adds the corresponding 4.16.3 changelog entry.
- Preserves the existing two-decimal `fontScale` calculation and serialized `Double` contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the numeric conversion preserves runtime behavior while resolving the targeted compiler ambiguity, and all release versions are synchronized.

The changed calculation continues producing the same rounded `Double` device attribute on supported targets, and the changelog, runtime SDK version, and podspec all consistently identify release 4.16.3.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift | Explicitly converts the UIKit `CGFloat` result to `Double`, fixing compiler ambiguity while preserving the existing rounded font-scale value. |
| Sources/SuperwallKit/Misc/Constants.swift | Updates the runtime-reported SDK version to 4.16.3 in the canonical version location. |
| SuperwallKit.podspec | Updates CocoaPods release metadata to the matching 4.16.3 version. |
| CHANGELOG.md | Documents the Xcode 26.0 build fix under the new 4.16.3 release. |

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #507 from superwall/f..."](https://github.com/superwall/superwall-ios/commit/bcaee895e96373ebf3cf674cf9219de3fd5cea16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54733440)</sub>

**Context used:**

- Knowledge Base — [Networking Layer](https://app.greptile.com/superwall/-/custom-context/knowledge-base/superwall/superwall-ios/-/docs/networking-layer.md)
- Knowledge Base — [SDK Entrypoint and Lifecycle](https://app.greptile.com/superwall/-/custom-context/knowledge-base/superwall/superwall-ios/-/docs/sdk-entrypoint-and-lifecycle.md)

<!-- /greptile_comment -->