### PR TITLE
fix(events): dedupe subscription status changes by logical state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Fixes
 
+- Fixes duplicate device attribute and subscription status change events being tracked when the subscription status is repeatedly set to the same logical state.
 - Fixes subscribers with an unexpired subscription being reported as `inactive` on cold launch when the App Store has no purchases to report. Refunded and expired App Store subscriptions still deactivate immediately.
 - Fixes a data race during SDK configuration that Thread Sanitizer flagged on every launch.
 - Fixes issue where paying web users could end up having a temporary inactive subscription status if the server temporarily returns no entitlement data for them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Fixes
 
-- Fixes duplicate device attribute and subscription status change events being tracked when the subscription status is repeatedly set to the same logical state.
+- Fixes duplicate device attribute and subscription status change events being tracked when the subscription status is repeatedly set to the same logical state. As part of this, `subscriptionStatusDidChange` now fires only when the logical status changes — the status case, the set of entitlements, or an entitlement's `isActive` flag. Updates to transaction metadata such as expiry dates or renewal state no longer trigger it; use `customerInfoDidChange` for those.
 - Fixes subscribers with an unexpired subscription being reported as `inactive` on cold launch when the App Store has no purchases to report. Refunded and expired App Store subscriptions still deactivate immediately.
 - Fixes a data race during SDK configuration that Thread Sanitizer flagged on every launch.
 - Fixes issue where paying web users could end up having a temporary inactive subscription status if the server temporarily returns no entitlement data for them.

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
@@ -16,7 +16,14 @@ import Foundation
 /// To learn how to conform to the delegate in your app and best practices, see
 /// [our docs](https://docs.superwall.com/docs/3rd-party-analytics).
 public protocol SuperwallDelegate: AnyObject {
-  /// Called when the ``Superwall/subscriptionStatus`` changes.
+  /// Called when the logical state of ``Superwall/subscriptionStatus`` changes:
+  /// the status moves between unknown, inactive, and active, an entitlement is
+  /// gained or lost, or an entitlement's `isActive` flag changes.
+  ///
+  /// Updates that only change transaction metadata — such as expiry dates,
+  /// renewal state, or the store an entitlement came from — don't trigger this
+  /// callback. Use ``SuperwallDelegate/customerInfoDidChange(from:to:)`` to
+  /// react to those.
   ///
   /// You can use this function to update the state of your application. Alternatively, you can
   /// use the published property ``Superwall/subscriptionStatus`` to react to

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegateObjc.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegateObjc.swift
@@ -78,7 +78,14 @@ public protocol SuperwallDelegateObjc: AnyObject {
   @MainActor
   @objc optional func handleSuperwallEvent(withInfo eventInfo: SuperwallEventInfo)
 
-  /// Called when the ``Superwall/subscriptionStatusObjc`` changes.
+  /// Called when the logical state of ``Superwall/subscriptionStatusObjc`` changes:
+  /// the status moves between unknown, inactive, and active, an entitlement is
+  /// gained or lost, or an entitlement's `isActive` flag changes.
+  ///
+  /// Updates that only change transaction metadata — such as expiry dates,
+  /// renewal state, or the store an entitlement came from — don't trigger this
+  /// callback. Use ``SuperwallDelegateObjc/customerInfoDidChange(from:to:)`` to
+  /// react to those.
   ///
   /// You can use this function to update the state of your application.
   ///

--- a/Sources/SuperwallKit/StoreKit/Products/EntitlementsStatus.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/EntitlementsStatus.swift
@@ -54,6 +54,26 @@ public enum SubscriptionStatus: Equatable, Codable {
   }
 }
 
+// MARK: - Logical Equality
+extension SubscriptionStatus {
+  /// Whether both statuses represent the same logical subscription state.
+  ///
+  /// Two `.active` statuses are logically equal when their entitlements have the
+  /// same identities (`id`, `type`, and `isActive`), even if transaction metadata
+  /// like expiry dates or renewal state differs. `==` compares that metadata too,
+  /// so repeat writes of the same logical status can read as changes.
+  func isLogicallyEqual(to other: SubscriptionStatus) -> Bool {
+    switch (self, other) {
+    case (.unknown, .unknown), (.inactive, .inactive):
+      return true
+    case let (.active(lhsEntitlements), .active(rhsEntitlements)):
+      return Set(lhsEntitlements.map(\.identity)) == Set(rhsEntitlements.map(\.identity))
+    default:
+      return false
+    }
+  }
+}
+
 // MARK: - CustomStringConvertible
 extension SubscriptionStatus: CustomStringConvertible {
   public var description: String {

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift
@@ -255,7 +255,8 @@ public final class Entitlement: NSObject, Codable, Sendable {
     try container.encodeIfPresent(offerType, forKey: .offerType)
   }
 
-  // Override isEqual to define equality based on `id` and `type`
+  // Deep equality across all fields. For detecting logical status changes,
+  // use `identity` instead, which ignores transaction metadata.
   public override func isEqual(_ object: Any?) -> Bool {
     guard let other = object as? Entitlement else {
       return false
@@ -291,6 +292,26 @@ public final class Entitlement: NSObject, Codable, Sendable {
     hasher.combine(state)
     hasher.combine(offerType)
     return hasher.finalize()
+  }
+}
+
+// MARK: - Logical Identity
+extension Entitlement {
+  /// The fields that define which entitlement this is and whether it grants
+  /// access. Transaction metadata like dates, product IDs, and renewal state
+  /// can differ between writes of the same logical status, so it's excluded.
+  struct Identity: Hashable {
+    let id: String
+    let type: EntitlementType
+    let isActive: Bool
+  }
+
+  var identity: Identity {
+    return Identity(
+      id: id,
+      type: type,
+      isActive: isActive
+    )
   }
 }
 

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -219,6 +219,9 @@ public final class Superwall: NSObject, ObservableObject {
         subscriptionStatus = resolved
         return
       }
+      // Saved here rather than in the status listener so that metadata-only
+      // updates, which the listener dedupes, still refresh the cache.
+      dependencyContainer.storage.save(subscriptionStatus, forType: SubscriptionStatusKey.self)
       entitlements.subscriptionStatusDidSet(subscriptionStatus)
 
       // When using an external purchase controller, update CustomerInfo.entitlements
@@ -568,7 +571,7 @@ public final class Superwall: NSObject, ObservableObject {
 
   private func listenToSubscriptionStatus() {
     $subscriptionStatus
-      .removeDuplicates()
+      .removeDuplicates { $0.isLogicallyEqual(to: $1) }
       .dropFirst()
       .scan((previous: subscriptionStatus, current: subscriptionStatus)) { previousPair, newStatus in
         // Shift the current value to previous, and set the new status as the current value
@@ -584,8 +587,6 @@ public final class Superwall: NSObject, ObservableObject {
             }
             let oldStatus = statusPair.previous
             let newStatus = statusPair.current
-
-            self.dependencyContainer.storage.save(newStatus, forType: SubscriptionStatusKey.self)
 
             Task {
               await self.dependencyContainer.delegateAdapter.subscriptionStatusDidChange(

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -210,7 +210,7 @@ public final class Superwall: NSObject, ObservableObject {
   ///
   /// Otherwise, you can check the delegate function
   /// ``SuperwallDelegate/subscriptionStatusDidChange(from:to:)``
-  /// to receive a callback every time it changes.
+  /// to receive a callback whenever the logical status changes.
   @Published
   public var subscriptionStatus: SubscriptionStatus = .unknown {
     didSet {
@@ -220,8 +220,11 @@ public final class Superwall: NSObject, ObservableObject {
         return
       }
       // Saved here rather than in the status listener so that metadata-only
-      // updates, which the listener dedupes, still refresh the cache.
-      dependencyContainer.storage.save(subscriptionStatus, forType: SubscriptionStatusKey.self)
+      // updates, which the listener dedupes, still refresh the cache. Identical
+      // writes are skipped so they don't re-encode and rewrite the file.
+      if oldValue != subscriptionStatus {
+        dependencyContainer.storage.save(subscriptionStatus, forType: SubscriptionStatusKey.self)
+      }
       entitlements.subscriptionStatusDidSet(subscriptionStatus)
 
       // When using an external purchase controller, update CustomerInfo.entitlements
@@ -569,7 +572,7 @@ public final class Superwall: NSObject, ObservableObject {
         ))
   }
 
-  private func listenToSubscriptionStatus() {
+  func listenToSubscriptionStatus() {
     $subscriptionStatus
       .removeDuplicates { $0.isLogicallyEqual(to: $1) }
       .dropFirst()

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		18D39CB7BCF324B44197735D /* TaskRetryingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D2422F9742D74360FB716B /* TaskRetryingTests.swift */; };
 		191AA8FBBF617251EF6F8628 /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1EFE389B54C304F2B01620 /* DeviceInfo.swift */; };
 		1A6C6E6DAD8C0236FA24FF10 /* CheckNoPaywallAlreadyPresented.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582CE0C5BA6EA57C7FE3EE43 /* CheckNoPaywallAlreadyPresented.swift */; };
+		1B071A6918B1B36BF6BCC0C2 /* SubscriptionStatusLogicalEqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D175537791B3A913425F88 /* SubscriptionStatusLogicalEqualityTests.swift */; };
 		1BA9EC022F0016E72A5EB01A /* PaywallPresentationRequestStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC211BFF9364E4B10418695B /* PaywallPresentationRequestStatus.swift */; };
 		1BDB91B70EAEC10097941381 /* SWBounceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299F91895EE88281B5ED8320 /* SWBounceButton.swift */; };
 		1E0D00DF75A6779C78145750 /* SurveyPresentationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B66B5A624F8A2E225EACA69 /* SurveyPresentationResult.swift */; };
@@ -964,6 +965,7 @@
 		A116633D7246EB7BB7AF7229 /* ExpressionEvaluatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorMock.swift; sourceTree = "<group>"; };
 		A12EB4944354482783293010 /* PaywallSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallSummary.swift; sourceTree = "<group>"; };
 		A154A9E99D00B9BD8837B798 /* ExpressionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionLogic.swift; sourceTree = "<group>"; };
+		A1D175537791B3A913425F88 /* SubscriptionStatusLogicalEqualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStatusLogicalEqualityTests.swift; sourceTree = "<group>"; };
 		A21ED2D8CB4DDA70E228E8BC /* TaskExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskExecutor.swift; sourceTree = "<group>"; };
 		A22E703895B07CF172665846 /* PaywallLoadingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallLoadingState.swift; sourceTree = "<group>"; };
 		A2D40088A465E104CF5C67CC /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1585,6 +1587,7 @@
 				BD6BA222CB2EAA4B65F362C5 /* ProductsFetcherSK1.swift */,
 				0ECD75DF8F3EB6A68A21444D /* ProductsFetcherSK2Tests.swift */,
 				B00929DACD8621FC32F83927 /* SK2StoreProductCyclesTests.swift */,
+				A1D175537791B3A913425F88 /* SubscriptionStatusLogicalEqualityTests.swift */,
 				0E9A13ACB22951C865722510 /* Receipt Manager */,
 				9160DE1504D8084C3DF51ADC /* StoreProduct */,
 			);
@@ -3385,6 +3388,7 @@
 				B162BE92B3568078BC0ADD1B /* StoreProductBillingPlanTests.swift in Sources */,
 				5E51E14716E29C9B88B8A6F2 /* StripeTrialEligibilityTests.swift in Sources */,
 				097719E21BBD153BA6FD6785 /* SubscriptionPeriodPriceTests.swift in Sources */,
+				1B071A6918B1B36BF6BCC0C2 /* SubscriptionStatusLogicalEqualityTests.swift in Sources */,
 				E9F892ABB9BDA85F4794E3CF /* SubscriptionStatusResolutionTests.swift in Sources */,
 				89CC491C60F7CD12D3E73284 /* SurveyManagerTests.swift in Sources */,
 				252D37DDAA2C97A6E2DDD6B7 /* SurveyTests.swift in Sources */,

--- a/SuperwallKit.xcodeproj/xcshareddata/xcschemes/SuperwallKit.xcscheme
+++ b/SuperwallKit.xcodeproj/xcshareddata/xcschemes/SuperwallKit.xcscheme
@@ -40,7 +40,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "AE77960D397D727A12230C60"

--- a/Tests/SuperwallKitTests/StoreKit/Products/SubscriptionStatusLogicalEqualityTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/SubscriptionStatusLogicalEqualityTests.swift
@@ -105,4 +105,68 @@ struct SubscriptionStatusLogicalEqualityTests {
     let lapsed: SubscriptionStatus = .active([enrichedEntitlement(isActive: false)])
     #expect(!active.isLogicallyEqual(to: lapsed))
   }
+
+  // MARK: - Persistence
+
+  @Test
+  func setSubscriptionStatus_metadataOnlyUpdate_refreshesCache() {
+    let dependencyContainer = DependencyContainer()
+    let superwall = Superwall(dependencyContainer: dependencyContainer)
+    dependencyContainer.storage.delete(SubscriptionStatusKey.self)
+
+    let first: SubscriptionStatus = .active([
+      enrichedEntitlement(expiresAt: Date(timeIntervalSince1970: 1_800_000_000))
+    ])
+    superwall.subscriptionStatus = first
+    #expect(dependencyContainer.storage.get(SubscriptionStatusKey.self) == first)
+
+    // Same logical state, different metadata. The listener dedupes this,
+    // but the persisted cache must still refresh.
+    let renewed: SubscriptionStatus = .active([
+      enrichedEntitlement(expiresAt: Date(timeIntervalSince1970: 1_900_000_000))
+    ])
+    superwall.subscriptionStatus = renewed
+    #expect(dependencyContainer.storage.get(SubscriptionStatusKey.self) == renewed)
+  }
+
+  // MARK: - Listener dedupe
+
+  @Test
+  func listener_metadataOnlyUpdate_doesNotCallDelegate() async {
+    let dependencyContainer = DependencyContainer()
+    let superwall = Superwall(dependencyContainer: dependencyContainer)
+    let delegate = MockSuperwallDelegate()
+    dependencyContainer.delegateAdapter.swiftDelegate = delegate
+    superwall.listenToSubscriptionStatus()
+
+    superwall.subscriptionStatus = .active([Entitlement(id: "premium")])
+    await waitUntil { delegate.subscriptionStatusChanges.count == 1 }
+    #expect(delegate.subscriptionStatusChanges.count == 1)
+
+    // Metadata-only update: same id/type/isActive, enriched with
+    // transaction metadata. Must not call the delegate again.
+    superwall.subscriptionStatus = .active([enrichedEntitlement(id: "premium")])
+    try? await Task.sleep(nanoseconds: 300_000_000)
+    #expect(delegate.subscriptionStatusChanges.count == 1)
+
+    // A logical change must still call the delegate.
+    superwall.subscriptionStatus = .inactive
+    await waitUntil { delegate.subscriptionStatusChanges.count == 2 }
+    #expect(delegate.subscriptionStatusChanges.count == 2)
+
+    // A different entitlement id is also a logical change.
+    superwall.subscriptionStatus = .active([enrichedEntitlement(id: "pro")])
+    await waitUntil { delegate.subscriptionStatusChanges.count == 3 }
+    #expect(delegate.subscriptionStatusChanges.count == 3)
+  }
+
+  private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: @escaping () -> Bool
+  ) async {
+    let start = Date()
+    while !condition() && Date().timeIntervalSince(start) < timeout {
+      try? await Task.sleep(nanoseconds: 50_000_000)
+    }
+  }
 }

--- a/Tests/SuperwallKitTests/StoreKit/Products/SubscriptionStatusLogicalEqualityTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/SubscriptionStatusLogicalEqualityTests.swift
@@ -1,0 +1,108 @@
+//
+//  SubscriptionStatusLogicalEqualityTests.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 2026-09-01.
+//
+// swiftlint:disable all
+
+@testable import SuperwallKit
+import Testing
+import Foundation
+
+struct SubscriptionStatusLogicalEqualityTests {
+  // MARK: - Helpers
+
+  private func enrichedEntitlement(
+    id: String = "premium",
+    isActive: Bool = true,
+    expiresAt: Date? = Date(timeIntervalSince1970: 1_800_000_000)
+  ) -> Entitlement {
+    return Entitlement(
+      id: id,
+      type: .serviceLevel,
+      isActive: isActive,
+      productIds: ["com.example.monthly", "com.example.annual"],
+      latestProductId: "com.example.monthly",
+      store: .appStore,
+      startsAt: Date(timeIntervalSince1970: 1_700_000_000),
+      renewedAt: Date(timeIntervalSince1970: 1_750_000_000),
+      expiresAt: expiresAt,
+      isLifetime: false,
+      willRenew: true,
+      state: .subscribed,
+      offerType: nil
+    )
+  }
+
+  // MARK: - Case comparisons
+
+  @Test
+  func sameCases_areLogicallyEqual() {
+    #expect(SubscriptionStatus.unknown.isLogicallyEqual(to: .unknown))
+    #expect(SubscriptionStatus.inactive.isLogicallyEqual(to: .inactive))
+  }
+
+  @Test
+  func differentCases_areNotLogicallyEqual() {
+    #expect(!SubscriptionStatus.unknown.isLogicallyEqual(to: .inactive))
+    #expect(!SubscriptionStatus.inactive.isLogicallyEqual(to: .active([Entitlement(id: "premium")])))
+    #expect(!SubscriptionStatus.active([Entitlement(id: "premium")]).isLogicallyEqual(to: .unknown))
+  }
+
+  // MARK: - Active status comparisons
+
+  @Test
+  func active_identicalEntitlements_areLogicallyEqual() {
+    let status: SubscriptionStatus = .active([enrichedEntitlement()])
+    let repeatWrite: SubscriptionStatus = .active([enrichedEntitlement()])
+    #expect(status.isLogicallyEqual(to: repeatWrite))
+  }
+
+  @Test
+  func active_bareVsEnrichedEntitlement_areLogicallyEqual() {
+    // An app using a purchase controller writes a bare entitlement while the
+    // SDK holds an enriched one with transaction metadata. Deep equality says
+    // these differ; logically the status is unchanged.
+    let bare: SubscriptionStatus = .active([Entitlement(id: "premium")])
+    let enriched: SubscriptionStatus = .active([enrichedEntitlement()])
+    #expect(bare != enriched)
+    #expect(bare.isLogicallyEqual(to: enriched))
+  }
+
+  @Test
+  func active_driftingMetadata_areLogicallyEqual() {
+    let first: SubscriptionStatus = .active([
+      enrichedEntitlement(expiresAt: Date(timeIntervalSince1970: 1_800_000_000))
+    ])
+    let second: SubscriptionStatus = .active([
+      enrichedEntitlement(expiresAt: Date(timeIntervalSince1970: 1_800_000_000.5))
+    ])
+    #expect(first != second)
+    #expect(first.isLogicallyEqual(to: second))
+  }
+
+  @Test
+  func active_differentEntitlementIds_areNotLogicallyEqual() {
+    let premium: SubscriptionStatus = .active([enrichedEntitlement(id: "premium")])
+    let pro: SubscriptionStatus = .active([enrichedEntitlement(id: "pro")])
+    #expect(!premium.isLogicallyEqual(to: pro))
+  }
+
+  @Test
+  func active_addedEntitlement_areNotLogicallyEqual() {
+    let one: SubscriptionStatus = .active([enrichedEntitlement(id: "premium")])
+    let two: SubscriptionStatus = .active([
+      enrichedEntitlement(id: "premium"),
+      enrichedEntitlement(id: "pro")
+    ])
+    #expect(!one.isLogicallyEqual(to: two))
+  }
+
+  @Test
+  func active_isActiveFlip_areNotLogicallyEqual() {
+    let active: SubscriptionStatus = .active([enrichedEntitlement(isActive: true)])
+    let lapsed: SubscriptionStatus = .active([enrichedEntitlement(isActive: false)])
+    #expect(!active.isLogicallyEqual(to: lapsed))
+  }
+}

--- a/Tests/SuperwallKitTests/Web/MockSuperwallDelegate.swift
+++ b/Tests/SuperwallKitTests/Web/MockSuperwallDelegate.swift
@@ -16,6 +16,14 @@ final class MockSuperwallDelegate: SuperwallDelegate {
   var willRedeemCallCount = 0
   var willRedeemCalledAt: Date?
   var didRedeemCalledAt: Date?
+  var subscriptionStatusChanges: [(from: SubscriptionStatus, to: SubscriptionStatus)] = []
+
+  func subscriptionStatusDidChange(
+    from oldValue: SubscriptionStatus,
+    to newValue: SubscriptionStatus
+  ) {
+    subscriptionStatusChanges.append((from: oldValue, to: newValue))
+  }
 
   func didRedeemLink(result: RedemptionResult) {
     receivedResult = result


### PR DESCRIPTION
Fixes [SW-5801](https://linear.app/superwall/issue/SW-5801/ios-sdk-device-attributes-fans-out-6x-per-session-when): the iOS SDK emits `device_attributes` on every `subscriptionStatus` change, and since 4.10.0 the `.removeDuplicates()` guard on that listener no longer works — `Entitlement` equality became deep (13 fields including dates and mutable subscription state), so repeat writes of the same logical status read as changes. Apps that resolve entitlement state in stages (e.g. Citizen, with both App Store and Stripe entitlements) emit `device_attributes` ~6x per session with byte-identical payloads.

## Fix

Implements the "split the equality" option from the issue rather than content-hashing in the emitter, since hashing would only mask the last step while leaving the redundant `subscriptionStatus_didChange` flood (1.57M events/30 min for Citizen alone) untouched.

- Adds an internal `Entitlement.Identity` (`id`, `type`, `isActive`) — the fields that define which entitlement it is and whether it grants access, excluding transaction metadata that drifts between writes.
- Adds `SubscriptionStatus.isLogicallyEqual(to:)` (same case; for `.active`, same set of entitlement identities) and uses it to dedupe `listenToSubscriptionStatus()`. This gates the delegate callback, the `subscriptionStatus_didChange` event, and the `device_attributes` event.
- Public `Entitlement.isEqual` stays deep — `customerInfo` change detection depends on it, so reverting it to shallow would stop `customerInfoDidChange` firing for genuine detail changes. Its stale "based on `id` and `type`" comment is fixed.
- Moves the persisted-status save from the deduped sink into the property's `didSet`, so metadata-only updates (e.g. new expiry after renewal) still refresh the on-disk cache. `Storage` serializes on its own queue.

## Verification

New Swift Testing suite `SubscriptionStatusLogicalEqualityTests` covers the failure mode directly: bare `Entitlement(id:)` vs SDK-enriched entitlement compares deep-unequal but logically equal, sub-second date drift dedupes, while id changes, added entitlements, and `isActive` flips still register as real changes.

After release, `device_attributes` per user for app 138 should drop from ~6.2 toward ~1.2, and `subscriptionStatus_didChange` should drop similarly.

## Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [x] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR deduplicates subscription-status side effects according to entitlement access identity while preserving deep equality for CustomerInfo and persistence for metadata-only updates.
- Adds logical equality based on entitlement ID, type, and active state.
- Applies logical equality to delegate and analytics event deduplication.
- Moves subscription-status persistence into `didSet` so suppressed metadata revisions still reach disk.
- Adds focused logical-equality tests and registers them with the Xcode test target and scheme.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with logical event deduplication separated cleanly from full state persistence and metadata-sensitive CustomerInfo updates.

The changed listener suppresses only logically equivalent subscription transitions, while every assignment still updates persisted status and downstream state holders; no concrete blocking or independently actionable non-blocking defect remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/StoreKit/Products/EntitlementsStatus.swift | Adds internal logical comparison of active statuses using sets of entitlement identities. |
| Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift | Introduces the ID/type/active logical identity while retaining deep NSObject equality and hashing. |
| Sources/SuperwallKit/Superwall.swift | Deduplicates listener side effects by logical state and persists every resolved assignment before deduplication. |
| Tests/SuperwallKitTests/StoreKit/Products/SubscriptionStatusLogicalEqualityTests.swift | Covers metadata drift, enrichment, entitlement additions, identity changes, and active-state changes. |
| SuperwallKit.xcodeproj/project.pbxproj | Registers the new logical-equality test source with the test target. |
| SuperwallKit.xcodeproj/xcshareddata/xcschemes/SuperwallKit.xcscheme | Updates the shared scheme to include the new test configuration. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[subscriptionStatus assigned] --> B[Resolve effective status]
  B --> C[Persist full status]
  C --> D[Update EntitlementsInfo and CustomerInfo]
  D --> E{Logical state changed?}
  E -- No: metadata-only --> F[Suppress delegate and analytics events]
  E -- Yes --> G[Notify delegate]
  G --> H[Track subscription-status and device-attribute events]
```

<sub>Reviews (1): Last reviewed commit: ["fix(events): dedupe subscription status ..."](https://github.com/superwall/superwall-ios/commit/7e87a07c28b9e2be688e4f9523463c634d4eda46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59020969)</sub>

<!-- /greptile_comment -->