### PR TITLE
Add grantedEntitlements merged into subscription status

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,9 @@ excluded:
   - ${PWD}/Pods
   - ${PWD}/DerivedData
   - ${PWD}/.build
+  # Git worktrees live here, each holding a full copy of the SDK source, so
+  # linting them reports another branch's violations against this one.
+  - ${PWD}/.claude
   - ${PWD}/Examples
   - ${PWD}/Tests
   - ${PWD}/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/ASN1Swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Enhancements
 
-- Adds `grantedEntitlements` so you can grant entitlements from your own backend, which the SDK merges with device and web entitlements. The `subscriptionStatus` publisher now only ever emits the merged status.
+- Adds `grantedEntitlements` so you can grant entitlements from your own backend, which the SDK merges with device and web entitlements.
+- `$subscriptionStatus` is now an `AnyPublisher<SubscriptionStatus, Never>` that only ever emits the merged status; it can no longer be the target of `assign(to:)`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 - Adds `grantedEntitlements` so you can grant entitlements from your own backend, which the SDK merges with device and web entitlements.
 - `$subscriptionStatus` is now an `AnyPublisher<SubscriptionStatus, Never>` that only ever emits the merged status; it can no longer be the target of `assign(to:)`.
+- Granted entitlements don't change an `unknown` subscription status. They're merged in as soon as the status is known.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
-## 4.16.4
+## 4.17.0
+
+### Enhancements
+
+- Adds `grantedEntitlements` so you can grant entitlements from your own backend, which the SDK merges with device and web entitlements.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Adds `grantedEntitlements` so you can grant entitlements from your own backend, which the SDK merges with device and web entitlements.
-- `$subscriptionStatus` is now an `AnyPublisher<SubscriptionStatus, Never>` that only ever emits the merged status; it can no longer be the target of `assign(to:)`.
-- Granted entitlements don't change an `unknown` subscription status. They're merged in as soon as the status is known.
+- Changes `$subscriptionStatus` from a `@Published` publisher to an `AnyPublisher`. Subscribing to it works as before, but it can no longer be the target of `assign(to:)`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Enhancements
 
-- Adds `grantedEntitlements` so you can grant entitlements from your own backend, which the SDK merges with device and web entitlements.
+- Adds `grantedEntitlements` so you can grant entitlements from your own backend, which the SDK merges with device and web entitlements. The `subscriptionStatus` publisher now only ever emits the merged status.
 
 ### Fixes
 

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -324,6 +324,7 @@ enum InternalSuperwallEvent {
   struct SubscriptionStatusDidChange: TrackableSuperwallEvent {
     let superwallEvent: SuperwallEvent = .subscriptionStatusDidChange
     let status: SubscriptionStatus
+    var grantedEntitlements: Set<Entitlement> = []
     var audienceFilterParams: [String: Any] = [:]
     func getSuperwallParameters() async -> [String: Any] {
       var params: [String: Any] = [
@@ -333,6 +334,15 @@ enum InternalSuperwallEvent {
         params += [
           "active_entitlement_ids": entitlements.map(\.id).joined(separator: ",")
         ]
+        // The active set has provenance merged away, so surface which of the
+        // active entitlements were developer-granted for debugging.
+        let grantedIds = Set(grantedEntitlements.map(\.id))
+        let activeGrantedIds = entitlements.map(\.id).filter { grantedIds.contains($0) }
+        if !activeGrantedIds.isEmpty {
+          params += [
+            "granted_entitlement_ids": activeGrantedIds.joined(separator: ",")
+          ]
+        }
       }
       return params
     }

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -337,7 +337,9 @@ enum InternalSuperwallEvent {
         // The active set has provenance merged away, so surface which of the
         // active entitlements were developer-granted for debugging.
         let grantedIds = Set(grantedEntitlements.map(\.id))
-        let activeGrantedIds = entitlements.map(\.id).filter { grantedIds.contains($0) }
+        let activeGrantedIds = entitlements
+          .filter { $0.isActive && grantedIds.contains($0.id) }
+          .map(\.id)
         if !activeGrantedIds.isEmpty {
           params += [
             "granted_entitlement_ids": activeGrantedIds.joined(separator: ",")

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -334,9 +334,9 @@ enum InternalSuperwallEvent {
         params += [
           "active_entitlement_ids": entitlements.map(\.id).joined(separator: ",")
         ]
-        // The merged set carries no provenance, so this lists the active IDs
-        // that are also granted — a device record that beat a grant for the
-        // same ID is included too.
+        // The merged set doesn't record where each entitlement came from, so
+        // this lists the active IDs that are also granted — a device record
+        // that beat a grant for the same ID is included too.
         let grantedIds = Set(grantedEntitlements.map(\.id))
         let activeGrantedIds = entitlements
           .filter { $0.isActive && grantedIds.contains($0.id) }

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -334,8 +334,9 @@ enum InternalSuperwallEvent {
         params += [
           "active_entitlement_ids": entitlements.map(\.id).joined(separator: ",")
         ]
-        // The active set has provenance merged away, so surface which of the
-        // active entitlements were developer-granted for debugging.
+        // The merged set carries no provenance, so this lists the active IDs
+        // that are also granted — a device record that beat a grant for the
+        // same ID is included too.
         let grantedIds = Set(grantedEntitlements.map(\.id))
         let activeGrantedIds = entitlements
           .filter { $0.isActive && grantedIds.contains($0.id) }

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -211,15 +211,13 @@ class ConfigManager {
     if storage.get(IsTestModeActiveSubscription.self) ?? false {
       return false
     }
-    // The persisted status can hold .active with no active entitlement
-    // (e.g. a developer-assigned .active([])) — inspect the set rather
-    // than pattern-matching the case alone.
-    if case .active(let entitlements) = storage.get(SubscriptionStatusKey.self),
-      entitlements.contains(where: { $0.isActive }) {
+    // isActive rather than a bare `case .active` match: the persisted status
+    // can be .active with no active entitlement (e.g. a developer-assigned
+    // .active([])).
+    if storage.get(SubscriptionStatusKey.self)?.isActive == true {
       return true
     }
-    let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
-    return grantedEntitlements.contains { $0.isActive }
+    return entitlementsInfo.granted.contains { $0.isActive }
   }
 
   private struct ConfigFetchResult {
@@ -417,11 +415,13 @@ class ConfigManager {
       if testModeJustDeactivated,
         !factory.makeHasExternalPurchaseController() {
         Superwall.shared.setSubscriptionStatus(assigned: .inactive)
+        // Granted entitlements survive test mode, so the customer info has
+        // to keep carrying them while the status does.
         Superwall.shared.customerInfo = CustomerInfo(
           subscriptions: [],
           nonSubscriptions: [],
           entitlements: []
-        )
+        ).merging(with: .blank(), granting: entitlementsInfo.granted)
       }
       await factory.loadPurchasedProducts(config: config)
     }

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -211,7 +211,11 @@ class ConfigManager {
     if storage.get(IsTestModeActiveSubscription.self) ?? false {
       return false
     }
-    if case .active = storage.get(SubscriptionStatusKey.self) {
+    // The persisted base can hold .active with no active entitlement
+    // (e.g. a developer-assigned .active([])) — inspect the set rather
+    // than pattern-matching the case alone.
+    if case .active(let entitlements) = storage.get(SubscriptionStatusKey.self),
+      entitlements.contains(where: { $0.isActive }) {
       return true
     }
     let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -205,13 +205,13 @@ class ConfigManager {
 
   /// Whether the cached subscription state indicates an active subscriber.
   ///
-  /// The persisted status is the unresolved base, before developer-granted
+  /// The persisted status is the assigned value, before developer-granted
   /// entitlements are merged in, so those are checked from their own storage.
   private func hasActiveCachedSubscription() -> Bool {
     if storage.get(IsTestModeActiveSubscription.self) ?? false {
       return false
     }
-    // The persisted base can hold .active with no active entitlement
+    // The persisted status can hold .active with no active entitlement
     // (e.g. a developer-assigned .active([])) — inspect the set rather
     // than pattern-matching the case alone.
     if case .active(let entitlements) = storage.get(SubscriptionStatusKey.self),
@@ -416,7 +416,7 @@ class ConfigManager {
       // loadPurchasedProducts / the controller itself will restore it.
       if testModeJustDeactivated,
         !factory.makeHasExternalPurchaseController() {
-        Superwall.shared.setSubscriptionStatus(base: .inactive)
+        Superwall.shared.setSubscriptionStatus(assigned: .inactive)
         Superwall.shared.customerInfo = CustomerInfo(
           subscriptions: [],
           nonSubscriptions: [],
@@ -782,11 +782,11 @@ class ConfigManager {
     if hasActiveEntitlements {
       let status = SubscriptionStatus.active(result.entitlements)
       testModeManager.overriddenSubscriptionStatus = status
-      Superwall.shared.setSubscriptionStatus(base: status)
+      Superwall.shared.setSubscriptionStatus(assigned: status)
       storage.save(true, forType: IsTestModeActiveSubscription.self)
     } else {
       testModeManager.overriddenSubscriptionStatus = .inactive
-      Superwall.shared.setSubscriptionStatus(base: .inactive)
+      Superwall.shared.setSubscriptionStatus(assigned: .inactive)
       storage.save(false, forType: IsTestModeActiveSubscription.self)
     }
   }

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -416,7 +416,7 @@ class ConfigManager {
       // loadPurchasedProducts / the controller itself will restore it.
       if testModeJustDeactivated,
         !factory.makeHasExternalPurchaseController() {
-        Superwall.shared.subscriptionStatus = .inactive
+        Superwall.shared.setSubscriptionStatus(base: .inactive)
         Superwall.shared.customerInfo = CustomerInfo(
           subscriptions: [],
           nonSubscriptions: [],
@@ -782,11 +782,11 @@ class ConfigManager {
     if hasActiveEntitlements {
       let status = SubscriptionStatus.active(result.entitlements)
       testModeManager.overriddenSubscriptionStatus = status
-      Superwall.shared.subscriptionStatus = status
+      Superwall.shared.setSubscriptionStatus(base: status)
       storage.save(true, forType: IsTestModeActiveSubscription.self)
     } else {
       testModeManager.overriddenSubscriptionStatus = .inactive
-      Superwall.shared.subscriptionStatus = .inactive
+      Superwall.shared.setSubscriptionStatus(base: .inactive)
       storage.save(false, forType: IsTestModeActiveSubscription.self)
     }
   }

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -150,15 +150,7 @@ class ConfigManager {
 
       // Step 1: Determine fetch strategy based on subscription status and cached data
       let cachedConfig = storage.get(LatestConfig.self)
-      let cachedSubsStatus = storage.get(SubscriptionStatusKey.self)
-
-      let isTestModeSubscription = storage.get(IsTestModeActiveSubscription.self) ?? false
-      let isSubscribed: Bool
-      if case .active = cachedSubsStatus, !isTestModeSubscription {
-        isSubscribed = true
-      } else {
-        isSubscribed = false
-      }
+      let isSubscribed = hasActiveCachedSubscription()
 
       let shouldFetchAsync = cachedConfig != nil && isSubscribed
 
@@ -211,6 +203,21 @@ class ConfigManager {
 
   // MARK: - Config Fetch Helpers
 
+  /// Whether the cached subscription state indicates an active subscriber.
+  ///
+  /// The persisted status is the unresolved base, before developer-granted
+  /// entitlements are merged in, so those are checked from their own storage.
+  private func hasActiveCachedSubscription() -> Bool {
+    if storage.get(IsTestModeActiveSubscription.self) ?? false {
+      return false
+    }
+    if case .active = storage.get(SubscriptionStatusKey.self) {
+      return true
+    }
+    let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
+    return grantedEntitlements.contains { $0.isActive }
+  }
+
   private struct ConfigFetchResult {
     let config: Config
     let isUsingCached: Bool
@@ -240,13 +247,7 @@ class ConfigManager {
       // Fetch config synchronously
       let enableConfigRefresh = cachedConfig?.featureFlags.enableConfigRefresh ?? false
 
-      let isActiveSubscription: Bool
-      if case .active = storage.get(SubscriptionStatusKey.self),
-        !(storage.get(IsTestModeActiveSubscription.self) ?? false) {
-        isActiveSubscription = true
-      } else {
-        isActiveSubscription = false
-      }
+      let isActiveSubscription = hasActiveCachedSubscription()
       let timeout: TimeInterval = isActiveSubscription ? 0.5 : 1
 
       if let cachedConfig = cachedConfig,
@@ -294,13 +295,7 @@ class ConfigManager {
       // Fetch enrichment with timeout for sync path
       let enableConfigRefresh = cachedConfig?.featureFlags.enableConfigRefresh ?? false
 
-      let isActiveSubscription: Bool
-      if case .active = storage.get(SubscriptionStatusKey.self),
-        !(storage.get(IsTestModeActiveSubscription.self) ?? false) {
-        isActiveSubscription = true
-      } else {
-        isActiveSubscription = false
-      }
+      let isActiveSubscription = hasActiveCachedSubscription()
       let timeout: TimeInterval = isActiveSubscription ? 0.5 : 1
 
       let cachedEnrichment = storage.get(LatestEnrichment.self)

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -51,10 +51,11 @@ final class DependencyContainer {
   init(
     apiKey: String = "",
     purchaseController controller: PurchaseController? = nil,
-    options: SuperwallOptions? = nil
+    options: SuperwallOptions? = nil,
+    cache: Cache = Cache()
   ) {
     delegateAdapter = SuperwallDelegateAdapter()
-    storage = Storage(factory: self)
+    storage = Storage(factory: self, cache: cache)
     storage.configure(apiKey: apiKey)
     entitlementsInfo = EntitlementsInfo(
       storage: storage,

--- a/Sources/SuperwallKit/Logger/LogScope.swift
+++ b/Sources/SuperwallKit/Logger/LogScope.swift
@@ -33,8 +33,10 @@ public enum LogScope: Int, Encodable, Sendable, CustomStringConvertible {
   case paywallViewController
   case cache
   case webEntitlements
-  case grantedEntitlements
   case all
+  // Declared after `all` so existing implicit raw values stay stable — they
+  // reach the backend via SuperwallOptions.toDictionary().
+  case grantedEntitlements
 
   public var description: String {
     switch self {

--- a/Sources/SuperwallKit/Logger/LogScope.swift
+++ b/Sources/SuperwallKit/Logger/LogScope.swift
@@ -33,6 +33,7 @@ public enum LogScope: Int, Encodable, Sendable, CustomStringConvertible {
   case paywallViewController
   case cache
   case webEntitlements
+  case grantedEntitlements
   case all
 
   public var description: String {
@@ -83,6 +84,8 @@ public enum LogScope: Int, Encodable, Sendable, CustomStringConvertible {
       return "cache"
     case .webEntitlements:
       return "webEntitlements"
+    case .grantedEntitlements:
+      return "grantedEntitlements"
     case .all:
       return "all"
     }

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.16.4
+4.17.0
 """

--- a/Sources/SuperwallKit/Models/Customer Info/CustomerInfo.swift
+++ b/Sources/SuperwallKit/Models/Customer Info/CustomerInfo.swift
@@ -134,7 +134,10 @@ public final class CustomerInfo: NSObject, Codable {
   ///
   /// - Parameter webCustomerInfo: The CustomerInfo from web2app endpoints containing web purchases/redemptions
   /// - Returns: A new CustomerInfo with merged data from both sources
-  func merging(with webCustomerInfo: CustomerInfo) -> CustomerInfo {
+  func merging(
+    with webCustomerInfo: CustomerInfo,
+    granting grantedEntitlements: Set<Entitlement> = []
+  ) -> CustomerInfo {
     // Merge non-subscription transactions (consumables, non-consumables)
     // Start with device transactions, then add web transactions that don't already exist
     var mergedNonSubscriptions = self.nonSubscriptions
@@ -155,13 +158,15 @@ public final class CustomerInfo: NSObject, Codable {
       mergedSubscriptions.append(webSub)
     }
 
-    // Merge entitlements using priority-based merging
+    // Merge entitlements from device, web, and developer-granted sources
+    // using priority-based merging.
     // This uses `Entitlement.mergePrioritized` which intelligently selects the highest
     // priority entitlement for each ID based on:
     // - Active status (active > inactive)
     // - Latest expiration date
     // - Other priority criteria defined in `shouldTakePriorityOver`
-    let combinedEntitlements = self.entitlements + webCustomerInfo.entitlements
+    let combinedEntitlements =
+      self.entitlements + webCustomerInfo.entitlements + Array(grantedEntitlements)
     let mergedEntitlements = Entitlement.mergePrioritized(combinedEntitlements)
 
     // Return merged CustomerInfo with sorted transactions and entitlements
@@ -169,6 +174,44 @@ public final class CustomerInfo: NSObject, Codable {
       subscriptions: mergedSubscriptions.sorted { $0.purchaseDate < $1.purchaseDate },
       nonSubscriptions: mergedNonSubscriptions.sorted { $0.purchaseDate < $1.purchaseDate },
       entitlements: mergedEntitlements.sorted { $0.id < $1.id }
+    )
+  }
+
+  /// Composes customer info from a fresh device snapshot under an external
+  /// purchase controller, preserving the entitlements that came from the
+  /// controller — its active entitlements won't necessarily be in device data.
+  static func preservingExternalControllerEntitlements(
+    device deviceCustomerInfo: CustomerInfo,
+    web webCustomerInfo: CustomerInfo?,
+    current currentCustomerInfo: CustomerInfo,
+    granted grantedEntitlements: Set<Entitlement>
+  ) -> CustomerInfo {
+    // Merge with web customer info if available
+    let baseCustomerInfo = webCustomerInfo.map {
+      deviceCustomerInfo.merging(with: $0)
+    } ?? deviceCustomerInfo
+
+    // Get entitlements that are only in current CustomerInfo (i.e., from external controller)
+    // by filtering out anything that matches device or web entitlements by ID
+    let deviceAndWebEntitlementIds = Set(baseCustomerInfo.entitlements.map { $0.id })
+    let externalOnlyEntitlements = currentCustomerInfo.entitlements.filter { entitlement in
+      // Keep external entitlement if it's not already in device/web
+      !deviceAndWebEntitlementIds.contains(entitlement.id)
+    }
+
+    // Merge external controller entitlements with device + web + granted.
+    // Granted entitlements are their own source here: the externalOnly
+    // filter above would drop one whose ID collides with an expired device
+    // entitlement, leaving customerInfo reporting it inactive while
+    // subscriptionStatus reports it active.
+    let allEntitlements =
+      baseCustomerInfo.entitlements + externalOnlyEntitlements + Array(grantedEntitlements)
+    let finalEntitlements = Entitlement.mergePrioritized(allEntitlements)
+
+    return CustomerInfo(
+      subscriptions: baseCustomerInfo.subscriptions,
+      nonSubscriptions: baseCustomerInfo.nonSubscriptions,
+      entitlements: finalEntitlements.sorted { $0.id < $1.id }
     )
   }
 
@@ -211,39 +254,25 @@ public final class CustomerInfo: NSObject, Codable {
       externalEntitlements = []
     }
 
-    // Merge: active from external controller + all web + inactive device
+    // Developer-granted entitlements are read from their own storage rather
+    // than recovered from subscriptionStatus — that's an already-merged value
+    // where sources are no longer distinguishable. They also can't ride in via
+    // the appStore filter above: widening it to admit them would resurrect
+    // revoked web entitlements, whose revocation is signalled only by their
+    // absence from webCustomerInfo.
+    let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
+
+    // Merge: active from external controller + all web + inactive device + granted
     // This gives us complete history while respecting external controller as source of truth for active status
-    let allEntitlements = externalEntitlements + webCustomerInfo.entitlements + inactiveDeviceEntitlements
+    let allEntitlements =
+      externalEntitlements + webCustomerInfo.entitlements + inactiveDeviceEntitlements
+      + Array(grantedEntitlements)
     let finalEntitlements = Entitlement.mergePrioritized(allEntitlements)
 
     return CustomerInfo(
       subscriptions: baseCustomerInfo.subscriptions,
       nonSubscriptions: baseCustomerInfo.nonSubscriptions,
       entitlements: finalEntitlements.sorted { $0.id < $1.id }
-    ).mergingGrantedEntitlements(from: storage)
-  }
-
-  /// Returns a copy with developer-granted entitlements merged in as their
-  /// own source.
-  ///
-  /// Granted entitlements are read from their own storage rather than
-  /// recovered from `subscriptionStatus` — that's an already-merged value
-  /// where sources are no longer distinguishable. They also can't ride in via
-  /// the appStore filter in `forExternalPurchaseController`: widening it to
-  /// admit them would resurrect revoked web entitlements, whose revocation is
-  /// signalled only by their absence from the web customer info.
-  func mergingGrantedEntitlements(from storage: Storage) -> CustomerInfo {
-    let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
-    if grantedEntitlements.isEmpty {
-      return self
-    }
-    let mergedEntitlements = Entitlement.mergePrioritized(
-      entitlements + Array(grantedEntitlements)
-    )
-    return CustomerInfo(
-      subscriptions: subscriptions,
-      nonSubscriptions: nonSubscriptions,
-      entitlements: mergedEntitlements.sorted { $0.id < $1.id }
     )
   }
 }

--- a/Sources/SuperwallKit/Models/Customer Info/CustomerInfo.swift
+++ b/Sources/SuperwallKit/Models/Customer Info/CustomerInfo.swift
@@ -169,11 +169,14 @@ public final class CustomerInfo: NSObject, Codable {
       self.entitlements + webCustomerInfo.entitlements + Array(grantedEntitlements)
     let mergedEntitlements = Entitlement.mergePrioritized(combinedEntitlements)
 
-    // Return merged CustomerInfo with sorted transactions and entitlements
+    // Return merged CustomerInfo with sorted transactions and entitlements.
+    // It stays a placeholder until real data has arrived from either side —
+    // granted entitlements alone don't mean the device has been read.
     return CustomerInfo(
       subscriptions: mergedSubscriptions.sorted { $0.purchaseDate < $1.purchaseDate },
       nonSubscriptions: mergedNonSubscriptions.sorted { $0.purchaseDate < $1.purchaseDate },
-      entitlements: mergedEntitlements.sorted { $0.id < $1.id }
+      entitlements: mergedEntitlements.sorted { $0.id < $1.id },
+      isPlaceholder: isPlaceholder && webCustomerInfo.isPlaceholder
     )
   }
 
@@ -227,7 +230,8 @@ public final class CustomerInfo: NSObject, Codable {
   /// - Returns: A new CustomerInfo with all sources merged
   static func forExternalPurchaseController(
     storage: Storage,
-    subscriptionStatus: SubscriptionStatus
+    subscriptionStatus: SubscriptionStatus,
+    granted grantedEntitlements: Set<Entitlement>
   ) -> CustomerInfo {
     // Get web CustomerInfo
     let webCustomerInfo = storage.get(LatestRedeemResponse.self)?.customerInfo ?? .blank()
@@ -254,13 +258,12 @@ public final class CustomerInfo: NSObject, Codable {
       externalEntitlements = []
     }
 
-    // Developer-granted entitlements are read from their own storage rather
-    // than recovered from subscriptionStatus — that's an already-merged value
+    // Developer-granted entitlements come in as their own source rather than
+    // recovered from subscriptionStatus — that's an already-merged value
     // where sources are no longer distinguishable. They also can't ride in via
     // the appStore filter above: widening it to admit them would resurrect
     // revoked web entitlements, whose revocation is signalled only by their
     // absence from webCustomerInfo.
-    let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
 
     // Merge: active from external controller + all web + inactive device + granted
     // This gives us complete history while respecting external controller as source of truth for active status

--- a/Sources/SuperwallKit/Models/Customer Info/CustomerInfo.swift
+++ b/Sources/SuperwallKit/Models/Customer Info/CustomerInfo.swift
@@ -220,6 +220,30 @@ public final class CustomerInfo: NSObject, Codable {
       subscriptions: baseCustomerInfo.subscriptions,
       nonSubscriptions: baseCustomerInfo.nonSubscriptions,
       entitlements: finalEntitlements.sorted { $0.id < $1.id }
+    ).mergingGrantedEntitlements(from: storage)
+  }
+
+  /// Returns a copy with developer-granted entitlements merged in as their
+  /// own source.
+  ///
+  /// Granted entitlements are read from their own storage rather than
+  /// recovered from `subscriptionStatus` — that's an already-merged value
+  /// where sources are no longer distinguishable. They also can't ride in via
+  /// the appStore filter in `forExternalPurchaseController`: widening it to
+  /// admit them would resurrect revoked web entitlements, whose revocation is
+  /// signalled only by their absence from the web customer info.
+  func mergingGrantedEntitlements(from storage: Storage) -> CustomerInfo {
+    let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
+    if grantedEntitlements.isEmpty {
+      return self
+    }
+    let mergedEntitlements = Entitlement.mergePrioritized(
+      entitlements + Array(grantedEntitlements)
+    )
+    return CustomerInfo(
+      subscriptions: subscriptions,
+      nonSubscriptions: nonSubscriptions,
+      entitlements: mergedEntitlements.sorted { $0.id < $1.id }
     )
   }
 }

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -201,6 +201,16 @@ enum SubscriptionStatusKey: Storable {
   typealias Value = SubscriptionStatus
 }
 
+enum GrantedEntitlements: Storable {
+  static var key: String {
+    "store.grantedEntitlements"
+  }
+  // App-specific so that `Storage.reset()` doesn't wipe it: the developer owns
+  // this bucket and its lifecycle, including across `reset()`/`identify()`.
+  static var directory: SearchPathDirectory = .appSpecificDocuments
+  typealias Value = Set<Entitlement>
+}
+
 enum SurveyAssignmentKey: Storable {
   static var key: String {
     "store.surveyAssignmentKey"

--- a/Sources/SuperwallKit/StoreKit/Products/EntitlementsInfo.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/EntitlementsInfo.swift
@@ -51,6 +51,30 @@ public final class EntitlementsInfo: NSObject, ObservableObject, @unchecked Send
     return Set(entitlements)
   }
 
+  /// The entitlements granted via ``Superwall/grantedEntitlements``.
+  ///
+  /// Loaded from storage once and kept in memory: it's read on every status
+  /// publish, and a storage miss — the common case, since most apps never
+  /// grant — isn't memoized by the cache, so reading through would hit disk
+  /// every time.
+  var granted: Set<Entitlement> {
+    return queue.sync {
+      if let granted = backingGranted {
+        return granted
+      }
+      let granted = storage.get(GrantedEntitlements.self) ?? []
+      backingGranted = granted
+      return granted
+    }
+  }
+
+  func setGranted(_ granted: Set<Entitlement>) {
+    queue.sync {
+      backingGranted = granted
+      storage.save(granted, forType: GrantedEntitlements.self)
+    }
+  }
+
   // MARK: - Internal vars
   /// The entitlements that belong to each product ID.
   var entitlementsByProductId: [String: Set<Entitlement>] = [:] {
@@ -63,6 +87,9 @@ public final class EntitlementsInfo: NSObject, ObservableObject, @unchecked Send
   // MARK: - Private vars
   /// The backing variable for ``EntitlementsInfo/active``.
   private var backingActive: Set<Entitlement> = []
+
+  /// The backing variable for `granted`; `nil` until first read.
+  private var backingGranted: Set<Entitlement>?
 
   /// The backing variable for ``EntitlementsInfo/all``.
   private var backingAll: Set<Entitlement> = []

--- a/Sources/SuperwallKit/StoreKit/Products/PublishedSubscriptionStatus.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/PublishedSubscriptionStatus.swift
@@ -1,0 +1,64 @@
+//
+//  PublishedSubscriptionStatus.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 2026-09-03.
+//
+
+import Combine
+import Foundation
+
+/// The property wrapper behind ``Superwall/subscriptionStatus``.
+///
+/// Every assignment is routed through `publishSubscriptionStatus`, so the
+/// stored and published value is always the merged one — subscribers never
+/// see the value a writer assigned before granted entitlements and test-mode
+/// overrides were applied. The projected value (`$subscriptionStatus`) replays
+/// the current value to new subscribers, like `@Published`.
+///
+/// Public only because a public property's wrapper type has to be; nothing
+/// but the projection is meant to be used. The enclosing-instance subscript
+/// is the same mechanism `@Published` itself uses to reach its owner.
+@propertyWrapper
+public struct PublishedSubscriptionStatus {
+  private var storage: SubscriptionStatus
+  private let subject: CurrentValueSubject<SubscriptionStatus, Never>
+
+  public init(wrappedValue: SubscriptionStatus) {
+    storage = wrappedValue
+    subject = CurrentValueSubject(wrappedValue)
+  }
+
+  @available(*, unavailable, message: "Only available on Superwall.")
+  public var wrappedValue: SubscriptionStatus {
+    get { fatalError("subscriptionStatus is only readable on Superwall.") }
+    set { fatalError("\(newValue) can only be assigned on Superwall.") }
+  }
+
+  public var projectedValue: AnyPublisher<SubscriptionStatus, Never> {
+    return subject.eraseToAnyPublisher()
+  }
+
+  public static subscript(
+    _enclosingInstance superwall: Superwall,
+    wrapped wrappedKeyPath: ReferenceWritableKeyPath<Superwall, SubscriptionStatus>,
+    storage storageKeyPath: ReferenceWritableKeyPath<Superwall, PublishedSubscriptionStatus>
+  ) -> SubscriptionStatus {
+    get {
+      return superwall[keyPath: storageKeyPath].storage
+    }
+    set {
+      superwall.publishSubscriptionStatus(assigned: newValue, isDeveloperAssignment: true)
+    }
+  }
+
+  /// Stores a merged status without emitting it.
+  mutating func store(_ merged: SubscriptionStatus) {
+    storage = merged
+  }
+
+  /// Emits a stored status to subscribers.
+  func emit(_ status: SubscriptionStatus) {
+    subject.send(status)
+  }
+}

--- a/Sources/SuperwallKit/StoreKit/Products/PublishedSubscriptionStatus.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/PublishedSubscriptionStatus.swift
@@ -48,7 +48,7 @@ public struct PublishedSubscriptionStatus {
       return superwall[keyPath: storageKeyPath].storage
     }
     set {
-      superwall.publishSubscriptionStatus(assigned: newValue, isDeveloperAssignment: true)
+      superwall.publishSubscriptionStatus(.developerAssignment(newValue))
     }
   }
 

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -213,11 +213,15 @@ actor ReceiptManager {
       let allEntitlements = baseCustomerInfo.entitlements + externalOnlyEntitlements
       let finalEntitlements = Entitlement.mergePrioritized(allEntitlements)
 
+      // Granted entitlements merge here too: the externalOnly filter above
+      // drops a granted entitlement whose ID collides with an expired
+      // device one, which would leave customerInfo reporting it inactive
+      // while subscriptionStatus reports it active.
       mergedCustomerInfo = CustomerInfo(
         subscriptions: baseCustomerInfo.subscriptions,
         nonSubscriptions: baseCustomerInfo.nonSubscriptions,
         entitlements: finalEntitlements.sorted { $0.id < $1.id }
-      )
+      ).mergingGrantedEntitlements(from: storage)
     } else {
       mergedCustomerInfo = baseCustomerInfo.mergingGrantedEntitlements(from: storage)
     }

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -189,7 +189,7 @@ actor ReceiptManager {
 
     // The other sources that merge with the device snapshot.
     let webCustomerInfo = storage.get(LatestRedeemResponse.self)?.customerInfo
-    let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
+    let grantedEntitlements = Superwall.shared.entitlements.granted
 
     let mergedCustomerInfo: CustomerInfo
     if factory.makeHasExternalPurchaseController() {

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -219,7 +219,7 @@ actor ReceiptManager {
         entitlements: finalEntitlements.sorted { $0.id < $1.id }
       )
     } else {
-      mergedCustomerInfo = baseCustomerInfo
+      mergedCustomerInfo = baseCustomerInfo.mergingGrantedEntitlements(from: storage)
     }
 
     await MainActor.run {

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -187,43 +187,24 @@ actor ReceiptManager {
     // Save device-only CustomerInfo to storage for use when merging with web entitlements
     storage.save(onDeviceSnapshot.customerInfo, forType: LatestDeviceCustomerInfo.self)
 
-    // Merge with web customer info if available
-    let baseCustomerInfo: CustomerInfo
-    if let latestRedeemResponse = storage.get(LatestRedeemResponse.self) {
-      baseCustomerInfo = onDeviceSnapshot.customerInfo.merging(with: latestRedeemResponse.customerInfo)
-    } else {
-      baseCustomerInfo = onDeviceSnapshot.customerInfo
-    }
+    // The other sources that merge with the device snapshot.
+    let webCustomerInfo = storage.get(LatestRedeemResponse.self)?.customerInfo
+    let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
 
-    // If using an external purchase controller, preserve entitlements that came from it
-    // (The external controller's active entitlements won't necessarily be in device data)
     let mergedCustomerInfo: CustomerInfo
     if factory.makeHasExternalPurchaseController() {
       let currentCustomerInfo = await MainActor.run { Superwall.shared.customerInfo }
-
-      // Get entitlements that are only in current CustomerInfo (i.e., from external controller)
-      // by filtering out anything that matches device or web entitlements by ID
-      let deviceAndWebEntitlementIds = Set(baseCustomerInfo.entitlements.map { $0.id })
-      let externalOnlyEntitlements = currentCustomerInfo.entitlements.filter { entitlement in
-        // Keep external entitlement if it's not already in device/web
-        !deviceAndWebEntitlementIds.contains(entitlement.id)
-      }
-
-      // Merge external controller entitlements with device + web
-      let allEntitlements = baseCustomerInfo.entitlements + externalOnlyEntitlements
-      let finalEntitlements = Entitlement.mergePrioritized(allEntitlements)
-
-      // Granted entitlements merge here too: the externalOnly filter above
-      // drops a granted entitlement whose ID collides with an expired
-      // device one, which would leave customerInfo reporting it inactive
-      // while subscriptionStatus reports it active.
-      mergedCustomerInfo = CustomerInfo(
-        subscriptions: baseCustomerInfo.subscriptions,
-        nonSubscriptions: baseCustomerInfo.nonSubscriptions,
-        entitlements: finalEntitlements.sorted { $0.id < $1.id }
-      ).mergingGrantedEntitlements(from: storage)
+      mergedCustomerInfo = CustomerInfo.preservingExternalControllerEntitlements(
+        device: onDeviceSnapshot.customerInfo,
+        web: webCustomerInfo,
+        current: currentCustomerInfo,
+        granted: grantedEntitlements
+      )
     } else {
-      mergedCustomerInfo = baseCustomerInfo.mergingGrantedEntitlements(from: storage)
+      mergedCustomerInfo = onDeviceSnapshot.customerInfo.merging(
+        with: webCustomerInfo ?? .blank(),
+        granting: grantedEntitlements
+      )
     }
 
     await MainActor.run {

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift
@@ -315,6 +315,30 @@ extension Entitlement {
   }
 }
 
+// MARK: - Comparison
+extension Entitlement {
+  /// Whether `other` is this entitlement with possibly different product IDs
+  /// — the shape a merge leaves behind, since it unions product IDs across a
+  /// shared ID regardless of which record wins.
+  func isEqualIgnoringProductIds(to other: Entitlement) -> Bool {
+    return Entitlement(
+      id: id,
+      type: type,
+      isActive: isActive,
+      productIds: other.productIds,
+      latestProductId: latestProductId,
+      store: store,
+      startsAt: startsAt,
+      renewedAt: renewedAt,
+      expiresAt: expiresAt,
+      isLifetime: isLifetime,
+      willRenew: willRenew,
+      state: state,
+      offerType: offerType
+    ) == other
+  }
+}
+
 // MARK: - Entitlement Merging
 extension Entitlement {
   /// Determines which entitlement should take priority when merging entitlements with the same ID.

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusChange.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusChange.swift
@@ -1,0 +1,27 @@
+//
+//  SubscriptionStatusChange.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 2026-09-03.
+//
+
+import Foundation
+
+/// What prompted a publish of ``Superwall/subscriptionStatus``.
+///
+/// The three cases are the only ways the published status can change, and
+/// each carries exactly what that path knows: the two assignments carry a
+/// new status, a grant change carries nothing because it leaves the assigned
+/// status alone and only changes what merges into it.
+enum SubscriptionStatusChange {
+  /// The developer assigned ``Superwall/subscriptionStatus`` directly.
+  case developerAssignment(SubscriptionStatus)
+
+  /// The SDK assigned a status it worked out itself — device + web
+  /// entitlements, the cold-launch restore, or test mode.
+  case sdkAssignment(SubscriptionStatus)
+
+  /// ``Superwall/grantedEntitlements`` changed, so the status is republished
+  /// from the assigned value it already had.
+  case grantChange
+}

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -23,9 +23,10 @@ import Foundation
 /// The assigned value is kept because the published one can't be un-merged:
 /// clearing granted entitlements recomputes the published status from it.
 ///
-/// Every writer ends up in `publishSubscriptionStatus`, which runs under
-/// `subscriptionStatusLock` so assignments from different threads can't
-/// interleave with the write-back of the merged value.
+/// Every writer — the public setter included, via ``PublishedSubscriptionStatus``
+/// — ends up in `publishSubscriptionStatus`, the one critical section under
+/// `subscriptionStatusLock`. The merged value is stored under the lock and
+/// emitted to subscribers after it's released.
 extension Superwall {
   // MARK: - Granted entitlements
 
@@ -48,34 +49,29 @@ extension Superwall {
   /// previous user's granted entitlements.
   public var grantedEntitlements: Set<Entitlement> {
     get {
-      return dependencyContainer.storage.get(GrantedEntitlements.self) ?? []
+      return entitlements.granted
     }
     set {
-      subscriptionStatusLock.lock()
-      defer {
-        subscriptionStatusLock.unlock()
-      }
-      dependencyContainer.storage.save(newValue, forType: GrantedEntitlements.self)
+      entitlements.setGranted(newValue)
       Logger.debug(
-        logLevel: .info,
+        logLevel: .debug,
         scope: .grantedEntitlements,
         message: newValue.isEmpty
           ? "Granted entitlements cleared."
           : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
       )
-      publishSubscriptionStatus(assigned: assignedSubscriptionStatus, isDeveloperAssignment: false)
-      refreshAutomaticCustomerInfoAfterGrantChange(granted: newValue)
+      publishSubscriptionStatus(assigned: nil, isDeveloperAssignment: false)
+      refreshAutomaticCustomerInfoAfterGrantChange()
     }
   }
 
   // MARK: - Assigning
 
-  /// Assigns a new status and publishes the merged result in a single
-  /// store, so subscribers never observe the un-merged value.
+  /// Assigns a new status and publishes the merged result.
   ///
-  /// SDK writers use this rather than assigning ``subscriptionStatus``: the
-  /// public setter has to store the raw value before `didSet` can merge it,
-  /// which publishes the raw value first.
+  /// SDK writers use this rather than assigning ``subscriptionStatus``, which
+  /// is the developer's entry point and gets the developer-assignment
+  /// treatment described on `publishSubscriptionStatus`.
   func setSubscriptionStatus(assigned status: SubscriptionStatus) {
     publishSubscriptionStatus(assigned: status, isDeveloperAssignment: false)
   }
@@ -115,53 +111,59 @@ extension Superwall {
 
   // MARK: - Publishing
 
-  /// Records `assigned`, publishes the merged status in a single store,
-  /// persists the assigned value, and runs the side effects of a change.
+  /// Records the assigned status, stores the merged status and persists the
+  /// assigned value under the lock, then emits the merged status and runs the
+  /// remaining side effects outside it.
   ///
-  /// Takes `subscriptionStatusLock` itself; callers that already hold it
-  /// (the ``subscriptionStatus`` observers, the ``grantedEntitlements``
-  /// setter) simply recurse. The granted snapshot is read here, under the
-  /// lock, so a concurrent grant write can't slip between the read and the
-  /// publish.
+  /// Pass `nil` as `assigned` to re-publish from the current assigned status
+  /// — after a grant change — which is then read under the lock.
   ///
   /// `isDeveloperAssignment` is `true` for writes through the public
-  /// ``subscriptionStatus`` setter — the only path that warrants warning
-  /// about granted entitlements overriding an `.inactive` assignment.
+  /// ``subscriptionStatus`` setter, which get two extra treatments: records
+  /// identical to a current grant are stripped, because a developer who reads
+  /// the published status and writes it back would otherwise hand the grants
+  /// back as their own and clearing them could never revoke; and an
+  /// `.inactive` assignment while active grants exist logs a one-time
+  /// warning, since the status publishes as active and otherwise looks
+  /// ignored.
   func publishSubscriptionStatus(
-    assigned: SubscriptionStatus,
+    assigned newAssigned: SubscriptionStatus?,
     isDeveloperAssignment: Bool
   ) {
     subscriptionStatusLock.lock()
-    defer {
-      subscriptionStatusLock.unlock()
-    }
-    // Snapshot once: the warning check and the merge both need it.
-    let granted = grantedEntitlements
 
-    // The status publishes as active regardless, which otherwise looks
-    // like the SDK ignored the assignment.
-    if isDeveloperAssignment,
-      case .inactive = assigned,
-      !granted.isEmpty,
-      !hasLoggedGrantedEntitlementsWarning {
-      hasLoggedGrantedEntitlementsWarning = true
-      Logger.debug(
-        logLevel: .warn,
-        scope: .grantedEntitlements,
-        message: "subscriptionStatus was set to .inactive but grantedEntitlements "
-          + "is not empty, so the status remains active. Assigning subscriptionStatus "
-          + "doesn't clear granted entitlements — set grantedEntitlements to an empty set to revoke them."
-      )
+    // Snapshot once, under the lock, so a concurrent grant write can't slip
+    // between the read and the store. Active grants are merged here so two
+    // grants sharing an ID collapse to one record on every path.
+    let granted = entitlements.granted
+    let activeGrants = Entitlement.mergePrioritized(Array(granted.filter(\.isActive)))
+
+    var assigned = newAssigned ?? assignedSubscriptionStatus
+    if isDeveloperAssignment {
+      if case .active(let assignedEntitlements) = assigned {
+        assigned = .active(assignedEntitlements.subtracting(granted))
+      }
+      if case .inactive = assigned,
+        !activeGrants.isEmpty,
+        !hasLoggedGrantedEntitlementsWarning {
+        hasLoggedGrantedEntitlementsWarning = true
+        Logger.debug(
+          logLevel: .warn,
+          scope: .grantedEntitlements,
+          message: "subscriptionStatus was set to .inactive but grantedEntitlements "
+            + "is not empty, so the status remains active. Assigning subscriptionStatus "
+            + "doesn't clear granted entitlements — set grantedEntitlements to an empty set to revoke them."
+        )
+      }
     }
 
     let previouslyAssigned = assignedSubscriptionStatus
     assignedSubscriptionStatus = assigned
 
-    let merged = mergedSubscriptionStatus(assigned: assigned, granted: granted)
-    if merged != subscriptionStatus {
-      isPublishingSubscriptionStatus = true
-      subscriptionStatus = merged
-      isPublishingSubscriptionStatus = false
+    let merged = mergedSubscriptionStatus(assigned: assigned, activeGrants: activeGrants)
+    let statusChanged = merged != subscriptionStatus
+    if statusChanged {
+      storeMergedSubscriptionStatus(merged)
     }
 
     // Persist the assigned value, not the merged one: restoring a merged
@@ -174,6 +176,13 @@ extension Superwall {
     if previouslyAssigned != assigned {
       dependencyContainer.storage.save(assigned, forType: SubscriptionStatusKey.self)
     }
+    subscriptionStatusLock.unlock()
+
+    // Subscribers and customer info observers run outside the lock, so a
+    // subscriber that blocks on another thread can't deadlock a writer.
+    if statusChanged {
+      emitSubscriptionStatus()
+    }
     entitlements.subscriptionStatusDidSet(subscriptionStatus)
 
     // When using an external purchase controller, update CustomerInfo.entitlements
@@ -183,10 +192,10 @@ extension Superwall {
       dependencyContainer.testModeManager?.isTestMode != true {
       customerInfo = CustomerInfo.forExternalPurchaseController(
         storage: dependencyContainer.storage,
-        subscriptionStatus: subscriptionStatus
+        subscriptionStatus: subscriptionStatus,
+        granted: granted
       )
     }
-    publishedSubscriptionStatusSubject.send(subscriptionStatus)
   }
 
   /// The status the SDK reports for `assigned`: active granted entitlements
@@ -194,7 +203,7 @@ extension Superwall {
   /// collapsed to `.inactive`.
   private func mergedSubscriptionStatus(
     assigned: SubscriptionStatus,
-    granted: Set<Entitlement>
+    activeGrants: Set<Entitlement>
   ) -> SubscriptionStatus {
     if let testModeManager = dependencyContainer.testModeManager,
       testModeManager.isTestMode,
@@ -205,15 +214,11 @@ extension Superwall {
     // Only active grants merge into the status, mirroring how web
     // entitlements merge (EntitlementsInfo.web filters to active).
     // Inactive grants still reach customerInfo for round-trip visibility.
-    let activeGrants = Set(granted.filter(\.isActive))
     if !activeGrants.isEmpty {
       switch status {
       case .active(let entitlements):
-        // mergePrioritized explicitly: plain Set.union dedupes by deep
-        // equality, which would keep both records for a shared ID.
-        status = .active(
-          Entitlement.mergePrioritized(Array(entitlements) + Array(activeGrants))
-        )
+        // Set<Entitlement>.union merges by priority, keeping one record per ID.
+        status = .active(entitlements.union(activeGrants))
       case .inactive, .unknown:
         // .unknown promotes to active, unlike web entitlements (see
         // internallySetSubscriptionStatus). With an external purchase
@@ -237,7 +242,7 @@ extension Superwall {
   /// actually disappear. The external purchase controller path is recomputed
   /// inside `publishSubscriptionStatus`; test mode manages its own customer
   /// info.
-  private func refreshAutomaticCustomerInfoAfterGrantChange(granted: Set<Entitlement>) {
+  private func refreshAutomaticCustomerInfoAfterGrantChange() {
     if dependencyContainer.makeHasExternalPurchaseController() {
       return
     }
@@ -247,17 +252,13 @@ extension Superwall {
     let storage: Storage = dependencyContainer.storage
     let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
     let webCustomerInfo = storage.get(LatestRedeemResponse.self)?.customerInfo ?? .blank()
-    customerInfo = deviceCustomerInfo.merging(with: webCustomerInfo, granting: granted)
+    customerInfo = deviceCustomerInfo.merging(with: webCustomerInfo, granting: entitlements.granted)
   }
 
   // MARK: - Listening
 
   func listenToSubscriptionStatus() {
-    // Listens to the published stream rather than $subscriptionStatus so the
-    // delegate and the status-change event never see the transient raw
-    // value that the public setter stores before merging.
-    publishedSubscriptionStatusSubject
-      .prepend(subscriptionStatus)
+    $subscriptionStatus
       .removeDuplicates { $0.isLogicallyEqual(to: $1) }
       .dropFirst()
       .scan((previous: subscriptionStatus, current: subscriptionStatus)) { previousPair, newStatus in
@@ -293,5 +294,58 @@ extension Superwall {
           }
         )
       )
+  }
+}
+
+// MARK: - Property wrapper
+
+/// The property wrapper behind ``Superwall/subscriptionStatus``.
+///
+/// Every assignment is routed through `publishSubscriptionStatus`, so the
+/// stored and published value is always the merged one — subscribers never
+/// see the value a writer assigned before granted entitlements and test-mode
+/// overrides were applied. The projected value (`$subscriptionStatus`) replays
+/// the current value to new subscribers, like `@Published`.
+@propertyWrapper
+public struct PublishedSubscriptionStatus {
+  private var storage: SubscriptionStatus
+  private let subject: CurrentValueSubject<SubscriptionStatus, Never>
+
+  public init(wrappedValue: SubscriptionStatus) {
+    storage = wrappedValue
+    subject = CurrentValueSubject(wrappedValue)
+  }
+
+  @available(*, unavailable, message: "Only available on Superwall.")
+  public var wrappedValue: SubscriptionStatus {
+    get { fatalError("subscriptionStatus is only readable on Superwall.") }
+    set { fatalError("\(newValue) can only be assigned on Superwall.") }
+  }
+
+  public var projectedValue: AnyPublisher<SubscriptionStatus, Never> {
+    return subject.eraseToAnyPublisher()
+  }
+
+  public static subscript(
+    _enclosingInstance superwall: Superwall,
+    wrapped wrappedKeyPath: ReferenceWritableKeyPath<Superwall, SubscriptionStatus>,
+    storage storageKeyPath: ReferenceWritableKeyPath<Superwall, PublishedSubscriptionStatus>
+  ) -> SubscriptionStatus {
+    get {
+      return superwall[keyPath: storageKeyPath].storage
+    }
+    set {
+      superwall.publishSubscriptionStatus(assigned: newValue, isDeveloperAssignment: true)
+    }
+  }
+
+  /// Stores a merged status without emitting it.
+  mutating func store(_ merged: SubscriptionStatus) {
+    storage = merged
+  }
+
+  /// Emits a stored status to subscribers.
+  func emit(_ status: SubscriptionStatus) {
+    subject.send(status)
   }
 }

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -63,7 +63,11 @@ extension Superwall {
           ? "Granted entitlements cleared."
           : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
       )
-      publishSubscriptionStatus(assigned: assignedSubscriptionStatus, isDeveloperAssignment: false)
+      publishSubscriptionStatus(
+        assigned: assignedSubscriptionStatus,
+        granted: newValue,
+        isDeveloperAssignment: false
+      )
       refreshAutomaticCustomerInfoAfterGrantChange(granted: newValue)
     }
   }
@@ -77,11 +81,11 @@ extension Superwall {
   /// public setter has to store the raw value before `didSet` can merge it,
   /// which publishes the raw value first.
   func setSubscriptionStatus(assigned status: SubscriptionStatus) {
-    subscriptionStatusLock.lock()
-    defer {
-      subscriptionStatusLock.unlock()
-    }
-    publishSubscriptionStatus(assigned: status, isDeveloperAssignment: false)
+    publishSubscriptionStatus(
+      assigned: status,
+      granted: grantedEntitlements,
+      isDeveloperAssignment: false
+    )
   }
 
   /// Merges web entitlements into the device status and assigns the result,
@@ -121,17 +125,23 @@ extension Superwall {
 
   /// Records `assigned`, publishes the merged status in a single store,
   /// persists the assigned value, and runs the side effects of a change.
-  /// Must be called with `subscriptionStatusLock` held.
+  ///
+  /// Takes `subscriptionStatusLock` itself; callers that already hold it
+  /// (the ``subscriptionStatus`` observers, the ``grantedEntitlements``
+  /// setter) simply recurse.
   ///
   /// `isDeveloperAssignment` is `true` for writes through the public
   /// ``subscriptionStatus`` setter — the only path that warrants warning
   /// about granted entitlements overriding an `.inactive` assignment.
   func publishSubscriptionStatus(
     assigned: SubscriptionStatus,
+    granted: Set<Entitlement>,
     isDeveloperAssignment: Bool
   ) {
-    // Snapshot once: each read hits storage under the lock.
-    let granted = grantedEntitlements
+    subscriptionStatusLock.lock()
+    defer {
+      subscriptionStatusLock.unlock()
+    }
 
     // The status publishes as active regardless, which otherwise looks
     // like the SDK ignored the assignment.

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -141,7 +141,14 @@ extension Superwall {
     var assigned = newAssigned ?? assignedSubscriptionStatus
     if isDeveloperAssignment {
       if case .active(let assignedEntitlements) = assigned {
-        assigned = .active(assignedEntitlements.subtracting(granted))
+        // Compared ignoring product IDs: the merge unions those across a
+        // shared ID, so a grant that won a collision comes back carrying the
+        // loser's product IDs.
+        assigned = .active(
+          assignedEntitlements.filter { record in
+            !granted.contains { $0.isEqualIgnoringProductIds(to: record) }
+          }
+        )
       }
       if case .inactive = assigned,
         !activeGrants.isEmpty,
@@ -190,11 +197,43 @@ extension Superwall {
     // Skip this in test mode — test mode manages its own CustomerInfo.
     if dependencyContainer.makeHasExternalPurchaseController(),
       dependencyContainer.testModeManager?.isTestMode != true {
+      refreshExternalControllerCustomerInfo()
+    }
+  }
+
+  /// A consistent pair of the published status and the granted set, read
+  /// under the lock.
+  private struct PublishedSnapshot: Equatable {
+    let status: SubscriptionStatus
+    let granted: Set<Entitlement>
+  }
+
+  private func publishedSnapshot() -> PublishedSnapshot {
+    subscriptionStatusLock.lock()
+    defer {
+      subscriptionStatusLock.unlock()
+    }
+    return PublishedSnapshot(status: subscriptionStatus, granted: entitlements.granted)
+  }
+
+  /// Recomputes `customerInfo` for the external purchase controller path
+  /// outside the lock, so `$customerInfo` subscribers don't run inside the
+  /// SDK's critical section. It's built from a consistent snapshot and
+  /// rebuilt if either input moved while it ran, so a slower writer can't
+  /// leave a stale customer info behind a newer publish.
+  private func refreshExternalControllerCustomerInfo() {
+    var snapshot = publishedSnapshot()
+    while true {
       customerInfo = CustomerInfo.forExternalPurchaseController(
         storage: dependencyContainer.storage,
-        subscriptionStatus: subscriptionStatus,
-        granted: granted
+        subscriptionStatus: snapshot.status,
+        granted: snapshot.granted
       )
+      let newest = publishedSnapshot()
+      if newest == snapshot {
+        return
+      }
+      snapshot = newest
     }
   }
 
@@ -306,6 +345,10 @@ extension Superwall {
 /// see the value a writer assigned before granted entitlements and test-mode
 /// overrides were applied. The projected value (`$subscriptionStatus`) replays
 /// the current value to new subscribers, like `@Published`.
+///
+/// Public only because a public property's wrapper type has to be; nothing
+/// but the projection is meant to be used. The enclosing-instance subscript
+/// is the same mechanism `@Published` itself uses to reach its owner.
 @propertyWrapper
 public struct PublishedSubscriptionStatus {
   private var storage: SubscriptionStatus

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -60,7 +60,7 @@ extension Superwall {
           ? "Granted entitlements cleared."
           : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
       )
-      publishSubscriptionStatus(assigned: nil, isDeveloperAssignment: false)
+      publishSubscriptionStatus(.grantChange)
       refreshAutomaticCustomerInfoAfterGrantChange()
     }
   }
@@ -73,7 +73,7 @@ extension Superwall {
   /// is the developer's entry point and gets the developer-assignment
   /// treatment described on `publishSubscriptionStatus`.
   func setSubscriptionStatus(assigned status: SubscriptionStatus) {
-    publishSubscriptionStatus(assigned: status, isDeveloperAssignment: false)
+    publishSubscriptionStatus(.sdkAssignment(status))
   }
 
   /// Merges web entitlements into the device status and assigns the result,
@@ -115,21 +115,13 @@ extension Superwall {
   /// assigned value under the lock, then emits the merged status and runs the
   /// remaining side effects outside it.
   ///
-  /// Pass `nil` as `assigned` to re-publish from the current assigned status
-  /// — after a grant change — which is then read under the lock.
-  ///
-  /// `isDeveloperAssignment` is `true` for writes through the public
-  /// ``subscriptionStatus`` setter, which get two extra treatments: records
-  /// identical to a current grant are stripped, because a developer who reads
-  /// the published status and writes it back would otherwise hand the grants
-  /// back as their own and clearing them could never revoke; and an
-  /// `.inactive` assignment while active grants exist logs a one-time
-  /// warning, since the status publishes as active and otherwise looks
-  /// ignored.
-  func publishSubscriptionStatus(
-    assigned newAssigned: SubscriptionStatus?,
-    isDeveloperAssignment: Bool
-  ) {
+  /// A developer assignment gets two extra treatments: records identical to a
+  /// current grant are stripped, because a developer who reads the published
+  /// status and writes it back would otherwise hand the grants back as their
+  /// own and clearing them could never revoke; and an `.inactive` assignment
+  /// while active grants exist logs a one-time warning, since the status
+  /// publishes as active and otherwise looks ignored.
+  func publishSubscriptionStatus(_ change: SubscriptionStatusChange) {
     subscriptionStatusLock.lock()
 
     // Snapshot once, under the lock, so a concurrent grant write can't slip
@@ -138,7 +130,21 @@ extension Superwall {
     let granted = entitlements.granted
     let activeGrants = Entitlement.mergePrioritized(Array(granted.filter(\.isActive)))
 
-    var assigned = newAssigned ?? assignedSubscriptionStatus
+    var assigned: SubscriptionStatus
+    let isDeveloperAssignment: Bool
+    switch change {
+    case .developerAssignment(let status):
+      assigned = status
+      isDeveloperAssignment = true
+    case .sdkAssignment(let status):
+      assigned = status
+      isDeveloperAssignment = false
+    case .grantChange:
+      // The assigned status is unchanged; only the grants merged into it are.
+      assigned = assignedSubscriptionStatus
+      isDeveloperAssignment = false
+    }
+
     if isDeveloperAssignment {
       if case .active(let assignedEntitlements) = assigned {
         // Compared ignoring product IDs: the merge unions those across a

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -218,23 +218,30 @@ extension Superwall {
 
   /// Recomputes `customerInfo` for the external purchase controller path
   /// outside the lock, so `$customerInfo` subscribers don't run inside the
-  /// SDK's critical section. It's built from a consistent snapshot and
-  /// rebuilt if either input moved while it ran, so a slower writer can't
-  /// leave a stale customer info behind a newer publish.
+  /// SDK's critical section. It's built from a consistent snapshot, and
+  /// rebuilt once if either input moved while it ran, so a slower writer
+  /// can't leave a stale customer info behind a newer publish.
+  ///
+  /// The retry is deliberately bounded rather than a loop: this runs
+  /// synchronously on the caller's thread, which can be the main one, and a
+  /// write landing during the rebuild is both vanishingly rare and corrected
+  /// by that write's own publish.
   private func refreshExternalControllerCustomerInfo() {
-    var snapshot = publishedSnapshot()
-    while true {
-      customerInfo = CustomerInfo.forExternalPurchaseController(
-        storage: dependencyContainer.storage,
-        subscriptionStatus: snapshot.status,
-        granted: snapshot.granted
-      )
-      let newest = publishedSnapshot()
-      if newest == snapshot {
-        return
-      }
-      snapshot = newest
+    let snapshot = publishedSnapshot()
+    customerInfo = customerInfo(for: snapshot)
+
+    let newest = publishedSnapshot()
+    if newest != snapshot {
+      customerInfo = customerInfo(for: newest)
     }
+  }
+
+  private func customerInfo(for snapshot: PublishedSnapshot) -> CustomerInfo {
+    return CustomerInfo.forExternalPurchaseController(
+      storage: dependencyContainer.storage,
+      subscriptionStatus: snapshot.status,
+      granted: snapshot.granted
+    )
   }
 
   /// The status the SDK reports for `assigned`: active granted entitlements
@@ -333,62 +340,5 @@ extension Superwall {
           }
         )
       )
-  }
-}
-
-// MARK: - Property wrapper
-
-/// The property wrapper behind ``Superwall/subscriptionStatus``.
-///
-/// Every assignment is routed through `publishSubscriptionStatus`, so the
-/// stored and published value is always the merged one — subscribers never
-/// see the value a writer assigned before granted entitlements and test-mode
-/// overrides were applied. The projected value (`$subscriptionStatus`) replays
-/// the current value to new subscribers, like `@Published`.
-///
-/// Public only because a public property's wrapper type has to be; nothing
-/// but the projection is meant to be used. The enclosing-instance subscript
-/// is the same mechanism `@Published` itself uses to reach its owner.
-@propertyWrapper
-public struct PublishedSubscriptionStatus {
-  private var storage: SubscriptionStatus
-  private let subject: CurrentValueSubject<SubscriptionStatus, Never>
-
-  public init(wrappedValue: SubscriptionStatus) {
-    storage = wrappedValue
-    subject = CurrentValueSubject(wrappedValue)
-  }
-
-  @available(*, unavailable, message: "Only available on Superwall.")
-  public var wrappedValue: SubscriptionStatus {
-    get { fatalError("subscriptionStatus is only readable on Superwall.") }
-    set { fatalError("\(newValue) can only be assigned on Superwall.") }
-  }
-
-  public var projectedValue: AnyPublisher<SubscriptionStatus, Never> {
-    return subject.eraseToAnyPublisher()
-  }
-
-  public static subscript(
-    _enclosingInstance superwall: Superwall,
-    wrapped wrappedKeyPath: ReferenceWritableKeyPath<Superwall, SubscriptionStatus>,
-    storage storageKeyPath: ReferenceWritableKeyPath<Superwall, PublishedSubscriptionStatus>
-  ) -> SubscriptionStatus {
-    get {
-      return superwall[keyPath: storageKeyPath].storage
-    }
-    set {
-      superwall.publishSubscriptionStatus(assigned: newValue, isDeveloperAssignment: true)
-    }
-  }
-
-  /// Stores a merged status without emitting it.
-  mutating func store(_ merged: SubscriptionStatus) {
-    storage = merged
-  }
-
-  /// Emits a stored status to subscribers.
-  func emit(_ status: SubscriptionStatus) {
-    subject.send(status)
   }
 }

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -1,0 +1,292 @@
+//
+//  SubscriptionStatusPublishing.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 2026-09-02.
+//
+
+import Combine
+import Foundation
+
+/// How ``Superwall/subscriptionStatus`` is produced.
+///
+/// Two values are involved:
+/// - The **assigned** status: what a writer handed the SDK — device + web
+///   entitlements on the automatic path, or the developer's own value when
+///   using a purchase controller. Kept in `assignedSubscriptionStatus` and
+///   persisted.
+/// - The **published** status: the assigned status with
+///   ``Superwall/grantedEntitlements`` merged in, any test-mode override
+///   applied, and an empty `.active` collapsed to `.inactive`. This is what
+///   ``Superwall/subscriptionStatus`` holds.
+///
+/// The assigned value is kept because the published one can't be un-merged:
+/// clearing granted entitlements recomputes the published status from it.
+///
+/// Every writer ends up in `publishSubscriptionStatus`, which runs under
+/// `subscriptionStatusLock` so assignments from different threads can't
+/// interleave with the write-back of the merged value.
+extension Superwall {
+  // MARK: - Granted entitlements
+
+  /// Entitlements granted by your own backend that Superwall can't observe,
+  /// which the SDK merges into ``subscriptionStatus`` alongside device and web
+  /// entitlements.
+  ///
+  /// Use this when access is granted outside of the App Store and the web —
+  /// for example, a promotional grant or an account comped by your backend.
+  /// Don't use this if you compute the full subscription picture in a
+  /// `PurchaseController` — in that case set ``subscriptionStatus`` directly,
+  /// otherwise two writers feed one value and the merge will surprise you.
+  ///
+  /// Each assignment replaces the previous value outright — granting `[a]`
+  /// and then `[b]` leaves only `b`. Assign an empty set to revoke.
+  ///
+  /// - Warning: This persists across app launches, ``reset()``, and
+  /// ``identify(userId:options:)``. You must set it again immediately after
+  /// calling `identify()` or `reset()` if the new user shouldn't inherit the
+  /// previous user's granted entitlements.
+  public var grantedEntitlements: Set<Entitlement> {
+    get {
+      return dependencyContainer.storage.get(GrantedEntitlements.self) ?? []
+    }
+    set {
+      subscriptionStatusLock.lock()
+      defer {
+        subscriptionStatusLock.unlock()
+      }
+      dependencyContainer.storage.save(newValue, forType: GrantedEntitlements.self)
+      Logger.debug(
+        logLevel: .info,
+        scope: .grantedEntitlements,
+        message: newValue.isEmpty
+          ? "Granted entitlements cleared."
+          : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
+      )
+      publishSubscriptionStatus(assigned: assignedSubscriptionStatus, isDeveloperAssignment: false)
+      refreshAutomaticCustomerInfoAfterGrantChange(granted: newValue)
+    }
+  }
+
+  // MARK: - Assigning
+
+  /// Assigns a new status and publishes the merged result in a single
+  /// store, so subscribers never observe the un-merged value.
+  ///
+  /// SDK writers use this rather than assigning ``subscriptionStatus``: the
+  /// public setter has to store the raw value before `didSet` can merge it,
+  /// which publishes the raw value first.
+  func setSubscriptionStatus(assigned status: SubscriptionStatus) {
+    subscriptionStatusLock.lock()
+    defer {
+      subscriptionStatusLock.unlock()
+    }
+    publishSubscriptionStatus(assigned: status, isDeveloperAssignment: false)
+  }
+
+  /// Merges web entitlements into the device status and assigns the result,
+  /// if there's no external purchase controller.
+  @MainActor
+  func internallySetSubscriptionStatus(
+    to status: SubscriptionStatus,
+    superwall: Superwall? = nil
+  ) {
+    if dependencyContainer.makeHasExternalPurchaseController() {
+      return
+    }
+    let activeWebEntitlements = dependencyContainer.entitlementsInfo.web
+    let superwall = superwall ?? Superwall.shared
+    let deviceAndWebStatus: SubscriptionStatus
+    switch status {
+    case .active(let entitlements):
+      // Use mergePrioritized to intelligently merge device and web entitlements
+      // This ensures the highest priority version is kept for each entitlement ID
+      let combinedEntitlements = Array(entitlements) + Array(activeWebEntitlements)
+      let mergedEntitlements = Entitlement.mergePrioritized(combinedEntitlements)
+      deviceAndWebStatus = mergedEntitlements.isEmpty ? .inactive : .active(mergedEntitlements)
+    case .inactive:
+      deviceAndWebStatus = activeWebEntitlements.isEmpty ? .inactive : .active(activeWebEntitlements)
+    case .unknown:
+      // Web entitlements deliberately don't promote .unknown to active,
+      // unlike granted entitlements (see mergedSubscriptionStatus). This
+      // branch only runs without an external purchase controller, where the
+      // AutomaticPurchaseController is guaranteed to replace .unknown after
+      // loading purchased products — so .unknown is always transient here.
+      deviceAndWebStatus = .unknown
+    }
+    superwall.setSubscriptionStatus(assigned: deviceAndWebStatus)
+  }
+
+  // MARK: - Publishing
+
+  /// Records `assigned`, publishes the merged status in a single store,
+  /// persists the assigned value, and runs the side effects of a change.
+  /// Must be called with `subscriptionStatusLock` held.
+  ///
+  /// `isDeveloperAssignment` is `true` for writes through the public
+  /// ``subscriptionStatus`` setter — the only path that warrants warning
+  /// about granted entitlements overriding an `.inactive` assignment.
+  func publishSubscriptionStatus(
+    assigned: SubscriptionStatus,
+    isDeveloperAssignment: Bool
+  ) {
+    // Snapshot once: each read hits storage under the lock.
+    let granted = grantedEntitlements
+
+    // The status publishes as active regardless, which otherwise looks
+    // like the SDK ignored the assignment.
+    if isDeveloperAssignment,
+      case .inactive = assigned,
+      !granted.isEmpty,
+      !hasLoggedGrantedEntitlementsWarning {
+      hasLoggedGrantedEntitlementsWarning = true
+      Logger.debug(
+        logLevel: .warn,
+        scope: .grantedEntitlements,
+        message: "subscriptionStatus was set to .inactive but grantedEntitlements "
+          + "is not empty, so the status remains active. Assigning subscriptionStatus "
+          + "doesn't clear granted entitlements — set grantedEntitlements to an empty set to revoke them."
+      )
+    }
+
+    let previouslyAssigned = assignedSubscriptionStatus
+    assignedSubscriptionStatus = assigned
+
+    let merged = mergedSubscriptionStatus(assigned: assigned, granted: granted)
+    if merged != subscriptionStatus {
+      isPublishingSubscriptionStatus = true
+      subscriptionStatus = merged
+      isPublishingSubscriptionStatus = false
+    }
+
+    // Persist the assigned value, not the merged one: restoring a merged
+    // value would bake granted entitlements into the assigned status for
+    // good, making them impossible to clear after a relaunch.
+    //
+    // Saved here rather than in the status listener so that metadata-only
+    // updates, which the listener dedupes, still refresh the cache. Identical
+    // writes are skipped so they don't re-encode and rewrite the file.
+    if previouslyAssigned != assigned {
+      dependencyContainer.storage.save(assigned, forType: SubscriptionStatusKey.self)
+    }
+    entitlements.subscriptionStatusDidSet(subscriptionStatus)
+
+    // When using an external purchase controller, update CustomerInfo.entitlements
+    // to reflect the entitlements from the purchase controller.
+    // Skip this in test mode — test mode manages its own CustomerInfo.
+    if dependencyContainer.makeHasExternalPurchaseController(),
+      dependencyContainer.testModeManager?.isTestMode != true {
+      customerInfo = CustomerInfo.forExternalPurchaseController(
+        storage: dependencyContainer.storage,
+        subscriptionStatus: subscriptionStatus
+      )
+    }
+    publishedSubscriptionStatusSubject.send(subscriptionStatus)
+  }
+
+  /// The status the SDK reports for `assigned`: active granted entitlements
+  /// merged in, any test-mode override applied, and an empty `.active`
+  /// collapsed to `.inactive`.
+  private func mergedSubscriptionStatus(
+    assigned: SubscriptionStatus,
+    granted: Set<Entitlement>
+  ) -> SubscriptionStatus {
+    if let testModeManager = dependencyContainer.testModeManager,
+      testModeManager.isTestMode,
+      let override = testModeManager.overriddenSubscriptionStatus {
+      return override
+    }
+    var status = assigned
+    // Only active grants merge into the status, mirroring how web
+    // entitlements merge (EntitlementsInfo.web filters to active).
+    // Inactive grants still reach customerInfo for round-trip visibility.
+    let activeGrants = Set(granted.filter(\.isActive))
+    if !activeGrants.isEmpty {
+      switch status {
+      case .active(let entitlements):
+        // mergePrioritized explicitly: plain Set.union dedupes by deep
+        // equality, which would keep both records for a shared ID.
+        status = .active(
+          Entitlement.mergePrioritized(Array(entitlements) + Array(activeGrants))
+        )
+      case .inactive, .unknown:
+        // .unknown promotes to active, unlike web entitlements (see
+        // internallySetSubscriptionStatus). With an external purchase
+        // controller the developer is the only writer of the status, so
+        // .unknown can be terminal — without promotion, a developer relying
+        // solely on granted entitlements would be locked out forever.
+        status = .active(activeGrants)
+      }
+    }
+    // This must run after the granted merge, or a developer-assigned
+    // .active([]) would collapse to .inactive before granted is applied.
+    if case .active(let entitlements) = status,
+      entitlements.isEmpty {
+      return .inactive
+    }
+    return status
+  }
+
+  /// Recomputes `customerInfo` on the automatic path after a grant change,
+  /// rebuilding from the stored device and web sources so cleared grants
+  /// actually disappear. The external purchase controller path is recomputed
+  /// inside `publishSubscriptionStatus`; test mode manages its own customer
+  /// info.
+  private func refreshAutomaticCustomerInfoAfterGrantChange(granted: Set<Entitlement>) {
+    if dependencyContainer.makeHasExternalPurchaseController() {
+      return
+    }
+    if dependencyContainer.testModeManager?.isTestMode == true {
+      return
+    }
+    let storage: Storage = dependencyContainer.storage
+    let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
+    let webCustomerInfo = storage.get(LatestRedeemResponse.self)?.customerInfo ?? .blank()
+    customerInfo = deviceCustomerInfo.merging(with: webCustomerInfo, granting: granted)
+  }
+
+  // MARK: - Listening
+
+  func listenToSubscriptionStatus() {
+    // Listens to the published stream rather than $subscriptionStatus so the
+    // delegate and the status-change event never see the transient raw
+    // value that the public setter stores before merging.
+    publishedSubscriptionStatusSubject
+      .prepend(subscriptionStatus)
+      .removeDuplicates { $0.isLogicallyEqual(to: $1) }
+      .dropFirst()
+      .scan((previous: subscriptionStatus, current: subscriptionStatus)) { previousPair, newStatus in
+        // Shift the current value to previous, and set the new status as the current value
+        (previous: previousPair.current, current: newStatus)
+      }
+      .receive(on: DispatchQueue.main)
+      .subscribe(
+        Subscribers.Sink(
+          receiveCompletion: { _ in },
+          receiveValue: { [weak self] statusPair in
+            guard let self = self else {
+              return
+            }
+            let oldStatus = statusPair.previous
+            let newStatus = statusPair.current
+
+            Task {
+              await self.dependencyContainer.delegateAdapter.subscriptionStatusDidChange(
+                from: oldStatus, to: newStatus)
+              let event = InternalSuperwallEvent.SubscriptionStatusDidChange(
+                status: newStatus,
+                grantedEntitlements: self.grantedEntitlements
+              )
+              await self.track(event)
+            }
+            Task {
+              let deviceAttributes = await self.dependencyContainer.makeSessionDeviceAttributes()
+              let deviceAttributesPlacement = InternalSuperwallEvent.DeviceAttributes(
+                deviceAttributes: deviceAttributes)
+              await self.track(deviceAttributesPlacement)
+            }
+          }
+        )
+      )
+  }
+}

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -224,30 +224,24 @@ extension Superwall {
 
   /// Recomputes `customerInfo` for the external purchase controller path
   /// outside the lock, so `$customerInfo` subscribers don't run inside the
-  /// SDK's critical section. It's built from a consistent snapshot, and
-  /// rebuilt once if either input moved while it ran, so a slower writer
-  /// can't leave a stale customer info behind a newer publish.
+  /// SDK's critical section.
   ///
-  /// The retry is deliberately bounded rather than a loop: this runs
-  /// synchronously on the caller's thread, which can be the main one, and a
-  /// write landing during the rebuild is both vanishingly rare and corrected
-  /// by that write's own publish.
+  /// It's built from a consistent snapshot and dropped if a concurrent
+  /// publish moved either input while it ran: that publish runs its own
+  /// refresh with the newer values, so assigning ours would put the older
+  /// customer info last. Uncontended — the normal case, and the only one a
+  /// synchronous read after a status write depends on — the snapshot is
+  /// unchanged and the value is assigned before this returns.
   private func refreshExternalControllerCustomerInfo() {
     let snapshot = publishedSnapshot()
-    customerInfo = customerInfo(for: snapshot)
-
-    let newest = publishedSnapshot()
-    if newest != snapshot {
-      customerInfo = customerInfo(for: newest)
-    }
-  }
-
-  private func customerInfo(for snapshot: PublishedSnapshot) -> CustomerInfo {
-    return CustomerInfo.forExternalPurchaseController(
+    let info = CustomerInfo.forExternalPurchaseController(
       storage: dependencyContainer.storage,
       subscriptionStatus: snapshot.status,
       granted: snapshot.granted
     )
+    if publishedSnapshot() == snapshot {
+      customerInfo = info
+    }
   }
 
   /// The status the SDK reports for `assigned`: active granted entitlements

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -99,11 +99,11 @@ extension Superwall {
     case .inactive:
       deviceAndWebStatus = activeWebEntitlements.isEmpty ? .inactive : .active(activeWebEntitlements)
     case .unknown:
-      // Web entitlements deliberately don't promote .unknown to active,
-      // unlike granted entitlements (see mergedSubscriptionStatus). This
-      // branch only runs without an external purchase controller, where the
-      // AutomaticPurchaseController is guaranteed to replace .unknown after
-      // loading purchased products — so .unknown is always transient here.
+      // Neither web nor granted entitlements turn .unknown into a decision
+      // (see mergedSubscriptionStatus). This branch only runs without an
+      // external purchase controller, where the AutomaticPurchaseController
+      // replaces .unknown after loading purchased products, so it's always
+      // transient here anyway.
       deviceAndWebStatus = .unknown
     }
     superwall.setSubscriptionStatus(assigned: deviceAndWebStatus)
@@ -265,13 +265,15 @@ extension Superwall {
       case .active(let entitlements):
         // Set<Entitlement>.union merges by priority, keeping one record per ID.
         status = .active(entitlements.union(activeGrants))
-      case .inactive, .unknown:
-        // .unknown promotes to active, unlike web entitlements (see
-        // internallySetSubscriptionStatus). With an external purchase
-        // controller the developer is the only writer of the status, so
-        // .unknown can be terminal — without promotion, a developer relying
-        // solely on granted entitlements would be locked out forever.
+      case .inactive:
         status = .active(activeGrants)
+      case .unknown:
+        // Left alone, exactly like web entitlements: .unknown means the
+        // status hasn't been determined yet, and grants don't determine it
+        // — they merge as soon as it is. Reporting active here would open
+        // the paywall presentation gate, which waits for a status other
+        // than .unknown, before a purchase controller has answered.
+        break
       }
     }
     // This must run after the granted merge, or a developer-assigned

--- a/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/SubscriptionStatusPublishing.swift
@@ -63,11 +63,7 @@ extension Superwall {
           ? "Granted entitlements cleared."
           : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
       )
-      publishSubscriptionStatus(
-        assigned: assignedSubscriptionStatus,
-        granted: newValue,
-        isDeveloperAssignment: false
-      )
+      publishSubscriptionStatus(assigned: assignedSubscriptionStatus, isDeveloperAssignment: false)
       refreshAutomaticCustomerInfoAfterGrantChange(granted: newValue)
     }
   }
@@ -81,11 +77,7 @@ extension Superwall {
   /// public setter has to store the raw value before `didSet` can merge it,
   /// which publishes the raw value first.
   func setSubscriptionStatus(assigned status: SubscriptionStatus) {
-    publishSubscriptionStatus(
-      assigned: status,
-      granted: grantedEntitlements,
-      isDeveloperAssignment: false
-    )
+    publishSubscriptionStatus(assigned: status, isDeveloperAssignment: false)
   }
 
   /// Merges web entitlements into the device status and assigns the result,
@@ -128,20 +120,23 @@ extension Superwall {
   ///
   /// Takes `subscriptionStatusLock` itself; callers that already hold it
   /// (the ``subscriptionStatus`` observers, the ``grantedEntitlements``
-  /// setter) simply recurse.
+  /// setter) simply recurse. The granted snapshot is read here, under the
+  /// lock, so a concurrent grant write can't slip between the read and the
+  /// publish.
   ///
   /// `isDeveloperAssignment` is `true` for writes through the public
   /// ``subscriptionStatus`` setter — the only path that warrants warning
   /// about granted entitlements overriding an `.inactive` assignment.
   func publishSubscriptionStatus(
     assigned: SubscriptionStatus,
-    granted: Set<Entitlement>,
     isDeveloperAssignment: Bool
   ) {
     subscriptionStatusLock.lock()
     defer {
       subscriptionStatusLock.unlock()
     }
+    // Snapshot once: the warning check and the merge both need it.
+    let granted = grantedEntitlements
 
     // The status publishes as active regardless, which otherwise looks
     // like the SDK ignored the assignment.

--- a/Sources/SuperwallKit/StoreKit/Purchase Controller/AutomaticPurchaseController.swift
+++ b/Sources/SuperwallKit/StoreKit/Purchase Controller/AutomaticPurchaseController.swift
@@ -62,7 +62,11 @@ final class AutomaticPurchaseController {
         // device-derived entitlements always carry it), so nil is protected
         // too. Entitlements with no expiry date never hold the status, so a
         // revoked lifetime purchase can still deactivate here.
-        if case .active(let currentEntitlements) = superwall.subscriptionStatus {
+        //
+        // The check reads the assigned status (device + web), not the
+        // published one: that also carries developer-granted entitlements,
+        // which would hold a lapsed App Store entitlement in place.
+        if case .active(let currentEntitlements) = superwall.assignedSubscriptionStatus {
           let holdsStatus = currentEntitlements.contains { entitlement in
             guard entitlement.isActive,
               (entitlement.expiresAt ?? .distantPast) > Date() else {

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -211,33 +211,136 @@ public final class Superwall: NSObject, ObservableObject {
   /// Otherwise, you can check the delegate function
   /// ``SuperwallDelegate/subscriptionStatusDidChange(from:to:)``
   /// to receive a callback whenever the logical status changes.
+  ///
+  /// - Warning: If you've set ``grantedEntitlements``, they are merged into
+  /// every value you assign here. Assigning `.inactive` does **not** remove
+  /// them — the status stays active for as long as ``grantedEntitlements``
+  /// contains an active entitlement. To revoke them, set
+  /// ``grantedEntitlements`` to an empty set.
   @Published
   public var subscriptionStatus: SubscriptionStatus = .unknown {
     didSet {
-      let resolved = resolvedSubscriptionStatus(subscriptionStatus)
-      if resolved != subscriptionStatus {
-        subscriptionStatus = resolved
+      if isResolvingSubscriptionStatus {
+        // Write-back of the resolved value from
+        // applySubscriptionStatusResolution, which runs the side effects.
         return
       }
-      // Saved here rather than in the status listener so that metadata-only
-      // updates, which the listener dedupes, still refresh the cache. Identical
-      // writes are skipped so they don't re-encode and rewrite the file.
-      if oldValue != subscriptionStatus {
-        dependencyContainer.storage.save(subscriptionStatus, forType: SubscriptionStatusKey.self)
-      }
-      entitlements.subscriptionStatusDidSet(subscriptionStatus)
-
-      // When using an external purchase controller, update CustomerInfo.entitlements
-      // to reflect the entitlements from the purchase controller.
-      // Skip this in test mode — test mode manages its own CustomerInfo.
-      if dependencyContainer.makeHasExternalPurchaseController(),
-        dependencyContainer.testModeManager?.isTestMode != true {
-        customerInfo = CustomerInfo.forExternalPurchaseController(
-          storage: dependencyContainer.storage,
-          subscriptionStatus: subscriptionStatus
-        )
-      }
+      let oldBase = unresolvedSubscriptionStatus
+      unresolvedSubscriptionStatus = subscriptionStatus
+      logIfGrantedEntitlementsOverrideInactive(subscriptionStatus)
+      applySubscriptionStatusResolution(oldBase: oldBase)
     }
+  }
+
+  /// The last externally assigned subscription status, before resolution
+  /// merges in ``grantedEntitlements`` or test-mode overrides.
+  ///
+  /// Resolution always starts from this base rather than from the published
+  /// value: the published value is already merged, so re-resolving it could
+  /// never remove granted entitlements once the developer clears them.
+  private var unresolvedSubscriptionStatus: SubscriptionStatus = .unknown
+
+  /// Guards the write-back of the resolved status inside
+  /// `applySubscriptionStatusResolution` so `didSet` doesn't mistake it for a
+  /// new external assignment and capture the resolved value as the base.
+  private var isResolvingSubscriptionStatus = false
+
+  /// Whether the one-time warning about granted entitlements overriding an
+  /// `.inactive` assignment has been logged.
+  private var hasLoggedGrantedEntitlementsWarning = false
+
+  /// Entitlements granted by your own backend that Superwall can't observe,
+  /// which the SDK merges into ``subscriptionStatus`` alongside device and web
+  /// entitlements.
+  ///
+  /// Use this when access is granted outside of the App Store and the web —
+  /// for example, a promotional grant or an account comped by your backend.
+  /// Don't use this if you compute the full subscription picture in a
+  /// `PurchaseController` — in that case set ``subscriptionStatus`` directly,
+  /// otherwise two writers feed one value and the merge will surprise you.
+  ///
+  /// Each assignment replaces the previous value outright — granting `[a]`
+  /// and then `[b]` leaves only `b`. Assign an empty set to revoke.
+  ///
+  /// - Warning: This persists across app launches, ``reset()``, and
+  /// ``identify(userId:options:)``. You must set it again immediately after
+  /// calling `identify()` or `reset()` if the new user shouldn't inherit the
+  /// previous user's granted entitlements.
+  public var grantedEntitlements: Set<Entitlement> {
+    get {
+      return dependencyContainer.storage.get(GrantedEntitlements.self) ?? []
+    }
+    set {
+      dependencyContainer.storage.save(newValue, forType: GrantedEntitlements.self)
+      Logger.debug(
+        logLevel: .info,
+        scope: .grantedEntitlements,
+        message: newValue.isEmpty
+          ? "Granted entitlements cleared."
+          : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
+      )
+      applySubscriptionStatusResolution(oldBase: unresolvedSubscriptionStatus)
+    }
+  }
+
+  /// Resolves the subscription status from the unresolved base and publishes
+  /// it, then runs the side effects of a status change.
+  ///
+  /// This is the only writer of the resolved value. It's called from the
+  /// `subscriptionStatus` `didSet` on external assignment and from the
+  /// ``grantedEntitlements`` setter, whose changes must re-resolve the status
+  /// without a new base being assigned.
+  private func applySubscriptionStatusResolution(oldBase: SubscriptionStatus) {
+    let resolved = resolvedSubscriptionStatus(unresolvedSubscriptionStatus)
+    if resolved != subscriptionStatus {
+      isResolvingSubscriptionStatus = true
+      subscriptionStatus = resolved
+      isResolvingSubscriptionStatus = false
+    }
+    // The unresolved base is persisted, not the resolved value: granted
+    // entitlements are merged during resolution, and restoring an
+    // already-merged value would bake them into the base forever, making
+    // them impossible to clear after a relaunch.
+    //
+    // Saved here rather than in the status listener so that metadata-only
+    // updates, which the listener dedupes, still refresh the cache. Identical
+    // writes are skipped so they don't re-encode and rewrite the file.
+    if oldBase != unresolvedSubscriptionStatus {
+      dependencyContainer.storage.save(unresolvedSubscriptionStatus, forType: SubscriptionStatusKey.self)
+    }
+    entitlements.subscriptionStatusDidSet(subscriptionStatus)
+
+    // When using an external purchase controller, update CustomerInfo.entitlements
+    // to reflect the entitlements from the purchase controller.
+    // Skip this in test mode — test mode manages its own CustomerInfo.
+    if dependencyContainer.makeHasExternalPurchaseController(),
+      dependencyContainer.testModeManager?.isTestMode != true {
+      customerInfo = CustomerInfo.forExternalPurchaseController(
+        storage: dependencyContainer.storage,
+        subscriptionStatus: subscriptionStatus
+      )
+    }
+  }
+
+  /// Logs a one-time warning when `.inactive` is assigned to
+  /// `subscriptionStatus` while granted entitlements exist. The status will
+  /// resolve back to active, which otherwise looks like the SDK ignored the
+  /// assignment.
+  private func logIfGrantedEntitlementsOverrideInactive(_ status: SubscriptionStatus) {
+    guard case .inactive = status,
+      !hasLoggedGrantedEntitlementsWarning,
+      !grantedEntitlements.isEmpty
+    else {
+      return
+    }
+    hasLoggedGrantedEntitlementsWarning = true
+    Logger.debug(
+      logLevel: .warn,
+      scope: .grantedEntitlements,
+      message: "subscriptionStatus was set to .inactive but grantedEntitlements "
+        + "is not empty, so the status remains active. Assigning subscriptionStatus "
+        + "doesn't clear granted entitlements — set grantedEntitlements to an empty set to revoke them."
+    )
   }
 
   /// Contains the latest information about all of the customer's purchase and subscription data.
@@ -315,6 +418,11 @@ public final class Superwall: NSObject, ObservableObject {
         superwall.subscriptionStatus = .active(activeWebEntitlements)
       }
     case .unknown:
+      // Web entitlements deliberately don't promote .unknown to active,
+      // unlike granted entitlements (see resolvedSubscriptionStatus). This
+      // branch only runs without an external purchase controller, where the
+      // AutomaticPurchaseController is guaranteed to resolve .unknown after
+      // loading purchased products — so .unknown is always transient here.
       superwall.subscriptionStatus = .unknown
     }
   }
@@ -435,6 +543,23 @@ public final class Superwall: NSObject, ObservableObject {
       let override = testModeManager.overriddenSubscriptionStatus {
       return override
     }
+    var status = status
+    let granted = grantedEntitlements
+    if !granted.isEmpty {
+      switch status {
+      case .active(let entitlements):
+        status = .active(entitlements.union(granted))
+      case .inactive, .unknown:
+        // .unknown promotes to active, unlike web entitlements (see
+        // internallySetSubscriptionStatus). With an external purchase
+        // controller the developer is the only writer of the status, so
+        // .unknown can be terminal — without promotion, a developer relying
+        // solely on granted entitlements would be locked out forever.
+        status = .active(granted)
+      }
+    }
+    // This must run after the granted merge, or a developer-assigned
+    // .active([]) would collapse to .inactive before granted is applied.
     if case .active(let entitlements) = status,
       entitlements.isEmpty {
       return .inactive
@@ -594,7 +719,10 @@ public final class Superwall: NSObject, ObservableObject {
             Task {
               await self.dependencyContainer.delegateAdapter.subscriptionStatusDidChange(
                 from: oldStatus, to: newStatus)
-              let event = InternalSuperwallEvent.SubscriptionStatusDidChange(status: newStatus)
+              let event = InternalSuperwallEvent.SubscriptionStatusDidChange(
+                status: newStatus,
+                grantedEntitlements: self.grantedEntitlements
+              )
               await self.track(event)
             }
             Task {
@@ -1097,7 +1225,19 @@ public final class Superwall: NSObject, ObservableObject {
   // MARK: - Reset
   /// Resets the `userId`, on-device paywall assignments, and data stored
   /// by Superwall.
+  ///
+  /// - Note: ``grantedEntitlements`` are not reset — you own that bucket and
+  /// its lifecycle. Set it again immediately after calling this if the next
+  /// user shouldn't inherit the previous user's granted entitlements.
   public func reset() {
+    if !grantedEntitlements.isEmpty {
+      Logger.debug(
+        logLevel: .warn,
+        scope: .grantedEntitlements,
+        message: "reset() was called but grantedEntitlements persist across reset. "
+          + "Set grantedEntitlements again if the next user shouldn't inherit them."
+      )
+    }
     reset(duringIdentify: false)
   }
 

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -220,6 +220,15 @@ public final class Superwall: NSObject, ObservableObject {
   @Published
   public var subscriptionStatus: SubscriptionStatus = .unknown {
     didSet {
+      // Serializes resolution across threads: without it, an assignment
+      // landing inside another thread's resolved write-back window would be
+      // mistaken for the write-back and silently dropped. The lock is
+      // recursive because the write-back re-enters this didSet on the
+      // same thread.
+      subscriptionStatusResolutionLock.lock()
+      defer {
+        subscriptionStatusResolutionLock.unlock()
+      }
       if isResolvingSubscriptionStatus {
         // Write-back of the resolved value from
         // applySubscriptionStatusResolution, which runs the side effects.
@@ -243,7 +252,13 @@ public final class Superwall: NSObject, ObservableObject {
   /// Guards the write-back of the resolved status inside
   /// `applySubscriptionStatusResolution` so `didSet` doesn't mistake it for a
   /// new external assignment and capture the resolved value as the base.
+  /// Only read and written while `subscriptionStatusResolutionLock` is held.
   private var isResolvingSubscriptionStatus = false
+
+  /// Serializes status resolution so concurrent assignments from different
+  /// threads can't interleave with the resolved write-back. Recursive
+  /// because the write-back re-enters the `subscriptionStatus` `didSet`.
+  private let subscriptionStatusResolutionLock = NSRecursiveLock()
 
   /// Whether the one-time warning about granted entitlements overriding an
   /// `.inactive` assignment has been logged.
@@ -271,6 +286,10 @@ public final class Superwall: NSObject, ObservableObject {
       return dependencyContainer.storage.get(GrantedEntitlements.self) ?? []
     }
     set {
+      subscriptionStatusResolutionLock.lock()
+      defer {
+        subscriptionStatusResolutionLock.unlock()
+      }
       dependencyContainer.storage.save(newValue, forType: GrantedEntitlements.self)
       Logger.debug(
         logLevel: .info,
@@ -280,7 +299,27 @@ public final class Superwall: NSObject, ObservableObject {
           : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
       )
       applySubscriptionStatusResolution(oldBase: unresolvedSubscriptionStatus)
+      refreshAutomaticCustomerInfoAfterGrantChange()
     }
+  }
+
+  /// Recomputes `customerInfo` on the automatic path after a grant change,
+  /// rebuilding from the stored device and web sources so cleared grants
+  /// actually disappear. The external purchase controller path is recomputed
+  /// inside `applySubscriptionStatusResolution`; test mode manages its own
+  /// customer info.
+  private func refreshAutomaticCustomerInfoAfterGrantChange() {
+    if dependencyContainer.makeHasExternalPurchaseController() {
+      return
+    }
+    if dependencyContainer.testModeManager?.isTestMode == true {
+      return
+    }
+    let storage: Storage = dependencyContainer.storage
+    let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
+    let webCustomerInfo = storage.get(LatestRedeemResponse.self)?.customerInfo ?? .blank()
+    customerInfo = deviceCustomerInfo.merging(with: webCustomerInfo)
+      .mergingGrantedEntitlements(from: storage)
   }
 
   /// Resolves the subscription status from the unresolved base and publishes
@@ -544,11 +583,18 @@ public final class Superwall: NSObject, ObservableObject {
       return override
     }
     var status = status
-    let granted = grantedEntitlements
+    // Only active grants merge into the status, mirroring how web
+    // entitlements merge (EntitlementsInfo.web filters to active).
+    // Inactive grants still reach customerInfo for round-trip visibility.
+    let granted = Set(grantedEntitlements.filter(\.isActive))
     if !granted.isEmpty {
       switch status {
       case .active(let entitlements):
-        status = .active(entitlements.union(granted))
+        // mergePrioritized explicitly: plain Set.union dedupes by deep
+        // equality, which would keep both records for a shared ID.
+        status = .active(
+          Entitlement.mergePrioritized(Array(entitlements) + Array(granted))
+        )
       case .inactive, .unknown:
         // .unknown promotes to active, unlike web entitlements (see
         // internallySetSubscriptionStatus). With an external purchase
@@ -1230,19 +1276,21 @@ public final class Superwall: NSObject, ObservableObject {
   /// its lifecycle. Set it again immediately after calling this if the next
   /// user shouldn't inherit the previous user's granted entitlements.
   public func reset() {
-    if !grantedEntitlements.isEmpty {
-      Logger.debug(
-        logLevel: .warn,
-        scope: .grantedEntitlements,
-        message: "reset() was called but grantedEntitlements persist across reset. "
-          + "Set grantedEntitlements again if the next user shouldn't inherit them."
-      )
-    }
     reset(duringIdentify: false)
   }
 
   /// Asynchronously resets. Presentation of paywalls is suspended until reset completes.
   func reset(duringIdentify: Bool) {
+    // Warn here rather than in the public reset() so the identify-triggered
+    // reset — the actual user-switch moment — warns too.
+    if !grantedEntitlements.isEmpty {
+      Logger.debug(
+        logLevel: .warn,
+        scope: .grantedEntitlements,
+        message: "The user was reset but grantedEntitlements persist across reset() "
+          + "and identify(). Set grantedEntitlements again if the new user shouldn't inherit them."
+      )
+    }
     dependencyContainer.identityManager.reset(duringIdentify: duringIdentify)
     // Cancel any in-flight attribution post before wiping its storage, so a
     // late-completing post can't race the new user's state.

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -224,9 +224,6 @@ public final class Superwall: NSObject, ObservableObject {
   public var subscriptionStatus: SubscriptionStatus = .unknown
 
   // MARK: - Subscription status state
-  // The publishing pipeline lives in SubscriptionStatusPublishing.swift; the
-  // stored state it needs, and the two accessors of the wrapper's private
-  // storage, have to live in the class.
 
   /// The status last handed to the SDK — device + web entitlements on the
   /// automatic path, or the developer's value with a purchase controller —

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -240,13 +240,11 @@ public final class Superwall: NSObject, ObservableObject {
         // applySubscriptionStatusResolution, which runs the side effects.
         return
       }
-      let oldBase = unresolvedSubscriptionStatus
-      unresolvedSubscriptionStatus = subscriptionStatus
       // Snapshot once: both the warning check and resolution need the
       // granted set, and each read hits storage under the lock.
       let granted = grantedEntitlements
       logIfGrantedEntitlementsOverrideInactive(subscriptionStatus, granted: granted)
-      applySubscriptionStatusResolution(oldBase: oldBase, granted: granted)
+      resolveSubscriptionStatus(from: subscriptionStatus, granted: granted)
     }
   }
 
@@ -272,6 +270,37 @@ public final class Superwall: NSObject, ObservableObject {
   /// Whether the one-time warning about granted entitlements overriding an
   /// `.inactive` assignment has been logged.
   private var hasLoggedGrantedEntitlementsWarning = false
+
+  /// Emits the resolved status exactly once per base assignment or grant
+  /// change. `$subscriptionStatus` can't serve this purpose: `@Published`
+  /// emits on every store, so a public-setter assignment that resolution
+  /// changes is published twice — the raw value, then the resolved one.
+  private let resolvedSubscriptionStatusSubject = PassthroughSubject<SubscriptionStatus, Never>()
+
+  /// Assigns a new unresolved base and publishes its resolution in a single
+  /// store, so subscribers never observe the unresolved value.
+  ///
+  /// SDK writers use this rather than assigning ``subscriptionStatus``: the
+  /// public setter has to store the raw value before `didSet` can resolve
+  /// it, which publishes the raw value first.
+  func setSubscriptionStatus(base: SubscriptionStatus) {
+    subscriptionStatusResolutionLock.lock()
+    defer {
+      subscriptionStatusResolutionLock.unlock()
+    }
+    resolveSubscriptionStatus(from: base, granted: grantedEntitlements)
+  }
+
+  /// Captures `base` as the unresolved status and resolves from it. Must be
+  /// called with `subscriptionStatusResolutionLock` held.
+  private func resolveSubscriptionStatus(
+    from base: SubscriptionStatus,
+    granted: Set<Entitlement>
+  ) {
+    let oldBase = unresolvedSubscriptionStatus
+    unresolvedSubscriptionStatus = base
+    applySubscriptionStatusResolution(oldBase: oldBase, granted: granted)
+  }
 
   /// Entitlements granted by your own backend that Superwall can't observe,
   /// which the SDK merges into ``subscriptionStatus`` alongside device and web
@@ -307,8 +336,8 @@ public final class Superwall: NSObject, ObservableObject {
           ? "Granted entitlements cleared."
           : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
       )
-      applySubscriptionStatusResolution(oldBase: unresolvedSubscriptionStatus, granted: newValue)
-      refreshAutomaticCustomerInfoAfterGrantChange()
+      resolveSubscriptionStatus(from: unresolvedSubscriptionStatus, granted: newValue)
+      refreshAutomaticCustomerInfoAfterGrantChange(granted: newValue)
     }
   }
 
@@ -317,7 +346,7 @@ public final class Superwall: NSObject, ObservableObject {
   /// actually disappear. The external purchase controller path is recomputed
   /// inside `applySubscriptionStatusResolution`; test mode manages its own
   /// customer info.
-  private func refreshAutomaticCustomerInfoAfterGrantChange() {
+  private func refreshAutomaticCustomerInfoAfterGrantChange(granted: Set<Entitlement>) {
     if dependencyContainer.makeHasExternalPurchaseController() {
       return
     }
@@ -327,8 +356,7 @@ public final class Superwall: NSObject, ObservableObject {
     let storage: Storage = dependencyContainer.storage
     let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
     let webCustomerInfo = storage.get(LatestRedeemResponse.self)?.customerInfo ?? .blank()
-    customerInfo = deviceCustomerInfo.merging(with: webCustomerInfo)
-      .mergingGrantedEntitlements(from: storage)
+    customerInfo = deviceCustomerInfo.merging(with: webCustomerInfo, granting: granted)
   }
 
   /// Resolves the subscription status from the unresolved base and publishes
@@ -371,6 +399,7 @@ public final class Superwall: NSObject, ObservableObject {
         subscriptionStatus: subscriptionStatus
       )
     }
+    resolvedSubscriptionStatusSubject.send(subscriptionStatus)
   }
 
   /// Logs a one-time warning when `.inactive` is assigned to
@@ -454,31 +483,26 @@ public final class Superwall: NSObject, ObservableObject {
     }
     let activeWebEntitlements = dependencyContainer.entitlementsInfo.web
     let superwall = superwall ?? Superwall.shared
+    let deviceAndWebStatus: SubscriptionStatus
     switch status {
     case .active(let entitlements):
       // Use mergePrioritized to intelligently merge device and web entitlements
       // This ensures the highest priority version is kept for each entitlement ID
       let combinedEntitlements = Array(entitlements) + Array(activeWebEntitlements)
       let mergedEntitlements = Entitlement.mergePrioritized(combinedEntitlements)
-      if mergedEntitlements.isEmpty {
-        superwall.subscriptionStatus = .inactive
-      } else {
-        superwall.subscriptionStatus = .active(mergedEntitlements)
-      }
+      deviceAndWebStatus = mergedEntitlements.isEmpty ? .inactive : .active(mergedEntitlements)
     case .inactive:
-      if activeWebEntitlements.isEmpty {
-        superwall.subscriptionStatus = .inactive
-      } else {
-        superwall.subscriptionStatus = .active(activeWebEntitlements)
-      }
+      deviceAndWebStatus = activeWebEntitlements.isEmpty ? .inactive : .active(activeWebEntitlements)
     case .unknown:
       // Web entitlements deliberately don't promote .unknown to active,
       // unlike granted entitlements (see resolvedSubscriptionStatus). This
       // branch only runs without an external purchase controller, where the
       // AutomaticPurchaseController is guaranteed to resolve .unknown after
       // loading purchased products — so .unknown is always transient here.
-      superwall.subscriptionStatus = .unknown
+      deviceAndWebStatus = .unknown
     }
+    // Granted entitlements merge during resolution, from this base.
+    superwall.setSubscriptionStatus(base: deviceAndWebStatus)
   }
 
   /// Returns the subscription status of the user.
@@ -661,7 +685,7 @@ public final class Superwall: NSObject, ObservableObject {
 
     customerInfo = dependencyContainer.storage.get(LatestCustomerInfo.self) ?? .blank()
 
-    subscriptionStatus = dependencyContainer.storage.get(SubscriptionStatusKey.self) ?? .unknown
+    setSubscriptionStatus(base: dependencyContainer.storage.get(SubscriptionStatusKey.self) ?? .unknown)
     dependencyContainer.entitlementsInfo.subscriptionStatusDidSet(subscriptionStatus)
 
     addListeners()
@@ -760,7 +784,11 @@ public final class Superwall: NSObject, ObservableObject {
   }
 
   func listenToSubscriptionStatus() {
-    $subscriptionStatus
+    // Listens to the resolved stream rather than $subscriptionStatus so the
+    // delegate and the status-change event never see the transient raw
+    // value that the public setter stores before resolution.
+    resolvedSubscriptionStatusSubject
+      .prepend(subscriptionStatus)
       .removeDuplicates { $0.isLogicallyEqual(to: $1) }
       .dropFirst()
       .scan((previous: subscriptionStatus, current: subscriptionStatus)) { previousPair, newStatus in

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -233,11 +233,7 @@ public final class Superwall: NSObject, ObservableObject {
         // Our own write-back of the merged value.
         return
       }
-      publishSubscriptionStatus(
-        assigned: subscriptionStatus,
-        granted: grantedEntitlements,
-        isDeveloperAssignment: true
-      )
+      publishSubscriptionStatus(assigned: subscriptionStatus, isDeveloperAssignment: true)
     }
   }
 

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -219,13 +219,19 @@ public final class Superwall: NSObject, ObservableObject {
   /// ``grantedEntitlements`` to an empty set.
   @Published
   public var subscriptionStatus: SubscriptionStatus = .unknown {
-    didSet {
-      // Serializes resolution across threads: without it, an assignment
-      // landing inside another thread's resolved write-back window would be
-      // mistaken for the write-back and silently dropped. The lock is
-      // recursive because the write-back re-enters this didSet on the
-      // same thread.
+    willSet {
+      // Serializes the property store itself, not just the resolution:
+      // didSet has no newValue and must re-read the property, so a store
+      // landing mid-resolution on another thread would be captured as that
+      // thread's base — including the resolved write-back, which would bake
+      // granted entitlements into the persisted base. Locking before the
+      // store makes store + resolution atomic. The lock is recursive
+      // because the write-back re-enters these observers on the same
+      // thread. Released at the end of didSet — the pair must stay
+      // balanced across every didSet exit path.
       subscriptionStatusResolutionLock.lock()
+    }
+    didSet {
       defer {
         subscriptionStatusResolutionLock.unlock()
       }

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -206,7 +206,10 @@ public final class Superwall: NSObject, ObservableObject {
   /// `PurchaseController`, you must set this.
   ///
   /// If you're using Combine or SwiftUI, you can subscribe or bind to it to get
-  /// notified whenever it changes.
+  /// notified whenever it changes. The publisher only ever emits the merged
+  /// status — never a value you assigned before granted entitlements were
+  /// applied. Subscribers are called synchronously on the thread that changed
+  /// the status, so don't block in them.
   ///
   /// Otherwise, you can check the delegate function
   /// ``SuperwallDelegate/subscriptionStatusDidChange(from:to:)``
@@ -217,29 +220,13 @@ public final class Superwall: NSObject, ObservableObject {
   /// them — the status stays active for as long as ``grantedEntitlements``
   /// contains an active entitlement. To revoke them, set
   /// ``grantedEntitlements`` to an empty set.
-  @Published
-  public var subscriptionStatus: SubscriptionStatus = .unknown {
-    willSet {
-      // Locked before the store so the store and the publish in didSet are
-      // atomic across threads — see SubscriptionStatusPublishing.swift.
-      // Released at the end of didSet; the pair must stay balanced.
-      subscriptionStatusLock.lock()
-    }
-    didSet {
-      defer {
-        subscriptionStatusLock.unlock()
-      }
-      if isPublishingSubscriptionStatus {
-        // Our own write-back of the merged value.
-        return
-      }
-      publishSubscriptionStatus(assigned: subscriptionStatus, isDeveloperAssignment: true)
-    }
-  }
+  @PublishedSubscriptionStatus
+  public var subscriptionStatus: SubscriptionStatus = .unknown
 
   // MARK: - Subscription status state
   // The publishing pipeline lives in SubscriptionStatusPublishing.swift; the
-  // stored state it needs has to live in the class.
+  // stored state it needs, and the two accessors of the wrapper's private
+  // storage, have to live in the class.
 
   /// The status last handed to the SDK — device + web entitlements on the
   /// automatic path, or the developer's value with a purchase controller —
@@ -248,24 +235,41 @@ public final class Superwall: NSObject, ObservableObject {
   /// so clearing granted entitlements can recompute it.
   var assignedSubscriptionStatus: SubscriptionStatus = .unknown
 
-  /// Serializes status assignment and publishing across threads. Recursive
-  /// because publishing re-enters the ``subscriptionStatus`` observers on
-  /// the same thread.
+  /// Serializes status assignment and publishing across threads. Recursive so
+  /// a subscriber that assigns the status from within an emission re-enters
+  /// the pipeline instead of deadlocking.
   let subscriptionStatusLock = NSRecursiveLock()
-
-  /// Set while `publishSubscriptionStatus` writes the merged value back, so
-  /// `didSet` doesn't treat that store as a new assignment. Only touched
-  /// with `subscriptionStatusLock` held.
-  var isPublishingSubscriptionStatus = false
-
-  /// Emits the merged status once per assignment or grant change, for the
-  /// status listener. `$subscriptionStatus` also emits the raw value the
-  /// public setter stores before merging, which must not reach the delegate.
-  let publishedSubscriptionStatusSubject = PassthroughSubject<SubscriptionStatus, Never>()
 
   /// Whether the one-time warning about granted entitlements overriding an
   /// `.inactive` assignment has been logged.
   var hasLoggedGrantedEntitlementsWarning = false
+
+  /// Stores the merged status. Only `publishSubscriptionStatus` calls this,
+  /// with `subscriptionStatusLock` held; the emission follows in
+  /// `emitSubscriptionStatus()` once the lock is released.
+  func storeMergedSubscriptionStatus(_ merged: SubscriptionStatus) {
+    objectWillChange.send()
+    _subscriptionStatus.store(merged)
+  }
+
+  /// Emits the stored status to `$subscriptionStatus` subscribers. Called
+  /// after the lock is released, so subscribers never run inside the SDK's
+  /// critical section. A store that landed on another thread between the
+  /// read and the emission is emitted again afterwards, so the publisher's
+  /// current value can't end up behind the stored one.
+  func emitSubscriptionStatus() {
+    subscriptionStatusLock.lock()
+    let emitted = subscriptionStatus
+    subscriptionStatusLock.unlock()
+    _subscriptionStatus.emit(emitted)
+
+    subscriptionStatusLock.lock()
+    let newest = subscriptionStatus
+    subscriptionStatusLock.unlock()
+    if newest != emitted {
+      _subscriptionStatus.emit(newest)
+    }
+  }
 
   /// Contains the latest information about all of the customer's purchase and subscription data.
   ///

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -207,9 +207,9 @@ public final class Superwall: NSObject, ObservableObject {
   ///
   /// If you're using Combine or SwiftUI, you can subscribe or bind to it to get
   /// notified whenever it changes. The publisher only ever emits the merged
-  /// status — never a value you assigned before granted entitlements were
-  /// applied. Subscribers are called synchronously on the thread that changed
-  /// the status, so don't block in them.
+  /// status – never a value you assigned before granted entitlements were
+  /// applied. Subscribers are called on whichever thread changed the status,
+  /// which is often a background one, so use `receive(on:)` before updating UI.
   ///
   /// Otherwise, you can check the delegate function
   /// ``SuperwallDelegate/subscriptionStatusDidChange(from:to:)``

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -220,211 +220,52 @@ public final class Superwall: NSObject, ObservableObject {
   @Published
   public var subscriptionStatus: SubscriptionStatus = .unknown {
     willSet {
-      // Serializes the property store itself, not just the resolution:
-      // didSet has no newValue and must re-read the property, so a store
-      // landing mid-resolution on another thread would be captured as that
-      // thread's base — including the resolved write-back, which would bake
-      // granted entitlements into the persisted base. Locking before the
-      // store makes store + resolution atomic. The lock is recursive
-      // because the write-back re-enters these observers on the same
-      // thread. Released at the end of didSet — the pair must stay
-      // balanced across every didSet exit path.
-      subscriptionStatusResolutionLock.lock()
+      // Locked before the store so the store and the publish in didSet are
+      // atomic across threads — see SubscriptionStatusPublishing.swift.
+      // Released at the end of didSet; the pair must stay balanced.
+      subscriptionStatusLock.lock()
     }
     didSet {
       defer {
-        subscriptionStatusResolutionLock.unlock()
+        subscriptionStatusLock.unlock()
       }
-      if isResolvingSubscriptionStatus {
-        // Write-back of the resolved value from
-        // applySubscriptionStatusResolution, which runs the side effects.
+      if isPublishingSubscriptionStatus {
+        // Our own write-back of the merged value.
         return
       }
-      // Snapshot once: both the warning check and resolution need the
-      // granted set, and each read hits storage under the lock.
-      let granted = grantedEntitlements
-      logIfGrantedEntitlementsOverrideInactive(subscriptionStatus, granted: granted)
-      resolveSubscriptionStatus(from: subscriptionStatus, granted: granted)
+      publishSubscriptionStatus(assigned: subscriptionStatus, isDeveloperAssignment: true)
     }
   }
 
-  /// The last externally assigned subscription status, before resolution
-  /// merges in ``grantedEntitlements`` or test-mode overrides.
-  ///
-  /// Resolution always starts from this base rather than from the published
-  /// value: the published value is already merged, so re-resolving it could
-  /// never remove granted entitlements once the developer clears them.
-  private var unresolvedSubscriptionStatus: SubscriptionStatus = .unknown
+  // MARK: - Subscription status state
+  // The publishing pipeline lives in SubscriptionStatusPublishing.swift; the
+  // stored state it needs has to live in the class.
 
-  /// Guards the write-back of the resolved status inside
-  /// `applySubscriptionStatusResolution` so `didSet` doesn't mistake it for a
-  /// new external assignment and capture the resolved value as the base.
-  /// Only read and written while `subscriptionStatusResolutionLock` is held.
-  private var isResolvingSubscriptionStatus = false
+  /// The status last handed to the SDK — device + web entitlements on the
+  /// automatic path, or the developer's value with a purchase controller —
+  /// before granted entitlements and test-mode overrides are merged in.
+  /// ``subscriptionStatus`` is always derived from this, never the reverse,
+  /// so clearing granted entitlements can recompute it.
+  var assignedSubscriptionStatus: SubscriptionStatus = .unknown
 
-  /// Serializes status resolution so concurrent assignments from different
-  /// threads can't interleave with the resolved write-back. Recursive
-  /// because the write-back re-enters the `subscriptionStatus` `didSet`.
-  private let subscriptionStatusResolutionLock = NSRecursiveLock()
+  /// Serializes status assignment and publishing across threads. Recursive
+  /// because publishing re-enters the ``subscriptionStatus`` observers on
+  /// the same thread.
+  let subscriptionStatusLock = NSRecursiveLock()
+
+  /// Set while `publishSubscriptionStatus` writes the merged value back, so
+  /// `didSet` doesn't treat that store as a new assignment. Only touched
+  /// with `subscriptionStatusLock` held.
+  var isPublishingSubscriptionStatus = false
+
+  /// Emits the merged status once per assignment or grant change, for the
+  /// status listener. `$subscriptionStatus` also emits the raw value the
+  /// public setter stores before merging, which must not reach the delegate.
+  let publishedSubscriptionStatusSubject = PassthroughSubject<SubscriptionStatus, Never>()
 
   /// Whether the one-time warning about granted entitlements overriding an
   /// `.inactive` assignment has been logged.
-  private var hasLoggedGrantedEntitlementsWarning = false
-
-  /// Emits the resolved status exactly once per base assignment or grant
-  /// change. `$subscriptionStatus` can't serve this purpose: `@Published`
-  /// emits on every store, so a public-setter assignment that resolution
-  /// changes is published twice — the raw value, then the resolved one.
-  private let resolvedSubscriptionStatusSubject = PassthroughSubject<SubscriptionStatus, Never>()
-
-  /// Assigns a new unresolved base and publishes its resolution in a single
-  /// store, so subscribers never observe the unresolved value.
-  ///
-  /// SDK writers use this rather than assigning ``subscriptionStatus``: the
-  /// public setter has to store the raw value before `didSet` can resolve
-  /// it, which publishes the raw value first.
-  func setSubscriptionStatus(base: SubscriptionStatus) {
-    subscriptionStatusResolutionLock.lock()
-    defer {
-      subscriptionStatusResolutionLock.unlock()
-    }
-    resolveSubscriptionStatus(from: base, granted: grantedEntitlements)
-  }
-
-  /// Captures `base` as the unresolved status and resolves from it. Must be
-  /// called with `subscriptionStatusResolutionLock` held.
-  private func resolveSubscriptionStatus(
-    from base: SubscriptionStatus,
-    granted: Set<Entitlement>
-  ) {
-    let oldBase = unresolvedSubscriptionStatus
-    unresolvedSubscriptionStatus = base
-    applySubscriptionStatusResolution(oldBase: oldBase, granted: granted)
-  }
-
-  /// Entitlements granted by your own backend that Superwall can't observe,
-  /// which the SDK merges into ``subscriptionStatus`` alongside device and web
-  /// entitlements.
-  ///
-  /// Use this when access is granted outside of the App Store and the web —
-  /// for example, a promotional grant or an account comped by your backend.
-  /// Don't use this if you compute the full subscription picture in a
-  /// `PurchaseController` — in that case set ``subscriptionStatus`` directly,
-  /// otherwise two writers feed one value and the merge will surprise you.
-  ///
-  /// Each assignment replaces the previous value outright — granting `[a]`
-  /// and then `[b]` leaves only `b`. Assign an empty set to revoke.
-  ///
-  /// - Warning: This persists across app launches, ``reset()``, and
-  /// ``identify(userId:options:)``. You must set it again immediately after
-  /// calling `identify()` or `reset()` if the new user shouldn't inherit the
-  /// previous user's granted entitlements.
-  public var grantedEntitlements: Set<Entitlement> {
-    get {
-      return dependencyContainer.storage.get(GrantedEntitlements.self) ?? []
-    }
-    set {
-      subscriptionStatusResolutionLock.lock()
-      defer {
-        subscriptionStatusResolutionLock.unlock()
-      }
-      dependencyContainer.storage.save(newValue, forType: GrantedEntitlements.self)
-      Logger.debug(
-        logLevel: .info,
-        scope: .grantedEntitlements,
-        message: newValue.isEmpty
-          ? "Granted entitlements cleared."
-          : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
-      )
-      resolveSubscriptionStatus(from: unresolvedSubscriptionStatus, granted: newValue)
-      refreshAutomaticCustomerInfoAfterGrantChange(granted: newValue)
-    }
-  }
-
-  /// Recomputes `customerInfo` on the automatic path after a grant change,
-  /// rebuilding from the stored device and web sources so cleared grants
-  /// actually disappear. The external purchase controller path is recomputed
-  /// inside `applySubscriptionStatusResolution`; test mode manages its own
-  /// customer info.
-  private func refreshAutomaticCustomerInfoAfterGrantChange(granted: Set<Entitlement>) {
-    if dependencyContainer.makeHasExternalPurchaseController() {
-      return
-    }
-    if dependencyContainer.testModeManager?.isTestMode == true {
-      return
-    }
-    let storage: Storage = dependencyContainer.storage
-    let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
-    let webCustomerInfo = storage.get(LatestRedeemResponse.self)?.customerInfo ?? .blank()
-    customerInfo = deviceCustomerInfo.merging(with: webCustomerInfo, granting: granted)
-  }
-
-  /// Resolves the subscription status from the unresolved base and publishes
-  /// it, then runs the side effects of a status change.
-  ///
-  /// This is the only writer of the resolved value. It's called from the
-  /// `subscriptionStatus` `didSet` on external assignment and from the
-  /// ``grantedEntitlements`` setter, whose changes must re-resolve the status
-  /// without a new base being assigned.
-  private func applySubscriptionStatusResolution(
-    oldBase: SubscriptionStatus,
-    granted: Set<Entitlement>
-  ) {
-    let resolved = resolvedSubscriptionStatus(unresolvedSubscriptionStatus, granted: granted)
-    if resolved != subscriptionStatus {
-      isResolvingSubscriptionStatus = true
-      subscriptionStatus = resolved
-      isResolvingSubscriptionStatus = false
-    }
-    // The unresolved base is persisted, not the resolved value: granted
-    // entitlements are merged during resolution, and restoring an
-    // already-merged value would bake them into the base forever, making
-    // them impossible to clear after a relaunch.
-    //
-    // Saved here rather than in the status listener so that metadata-only
-    // updates, which the listener dedupes, still refresh the cache. Identical
-    // writes are skipped so they don't re-encode and rewrite the file.
-    if oldBase != unresolvedSubscriptionStatus {
-      dependencyContainer.storage.save(unresolvedSubscriptionStatus, forType: SubscriptionStatusKey.self)
-    }
-    entitlements.subscriptionStatusDidSet(subscriptionStatus)
-
-    // When using an external purchase controller, update CustomerInfo.entitlements
-    // to reflect the entitlements from the purchase controller.
-    // Skip this in test mode — test mode manages its own CustomerInfo.
-    if dependencyContainer.makeHasExternalPurchaseController(),
-      dependencyContainer.testModeManager?.isTestMode != true {
-      customerInfo = CustomerInfo.forExternalPurchaseController(
-        storage: dependencyContainer.storage,
-        subscriptionStatus: subscriptionStatus
-      )
-    }
-    resolvedSubscriptionStatusSubject.send(subscriptionStatus)
-  }
-
-  /// Logs a one-time warning when `.inactive` is assigned to
-  /// `subscriptionStatus` while granted entitlements exist. The status will
-  /// resolve back to active, which otherwise looks like the SDK ignored the
-  /// assignment.
-  private func logIfGrantedEntitlementsOverrideInactive(
-    _ status: SubscriptionStatus,
-    granted: Set<Entitlement>
-  ) {
-    guard case .inactive = status,
-      !hasLoggedGrantedEntitlementsWarning,
-      !granted.isEmpty
-    else {
-      return
-    }
-    hasLoggedGrantedEntitlementsWarning = true
-    Logger.debug(
-      logLevel: .warn,
-      scope: .grantedEntitlements,
-      message: "subscriptionStatus was set to .inactive but grantedEntitlements "
-        + "is not empty, so the status remains active. Assigning subscriptionStatus "
-        + "doesn't clear granted entitlements — set grantedEntitlements to an empty set to revoke them."
-    )
-  }
+  var hasLoggedGrantedEntitlementsWarning = false
 
   /// Contains the latest information about all of the customer's purchase and subscription data.
   ///
@@ -469,40 +310,6 @@ public final class Superwall: NSObject, ObservableObject {
   /// Gets properties stored about the device that are used in audience filters.
   public func getDeviceAttributes() async -> [String: Any] {
     return await dependencyContainer.deviceHelper.getTemplateDevice()
-  }
-
-  /// Gets web entitlements and merges them with device entitlements before
-  /// setting the status if no external purchase controller.
-  @MainActor
-  func internallySetSubscriptionStatus(
-    to status: SubscriptionStatus,
-    superwall: Superwall? = nil
-  ) {
-    if dependencyContainer.makeHasExternalPurchaseController() {
-      return
-    }
-    let activeWebEntitlements = dependencyContainer.entitlementsInfo.web
-    let superwall = superwall ?? Superwall.shared
-    let deviceAndWebStatus: SubscriptionStatus
-    switch status {
-    case .active(let entitlements):
-      // Use mergePrioritized to intelligently merge device and web entitlements
-      // This ensures the highest priority version is kept for each entitlement ID
-      let combinedEntitlements = Array(entitlements) + Array(activeWebEntitlements)
-      let mergedEntitlements = Entitlement.mergePrioritized(combinedEntitlements)
-      deviceAndWebStatus = mergedEntitlements.isEmpty ? .inactive : .active(mergedEntitlements)
-    case .inactive:
-      deviceAndWebStatus = activeWebEntitlements.isEmpty ? .inactive : .active(activeWebEntitlements)
-    case .unknown:
-      // Web entitlements deliberately don't promote .unknown to active,
-      // unlike granted entitlements (see resolvedSubscriptionStatus). This
-      // branch only runs without an external purchase controller, where the
-      // AutomaticPurchaseController is guaranteed to resolve .unknown after
-      // loading purchased products — so .unknown is always transient here.
-      deviceAndWebStatus = .unknown
-    }
-    // Granted entitlements merge during resolution, from this base.
-    superwall.setSubscriptionStatus(base: deviceAndWebStatus)
   }
 
   /// Returns the subscription status of the user.
@@ -613,46 +420,6 @@ public final class Superwall: NSObject, ObservableObject {
 
   // MARK: - Value Resolution
 
-  private func resolvedSubscriptionStatus(
-    _ status: SubscriptionStatus,
-    granted: Set<Entitlement>
-  ) -> SubscriptionStatus {
-    if let testModeManager = dependencyContainer.testModeManager,
-      testModeManager.isTestMode,
-      let override = testModeManager.overriddenSubscriptionStatus {
-      return override
-    }
-    var status = status
-    // Only active grants merge into the status, mirroring how web
-    // entitlements merge (EntitlementsInfo.web filters to active).
-    // Inactive grants still reach customerInfo for round-trip visibility.
-    let granted = Set(granted.filter(\.isActive))
-    if !granted.isEmpty {
-      switch status {
-      case .active(let entitlements):
-        // mergePrioritized explicitly: plain Set.union dedupes by deep
-        // equality, which would keep both records for a shared ID.
-        status = .active(
-          Entitlement.mergePrioritized(Array(entitlements) + Array(granted))
-        )
-      case .inactive, .unknown:
-        // .unknown promotes to active, unlike web entitlements (see
-        // internallySetSubscriptionStatus). With an external purchase
-        // controller the developer is the only writer of the status, so
-        // .unknown can be terminal — without promotion, a developer relying
-        // solely on granted entitlements would be locked out forever.
-        status = .active(granted)
-      }
-    }
-    // This must run after the granted merge, or a developer-assigned
-    // .active([]) would collapse to .inactive before granted is applied.
-    if case .active(let entitlements) = status,
-      entitlements.isEmpty {
-      return .inactive
-    }
-    return status
-  }
-
   private func resolvedCustomerInfo(
     _ info: CustomerInfo
   ) -> CustomerInfo {
@@ -685,7 +452,7 @@ public final class Superwall: NSObject, ObservableObject {
 
     customerInfo = dependencyContainer.storage.get(LatestCustomerInfo.self) ?? .blank()
 
-    setSubscriptionStatus(base: dependencyContainer.storage.get(SubscriptionStatusKey.self) ?? .unknown)
+    setSubscriptionStatus(assigned: dependencyContainer.storage.get(SubscriptionStatusKey.self) ?? .unknown)
     dependencyContainer.entitlementsInfo.subscriptionStatusDidSet(subscriptionStatus)
 
     addListeners()
@@ -781,49 +548,6 @@ public final class Superwall: NSObject, ObservableObject {
             }
           }
         ))
-  }
-
-  func listenToSubscriptionStatus() {
-    // Listens to the resolved stream rather than $subscriptionStatus so the
-    // delegate and the status-change event never see the transient raw
-    // value that the public setter stores before resolution.
-    resolvedSubscriptionStatusSubject
-      .prepend(subscriptionStatus)
-      .removeDuplicates { $0.isLogicallyEqual(to: $1) }
-      .dropFirst()
-      .scan((previous: subscriptionStatus, current: subscriptionStatus)) { previousPair, newStatus in
-        // Shift the current value to previous, and set the new status as the current value
-        (previous: previousPair.current, current: newStatus)
-      }
-      .receive(on: DispatchQueue.main)
-      .subscribe(
-        Subscribers.Sink(
-          receiveCompletion: { _ in },
-          receiveValue: { [weak self] statusPair in
-            guard let self = self else {
-              return
-            }
-            let oldStatus = statusPair.previous
-            let newStatus = statusPair.current
-
-            Task {
-              await self.dependencyContainer.delegateAdapter.subscriptionStatusDidChange(
-                from: oldStatus, to: newStatus)
-              let event = InternalSuperwallEvent.SubscriptionStatusDidChange(
-                status: newStatus,
-                grantedEntitlements: self.grantedEntitlements
-              )
-              await self.track(event)
-            }
-            Task {
-              let deviceAttributes = await self.dependencyContainer.makeSessionDeviceAttributes()
-              let deviceAttributesPlacement = InternalSuperwallEvent.DeviceAttributes(
-                deviceAttributes: deviceAttributes)
-              await self.track(deviceAttributesPlacement)
-            }
-          }
-        )
-      )
   }
 
   private func listenToCustomerInfo() {

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -242,8 +242,11 @@ public final class Superwall: NSObject, ObservableObject {
       }
       let oldBase = unresolvedSubscriptionStatus
       unresolvedSubscriptionStatus = subscriptionStatus
-      logIfGrantedEntitlementsOverrideInactive(subscriptionStatus)
-      applySubscriptionStatusResolution(oldBase: oldBase)
+      // Snapshot once: both the warning check and resolution need the
+      // granted set, and each read hits storage under the lock.
+      let granted = grantedEntitlements
+      logIfGrantedEntitlementsOverrideInactive(subscriptionStatus, granted: granted)
+      applySubscriptionStatusResolution(oldBase: oldBase, granted: granted)
     }
   }
 
@@ -304,7 +307,7 @@ public final class Superwall: NSObject, ObservableObject {
           ? "Granted entitlements cleared."
           : "Granted entitlements set: \(newValue.map(\.id).sorted().joined(separator: ", "))"
       )
-      applySubscriptionStatusResolution(oldBase: unresolvedSubscriptionStatus)
+      applySubscriptionStatusResolution(oldBase: unresolvedSubscriptionStatus, granted: newValue)
       refreshAutomaticCustomerInfoAfterGrantChange()
     }
   }
@@ -335,8 +338,11 @@ public final class Superwall: NSObject, ObservableObject {
   /// `subscriptionStatus` `didSet` on external assignment and from the
   /// ``grantedEntitlements`` setter, whose changes must re-resolve the status
   /// without a new base being assigned.
-  private func applySubscriptionStatusResolution(oldBase: SubscriptionStatus) {
-    let resolved = resolvedSubscriptionStatus(unresolvedSubscriptionStatus)
+  private func applySubscriptionStatusResolution(
+    oldBase: SubscriptionStatus,
+    granted: Set<Entitlement>
+  ) {
+    let resolved = resolvedSubscriptionStatus(unresolvedSubscriptionStatus, granted: granted)
     if resolved != subscriptionStatus {
       isResolvingSubscriptionStatus = true
       subscriptionStatus = resolved
@@ -371,10 +377,13 @@ public final class Superwall: NSObject, ObservableObject {
   /// `subscriptionStatus` while granted entitlements exist. The status will
   /// resolve back to active, which otherwise looks like the SDK ignored the
   /// assignment.
-  private func logIfGrantedEntitlementsOverrideInactive(_ status: SubscriptionStatus) {
+  private func logIfGrantedEntitlementsOverrideInactive(
+    _ status: SubscriptionStatus,
+    granted: Set<Entitlement>
+  ) {
     guard case .inactive = status,
       !hasLoggedGrantedEntitlementsWarning,
-      !grantedEntitlements.isEmpty
+      !granted.isEmpty
     else {
       return
     }
@@ -581,7 +590,8 @@ public final class Superwall: NSObject, ObservableObject {
   // MARK: - Value Resolution
 
   private func resolvedSubscriptionStatus(
-    _ status: SubscriptionStatus
+    _ status: SubscriptionStatus,
+    granted: Set<Entitlement>
   ) -> SubscriptionStatus {
     if let testModeManager = dependencyContainer.testModeManager,
       testModeManager.isTestMode,
@@ -592,7 +602,7 @@ public final class Superwall: NSObject, ObservableObject {
     // Only active grants merge into the status, mirroring how web
     // entitlements merge (EntitlementsInfo.web filters to active).
     // Inactive grants still reach customerInfo for round-trip visibility.
-    let granted = Set(grantedEntitlements.filter(\.isActive))
+    let granted = Set(granted.filter(\.isActive))
     if !granted.isEmpty {
       switch status {
       case .active(let entitlements):

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -233,7 +233,11 @@ public final class Superwall: NSObject, ObservableObject {
         // Our own write-back of the merged value.
         return
       }
-      publishSubscriptionStatus(assigned: subscriptionStatus, isDeveloperAssignment: true)
+      publishSubscriptionStatus(
+        assigned: subscriptionStatus,
+        granted: grantedEntitlements,
+        isDeveloperAssignment: true
+      )
     }
   }
 

--- a/Sources/SuperwallKit/TestMode/TestModeTransactionHandler.swift
+++ b/Sources/SuperwallKit/TestMode/TestModeTransactionHandler.swift
@@ -78,10 +78,10 @@ final class TestModeTransactionHandler {
       if hasActiveEntitlements {
         let status = SubscriptionStatus.active(entitlementSet)
         testModeManager.overriddenSubscriptionStatus = status
-        Superwall.shared.subscriptionStatus = status
+        Superwall.shared.setSubscriptionStatus(base: status)
       } else {
         testModeManager.overriddenSubscriptionStatus = .inactive
-        Superwall.shared.subscriptionStatus = .inactive
+        Superwall.shared.setSubscriptionStatus(base: .inactive)
       }
 
       // Track free trial start if free trial is shown (respecting override)
@@ -147,7 +147,7 @@ final class TestModeTransactionHandler {
         testModeManager.overriddenCustomerInfo = customerInfo
         Superwall.shared.customerInfo = customerInfo
         testModeManager.overriddenSubscriptionStatus = .inactive
-        Superwall.shared.subscriptionStatus = .inactive
+        Superwall.shared.setSubscriptionStatus(base: .inactive)
       } else {
         // Update test mode manager with selected entitlement IDs
         let activeIds = Set(entitlements.map { $0.id })
@@ -164,10 +164,10 @@ final class TestModeTransactionHandler {
         if hasActive {
           let status = SubscriptionStatus.active(entitlements)
           testModeManager.overriddenSubscriptionStatus = status
-          Superwall.shared.subscriptionStatus = status
+          Superwall.shared.setSubscriptionStatus(base: status)
         } else {
           testModeManager.overriddenSubscriptionStatus = .inactive
-          Superwall.shared.subscriptionStatus = .inactive
+          Superwall.shared.setSubscriptionStatus(base: .inactive)
         }
       }
 

--- a/Sources/SuperwallKit/TestMode/TestModeTransactionHandler.swift
+++ b/Sources/SuperwallKit/TestMode/TestModeTransactionHandler.swift
@@ -78,10 +78,10 @@ final class TestModeTransactionHandler {
       if hasActiveEntitlements {
         let status = SubscriptionStatus.active(entitlementSet)
         testModeManager.overriddenSubscriptionStatus = status
-        Superwall.shared.setSubscriptionStatus(base: status)
+        Superwall.shared.setSubscriptionStatus(assigned: status)
       } else {
         testModeManager.overriddenSubscriptionStatus = .inactive
-        Superwall.shared.setSubscriptionStatus(base: .inactive)
+        Superwall.shared.setSubscriptionStatus(assigned: .inactive)
       }
 
       // Track free trial start if free trial is shown (respecting override)
@@ -147,7 +147,7 @@ final class TestModeTransactionHandler {
         testModeManager.overriddenCustomerInfo = customerInfo
         Superwall.shared.customerInfo = customerInfo
         testModeManager.overriddenSubscriptionStatus = .inactive
-        Superwall.shared.setSubscriptionStatus(base: .inactive)
+        Superwall.shared.setSubscriptionStatus(assigned: .inactive)
       } else {
         // Update test mode manager with selected entitlement IDs
         let activeIds = Set(entitlements.map { $0.id })
@@ -164,10 +164,10 @@ final class TestModeTransactionHandler {
         if hasActive {
           let status = SubscriptionStatus.active(entitlements)
           testModeManager.overriddenSubscriptionStatus = status
-          Superwall.shared.setSubscriptionStatus(base: status)
+          Superwall.shared.setSubscriptionStatus(assigned: status)
         } else {
           testModeManager.overriddenSubscriptionStatus = .inactive
-          Superwall.shared.setSubscriptionStatus(base: .inactive)
+          Superwall.shared.setSubscriptionStatus(assigned: .inactive)
         }
       }
 

--- a/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
+++ b/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
@@ -522,14 +522,14 @@ actor WebEntitlementRedeemer {
       let subscriptionStatus = await MainActor.run { superwall.subscriptionStatus }
       mergedCustomerInfo = CustomerInfo.forExternalPurchaseController(
         storage: storage,
-        subscriptionStatus: subscriptionStatus
+        subscriptionStatus: subscriptionStatus,
+        granted: entitlementsInfo.granted
       )
     } else {
       let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
-      let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
       mergedCustomerInfo = deviceCustomerInfo.merging(
         with: webCustomerInfo,
-        granting: grantedEntitlements
+        granting: entitlementsInfo.granted
       )
     }
 
@@ -978,20 +978,22 @@ actor WebEntitlementRedeemer {
           return
         }
 
-        let mergedCustomerInfo = await mergeAndApplyCustomerInfo(
+        _ = await mergeAndApplyCustomerInfo(
           webCustomerInfo: response.customerInfo,
           superwall: superwall
         )
 
-        let activeEntitlements = Set(mergedCustomerInfo.entitlements.filter { $0.isActive })
-        if activeEntitlements.isEmpty {
-          await superwall.internallySetSubscriptionStatus(to: .inactive, superwall: superwall)
-        } else {
-          await superwall.internallySetSubscriptionStatus(
-            to: .active(activeEntitlements),
-            superwall: superwall
-          )
-        }
+        // Derive the status from device + web only, as the redeem path does.
+        // The merged customer info also carries granted entitlements, which
+        // are applied when the status publishes and must never enter the
+        // assigned status — or clearing them could never revoke them.
+        let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
+        let activeDeviceEntitlements = Set(deviceCustomerInfo.entitlements.filter { $0.isActive })
+        let deviceAndWebEntitlements = activeDeviceEntitlements.union(
+          Set(response.customerInfo.entitlements)
+        )
+        let activeEntitlements = deviceAndWebEntitlements.filter { $0.isActive }
+        await updateSubscriptionStatus(with: deviceAndWebEntitlements, superwall: superwall)
 
         // If there's a paywall, check if we should dismiss it
         if let paywallVc = superwall.paywallViewController {

--- a/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
+++ b/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
@@ -527,6 +527,7 @@ actor WebEntitlementRedeemer {
     } else {
       let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
       mergedCustomerInfo = deviceCustomerInfo.merging(with: webCustomerInfo)
+        .mergingGrantedEntitlements(from: storage)
     }
 
     await MainActor.run {

--- a/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
+++ b/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
@@ -526,8 +526,11 @@ actor WebEntitlementRedeemer {
       )
     } else {
       let deviceCustomerInfo = storage.get(LatestDeviceCustomerInfo.self) ?? .blank()
-      mergedCustomerInfo = deviceCustomerInfo.merging(with: webCustomerInfo)
-        .mergingGrantedEntitlements(from: storage)
+      let grantedEntitlements = storage.get(GrantedEntitlements.self) ?? []
+      mergedCustomerInfo = deviceCustomerInfo.merging(
+        with: webCustomerInfo,
+        granting: grantedEntitlements
+      )
     }
 
     await MainActor.run {

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.16.4"
+  s.version      = "4.17.0"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 		E0F3648081AB86077201EB5D /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83416F0F1B5294C350D5CF70 /* FeatureFlags.swift */; };
 		E0F69E406F64A1160FF55BFA /* SWProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B6F98BADD9EC96A978E40 /* SWProduct.swift */; };
 		E1A838C9CE62C9479D0C68F4 /* SWDebugManagerLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C733A9BE56EA9E10D75B073B /* SWDebugManagerLogicTests.swift */; };
+		E20B1214CA9785C0D0C7AD7A /* PublishedSubscriptionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328C01066B84891ECF4B7F34 /* PublishedSubscriptionStatus.swift */; };
 		E2E0E2A82200943E73E3A92A /* AppSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A767F107FB1FBBC2F22DB3 /* AppSessionManagerTests.swift */; };
 		E315F3C6BBCA8582BF540086 /* GetExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE5DAD3AB51C8C6B5AB88D2 /* GetExperiment.swift */; };
 		E3DC0E7597234DC8CC508A33 /* MapSwiftErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D80A7C5B8A17B83C218656 /* MapSwiftErrors.swift */; };
@@ -720,6 +721,7 @@
 		311D187DE8B8A5D0699F31A2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		320AA5349848F696950F441A /* IdentityOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityOptions.swift; sourceTree = "<group>"; };
 		323B5E3D7E69FB3E718EED02 /* TestModeModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModeModal.swift; sourceTree = "<group>"; };
+		328C01066B84891ECF4B7F34 /* PublishedSubscriptionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedSubscriptionStatus.swift; sourceTree = "<group>"; };
 		335888285131F832E1C91A8F /* Dictionary+Merging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Merging.swift"; sourceTree = "<group>"; };
 		337B611696DC32BD227CD020 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		33A9E0597972B90E3B9DFFE1 /* SuperwallDelegateObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallDelegateObjc.swift; sourceTree = "<group>"; };
@@ -2510,6 +2512,7 @@
 			children = (
 				C6BB83F17D20143827C28042 /* EntitlementsInfo.swift */,
 				E0A7F2B0E53BE42DC6B52873 /* EntitlementsStatus.swift */,
+				328C01066B84891ECF4B7F34 /* PublishedSubscriptionStatus.swift */,
 				469037ACFCAE3F46CF751E43 /* SubscriptionStatusPublishing.swift */,
 				0D4F1B49114819E9E6923508 /* Product Fetching */,
 				E36E6C0CB40C3F44423C80CF /* Receipt Manager */,
@@ -3687,6 +3690,7 @@
 				F5CCDC90D8CBA5ED0C5BAD2E /* PublicGetPresentationResult.swift in Sources */,
 				0AB9CCC164DD87C81318AAB0 /* PublicIdentity.swift in Sources */,
 				8F24AAC773F119481E2C654F /* PublicPresentation.swift in Sources */,
+				E20B1214CA9785C0D0C7AD7A /* PublishedSubscriptionStatus.swift in Sources */,
 				D66461863D54A56BE9C29310 /* Publisher+Async.swift in Sources */,
 				4E078EFFD0C1992563021220 /* PurchaseController.swift in Sources */,
 				0F00D32C125E8B86EA477631 /* PurchaseControllerObjc.swift in Sources */,

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		31E937EB414F62268F6C953C /* TestModeInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3548435BDE49161E3BDFA358 /* TestModeInfoCell.swift */; };
 		32C1A7BB48AC2A5CB88C448B /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1E17A7907C42F27817C958 /* NonSubscriptionTransaction.swift */; };
 		3313CD30A969731960FC32BF /* PaywallOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1439A212719AA2EA8BEA357 /* PaywallOverrides.swift */; };
+		332915728292DE705DB09338 /* SubscriptionStatusChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5813618E0E26698492BC7485 /* SubscriptionStatusChange.swift */; };
 		339F1D07DB57DBEC46940DB6 /* CheckoutWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0B401CD38DBD6D90E4EB3E /* CheckoutWebViewController.swift */; };
 		342593FCA24FBEA77FE472C7 /* SK2ReceiptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050BC76657949DBB5F3D551C /* SK2ReceiptManager.swift */; };
 		3464196F9088F8A320FE24A4 /* PendingStripeCheckoutPollState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797EC0356AA1065ED11835BF /* PendingStripeCheckoutPollState.swift */; };
@@ -789,6 +790,7 @@
 		577A16EE2161E2CDEDFA48C0 /* GameControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerManager.swift; sourceTree = "<group>"; };
 		57AD390BC73341A49301B4AA /* ProductsFetcherSK2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK2.swift; sourceTree = "<group>"; };
 		57C7673988B39FB0BDEA8BE4 /* Date+IsoStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+IsoStringTests.swift"; sourceTree = "<group>"; };
+		5813618E0E26698492BC7485 /* SubscriptionStatusChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStatusChange.swift; sourceTree = "<group>"; };
 		582CE0C5BA6EA57C7FE3EE43 /* CheckNoPaywallAlreadyPresented.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckNoPaywallAlreadyPresented.swift; sourceTree = "<group>"; };
 		5836EFACFA00594CE8F9F377 /* Experiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Experiment.swift; sourceTree = "<group>"; };
 		58466FF38687A9F8715F9B54 /* Array+Capability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Capability.swift"; sourceTree = "<group>"; };
@@ -2513,6 +2515,7 @@
 				C6BB83F17D20143827C28042 /* EntitlementsInfo.swift */,
 				E0A7F2B0E53BE42DC6B52873 /* EntitlementsStatus.swift */,
 				328C01066B84891ECF4B7F34 /* PublishedSubscriptionStatus.swift */,
+				5813618E0E26698492BC7485 /* SubscriptionStatusChange.swift */,
 				469037ACFCAE3F46CF751E43 /* SubscriptionStatusPublishing.swift */,
 				0D4F1B49114819E9E6923508 /* Product Fetching */,
 				E36E6C0CB40C3F44423C80CF /* Receipt Manager */,
@@ -3765,6 +3768,7 @@
 				91BA5E01D0FB528954ABB937 /* StripeStoreProductDiscount.swift in Sources */,
 				B60C3A3AD25CE2E2C513A2D2 /* Stubbable.swift in Sources */,
 				C34A4AF2C8CD9ACBD2C370F8 /* SubscriptionPeriod.swift in Sources */,
+				332915728292DE705DB09338 /* SubscriptionStatusChange.swift in Sources */,
 				C8540455BC520DAB75862A5D /* SubscriptionStatusPublishing.swift in Sources */,
 				B0AD4A89AD5101360F93652D /* SubscriptionTransaction.swift in Sources */,
 				CFEB0D797815E8EDFB059767 /* Superwall.swift in Sources */,

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -436,6 +436,7 @@
 		C7AB21123540550E513AD28A /* CoreDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9CC1B947A08633E1C7BAE3 /* CoreDataManagerTests.swift */; };
 		C7E140466315324E9A1B9407 /* PermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB7CF97D0926DCDAB133DB1 /* PermissionStatus.swift */; };
 		C80ACD3C05345709DAB248FD /* RestoreType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEBD34CFE62DCFE0AFD80D6 /* RestoreType.swift */; };
+		C8540455BC520DAB75862A5D /* SubscriptionStatusPublishing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469037ACFCAE3F46CF751E43 /* SubscriptionStatusPublishing.swift */; };
 		C8671043E6585DE19AAD1DAD /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AD727C5A8639E704F7BE98 /* PaywallView.swift */; };
 		C86B9D3992BBD1E8A1105F3C /* SuperwallDelegateObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A9E0597972B90E3B9DFFE1 /* SuperwallDelegateObjc.swift */; };
 		C8BCF3C0404622139D002893 /* PushTransitionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC74F16DC5A17489E97061EA /* PushTransitionLogic.swift */; };
@@ -748,6 +749,7 @@
 		45B3BC4249A9E9BA8E99EC7C /* CustomCallbackRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCallbackRegistry.swift; sourceTree = "<group>"; };
 		460B6F98BADD9EC96A978E40 /* SWProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWProduct.swift; sourceTree = "<group>"; };
 		4634E3B868871DD24C2555F9 /* SWWebViewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWWebViewLogic.swift; sourceTree = "<group>"; };
+		469037ACFCAE3F46CF751E43 /* SubscriptionStatusPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStatusPublishing.swift; sourceTree = "<group>"; };
 		46D2598EB46E9A27E2BD5104 /* PreloadingDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadingDisabled.swift; sourceTree = "<group>"; };
 		4711FABAB250221629C47688 /* AppStoreProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreProductTests.swift; sourceTree = "<group>"; };
 		481D47E5121C521DDA268609 /* TriggerRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerRule.swift; sourceTree = "<group>"; };
@@ -2508,6 +2510,7 @@
 			children = (
 				C6BB83F17D20143827C28042 /* EntitlementsInfo.swift */,
 				E0A7F2B0E53BE42DC6B52873 /* EntitlementsStatus.swift */,
+				469037ACFCAE3F46CF751E43 /* SubscriptionStatusPublishing.swift */,
 				0D4F1B49114819E9E6923508 /* Product Fetching */,
 				E36E6C0CB40C3F44423C80CF /* Receipt Manager */,
 				CB4191E8F35374E6FF55C5D0 /* StoreProduct */,
@@ -3758,6 +3761,7 @@
 				91BA5E01D0FB528954ABB937 /* StripeStoreProductDiscount.swift in Sources */,
 				B60C3A3AD25CE2E2C513A2D2 /* Stubbable.swift in Sources */,
 				C34A4AF2C8CD9ACBD2C370F8 /* SubscriptionPeriod.swift in Sources */,
+				C8540455BC520DAB75862A5D /* SubscriptionStatusPublishing.swift in Sources */,
 				B0AD4A89AD5101360F93652D /* SubscriptionTransaction.swift in Sources */,
 				CFEB0D797815E8EDFB059767 /* Superwall.swift in Sources */,
 				17C0F1960CD89B6BFA8B2FBB /* SuperwallDelegate.swift in Sources */,

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 		CF2064883604B915C8768FC5 /* ASIdManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF989B3D90DC3D88FACC4D45 /* ASIdManagerProxy.swift */; };
 		CF3683E2AD703237EC0CE22E /* PaywallProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C95DABA23C6CBEF0AAA63C0 /* PaywallProducts.swift */; };
 		CFEB0D797815E8EDFB059767 /* Superwall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7EDB6D68D0AEDD332E40BB /* Superwall.swift */; };
+		D0D4568B72D20652C12AA89B /* GrantedEntitlementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1099A063D46DE7373CFABC4C /* GrantedEntitlementsTests.swift */; };
 		D0E19F665C7B230BF3FA122D /* TrackingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85ED994DEC92BB90ACC6AC2 /* TrackingResult.swift */; };
 		D1F8771E65157D1B0E05D0B9 /* ManifestDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2915A802FACB53B6094B011 /* ManifestDataFetcher.swift */; };
 		D25B3A24CEE42FC90BFA31D2 /* SuperwallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E4096EBF0B8C9693322CD1 /* SuperwallEvent.swift */; };
@@ -633,6 +634,7 @@
 		0EC8705042D6AA74D40350A9 /* SK2ObserverModePurchaseDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2ObserverModePurchaseDetector.swift; sourceTree = "<group>"; };
 		0ECD75DF8F3EB6A68A21444D /* ProductsFetcherSK2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK2Tests.swift; sourceTree = "<group>"; };
 		0FDB1F66C8DB4C53466266D8 /* String+SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA256.swift"; sourceTree = "<group>"; };
+		1099A063D46DE7373CFABC4C /* GrantedEntitlementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrantedEntitlementsTests.swift; sourceTree = "<group>"; };
 		10D5ABDB23D56393EFDCF73A /* NetworkMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMock.swift; sourceTree = "<group>"; };
 		115132479C9C41D57C9E3BA9 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		124F219E38F8398A65A7EB32 /* DependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
@@ -1584,6 +1586,7 @@
 		2C05828E18C52F510F7CDFA2 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				1099A063D46DE7373CFABC4C /* GrantedEntitlementsTests.swift */,
 				BD6BA222CB2EAA4B65F362C5 /* ProductsFetcherSK1.swift */,
 				0ECD75DF8F3EB6A68A21444D /* ProductsFetcherSK2Tests.swift */,
 				B00929DACD8621FC32F83927 /* SK2StoreProductCyclesTests.swift */,
@@ -3320,6 +3323,7 @@
 				AC7D527612F631AAADC7D225 /* FileManagerMigratorTests.swift in Sources */,
 				D4B5A9708204AB6D58904733 /* GetPaywallVcOperatorTests.swift in Sources */,
 				64B962A8B59ACE514B0E48AE /* GetPresenterOperatorTests.swift in Sources */,
+				D0D4568B72D20652C12AA89B /* GrantedEntitlementsTests.swift in Sources */,
 				AF4AD928FACF9056E00D5920 /* HandleTriggerResultOperatorTests.swift in Sources */,
 				77EDD2927FF8DCF95579BE3E /* IdentityLogicTests.swift in Sources */,
 				D89E9C69317044050B97B573 /* IdentityManagerMock.swift in Sources */,

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -88,11 +88,25 @@ final class GrantedEntitlementsTests {
   }
 
   @Test
-  func unknownStatus_promotesToActiveWithGranted() {
+  func unknownStatus_staysUnknownWithGranted() {
     superwall.subscriptionStatus = .unknown
     superwall.grantedEntitlements = [grantedEntitlement()]
 
-    #expect(superwall.subscriptionStatus.isActive)
+    // Grants don't decide a status that hasn't been determined — reporting
+    // active here would let a paywall present before a purchase controller
+    // has answered.
+    #expect(superwall.subscriptionStatus == .unknown)
+  }
+
+  @Test
+  func grantsSetWhileUnknown_mergeOnceTheStatusIsKnown() {
+    superwall.subscriptionStatus = .unknown
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    #expect(superwall.subscriptionStatus == .unknown)
+
+    superwall.subscriptionStatus = .inactive
+
+    #expect(activeIds(superwall.subscriptionStatus) == ["granted"])
   }
 
   @Test
@@ -100,8 +114,8 @@ final class GrantedEntitlementsTests {
     superwall.subscriptionStatus = .inactive
     superwall.grantedEntitlements = [grantedEntitlement(isActive: false)]
 
-    // Inactive-only grants must not promote — the status stays .inactive,
-    // not an .active-cased status that's effectively inactive.
+    // The status stays .inactive, not an .active-cased status that's
+    // effectively inactive.
     #expect(superwall.subscriptionStatus == .inactive)
   }
 
@@ -494,6 +508,10 @@ final class GrantedEntitlementsTests {
 
   @Test
   func inactiveWritesWithGrant_doNotNotifyDelegate() async {
+    // The device has answered, so the grant has a determined status to
+    // merge into. Set before listening so only the grant is observed.
+    superwall.setSubscriptionStatus(assigned: .inactive)
+
     let delegate = MockSuperwallDelegate()
     dependencyContainer.delegateAdapter.swiftDelegate = delegate
     superwall.listenToSubscriptionStatus()

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -1,0 +1,304 @@
+//
+//  GrantedEntitlementsTests.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 2026-09-01.
+//
+// swiftlint:disable all
+
+@testable import SuperwallKit
+import Testing
+import Foundation
+
+@Suite(.serialized)
+final class GrantedEntitlementsTests {
+  private let dependencyContainer: DependencyContainer
+  private let superwall: Superwall
+
+  init() {
+    dependencyContainer = DependencyContainer()
+    superwall = Superwall(dependencyContainer: dependencyContainer)
+    cleanStorage()
+  }
+
+  deinit {
+    cleanStorage()
+  }
+
+  private func cleanStorage() {
+    dependencyContainer.storage.delete(GrantedEntitlements.self)
+    dependencyContainer.storage.delete(SubscriptionStatusKey.self)
+    dependencyContainer.storage.delete(LatestRedeemResponse.self)
+    dependencyContainer.storage.delete(LatestDeviceCustomerInfo.self)
+  }
+
+  // MARK: - Helpers
+
+  /// A bare developer-granted entitlement: no transaction history, no store.
+  private func grantedEntitlement(
+    id: String = "granted",
+    isActive: Bool = true
+  ) -> Entitlement {
+    return Entitlement(
+      id: id,
+      type: .serviceLevel,
+      isActive: isActive
+    )
+  }
+
+  /// A device entitlement enriched with transaction metadata.
+  private func deviceEntitlement(
+    id: String = "premium",
+    isActive: Bool = true
+  ) -> Entitlement {
+    return Entitlement(
+      id: id,
+      type: .serviceLevel,
+      isActive: isActive,
+      productIds: ["com.example.monthly"],
+      latestProductId: "com.example.monthly",
+      store: .appStore,
+      startsAt: Date(timeIntervalSince1970: 1_700_000_000),
+      expiresAt: Date(timeIntervalSince1970: 1_800_000_000),
+      isLifetime: false,
+      willRenew: true,
+      state: .subscribed
+    )
+  }
+
+  // MARK: - Merging
+
+  @Test
+  func settingGranted_activatesInactiveStatus() {
+    superwall.subscriptionStatus = .inactive
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    #expect(superwall.subscriptionStatus.isActive)
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(entitlements.map(\.id) == ["granted"])
+    } else {
+      Issue.record("Expected .active status")
+    }
+  }
+
+  @Test
+  func settingGranted_mergesWithActiveStatus() {
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
+    superwall.grantedEntitlements = [grantedEntitlement(id: "granted")]
+
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(Set(entitlements.map(\.id)) == ["premium", "granted"])
+    } else {
+      Issue.record("Expected .active status")
+    }
+  }
+
+  @Test
+  func unknownStatus_promotesToActiveWithGranted() {
+    superwall.subscriptionStatus = .unknown
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    #expect(superwall.subscriptionStatus.isActive)
+  }
+
+  @Test
+  func inactiveGrantedOnly_doesNotActivateStatus() {
+    superwall.subscriptionStatus = .inactive
+    superwall.grantedEntitlements = [grantedEntitlement(isActive: false)]
+
+    #expect(!superwall.subscriptionStatus.isActive)
+  }
+
+  @Test
+  func assigningInactive_keepsGrantedActive() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    superwall.subscriptionStatus = .active([deviceEntitlement()])
+
+    superwall.subscriptionStatus = .inactive
+
+    #expect(superwall.subscriptionStatus.isActive)
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(entitlements.map(\.id) == ["granted"])
+    }
+  }
+
+  @Test
+  func emptyActiveAssignment_stillMergesGranted() {
+    // The empty-.active → .inactive collapse must run after the granted
+    // merge, not before it.
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    superwall.subscriptionStatus = .active([])
+
+    #expect(superwall.subscriptionStatus.isActive)
+  }
+
+  // MARK: - Clearing
+
+  @Test
+  func clearingGranted_restoresBaseStatus() {
+    superwall.subscriptionStatus = .inactive
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    #expect(superwall.subscriptionStatus.isActive)
+
+    superwall.grantedEntitlements = []
+
+    #expect(superwall.subscriptionStatus == .inactive)
+  }
+
+  @Test
+  func replacingGranted_replacesOutright() {
+    superwall.subscriptionStatus = .inactive
+    superwall.grantedEntitlements = [grantedEntitlement(id: "a")]
+    superwall.grantedEntitlements = [grantedEntitlement(id: "b")]
+
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(entitlements.map(\.id) == ["b"])
+    } else {
+      Issue.record("Expected .active status")
+    }
+  }
+
+  // MARK: - Merge precedence
+
+  @Test
+  func granted_losesToActiveDeviceEntitlementWithHistory() {
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
+    superwall.grantedEntitlements = [grantedEntitlement(id: "premium")]
+
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(entitlements.count == 1)
+      // The device entitlement's transaction metadata must be kept.
+      #expect(entitlements.first?.latestProductId == "com.example.monthly")
+      #expect(entitlements.first?.store == .appStore)
+    } else {
+      Issue.record("Expected .active status")
+    }
+  }
+
+  @Test
+  func activeGranted_beatsExpiredDeviceEntitlement() {
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium", isActive: false)])
+    superwall.grantedEntitlements = [grantedEntitlement(id: "premium")]
+
+    #expect(superwall.subscriptionStatus.isActive)
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(entitlements.count == 1)
+      #expect(entitlements.first?.isActive == true)
+      // The granted record wins wholesale — it mustn't inherit the expired
+      // transaction's metadata and masquerade as a store subscription.
+      #expect(entitlements.first?.latestProductId == nil)
+    } else {
+      Issue.record("Expected .active status")
+    }
+  }
+
+  // MARK: - Idempotence
+
+  @Test
+  func reassigningResolvedStatus_isStable() {
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
+    superwall.grantedEntitlements = [grantedEntitlement(id: "granted")]
+
+    let resolved = superwall.subscriptionStatus
+    superwall.subscriptionStatus = resolved
+
+    // resolve(resolve(x)) == resolve(x): re-resolving an already-merged
+    // value must settle, not loop or grow.
+    #expect(superwall.subscriptionStatus == resolved)
+  }
+
+  // MARK: - Persistence
+
+  @Test
+  func persistedStatus_isUnresolvedBase() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    superwall.subscriptionStatus = .inactive
+
+    // The published status is merged, but the persisted one must be the
+    // unresolved base — otherwise granted entitlements are baked into the
+    // restored value and can never be cleared after a relaunch.
+    #expect(superwall.subscriptionStatus.isActive)
+    #expect(dependencyContainer.storage.get(SubscriptionStatusKey.self) == .inactive)
+  }
+
+  @Test
+  func clearingGranted_afterRestore_restoresBaseStatus() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    superwall.subscriptionStatus = .inactive
+    #expect(superwall.subscriptionStatus.isActive)
+
+    // Simulate a relaunch: a fresh instance restores the persisted status,
+    // exactly as Superwall's configure init does.
+    let relaunched = Superwall(dependencyContainer: dependencyContainer)
+    relaunched.subscriptionStatus =
+      dependencyContainer.storage.get(SubscriptionStatusKey.self) ?? .unknown
+    #expect(relaunched.subscriptionStatus.isActive)
+
+    relaunched.grantedEntitlements = []
+
+    #expect(relaunched.subscriptionStatus == .inactive)
+  }
+
+  @Test
+  func granted_survivesStorageReset() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    dependencyContainer.storage.reset()
+
+    #expect(superwall.grantedEntitlements.map(\.id) == ["granted"])
+  }
+
+  // MARK: - CustomerInfo
+
+  @Test
+  func granted_reachesCustomerInfoForExternalPurchaseController() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    let customerInfo = CustomerInfo.forExternalPurchaseController(
+      storage: dependencyContainer.storage,
+      subscriptionStatus: .inactive
+    )
+
+    #expect(customerInfo.entitlements.contains { $0.id == "granted" && $0.isActive })
+  }
+
+  @Test
+  func granted_mergesIntoAutomaticPathCustomerInfo() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    let base = CustomerInfo(
+      subscriptions: [],
+      nonSubscriptions: [],
+      entitlements: [deviceEntitlement(id: "premium")]
+    )
+    let merged = base.mergingGrantedEntitlements(from: dependencyContainer.storage)
+
+    #expect(Set(merged.entitlements.map(\.id)) == ["premium", "granted"])
+  }
+
+  // MARK: - Event parameters
+
+  @Test
+  func statusChangeEvent_includesGrantedEntitlementIds() async {
+    let granted = grantedEntitlement(id: "granted")
+    let event = InternalSuperwallEvent.SubscriptionStatusDidChange(
+      status: .active([deviceEntitlement(id: "premium"), granted]),
+      grantedEntitlements: [granted]
+    )
+
+    let params = await event.getSuperwallParameters()
+
+    #expect(params["granted_entitlement_ids"] as? String == "granted")
+  }
+
+  @Test
+  func statusChangeEvent_omitsGrantedParamWhenNoneGranted() async {
+    let event = InternalSuperwallEvent.SubscriptionStatusDidChange(
+      status: .active([deviceEntitlement(id: "premium")])
+    )
+
+    let params = await event.getSuperwallParameters()
+
+    #expect(params["granted_entitlement_ids"] == nil)
+  }
+}

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -158,7 +158,7 @@ final class GrantedEntitlementsTests {
   // MARK: - Clearing
 
   @Test
-  func clearingGranted_restoresBaseStatus() {
+  func clearingGranted_restoresAssignedStatus() {
     superwall.subscriptionStatus = .inactive
     superwall.grantedEntitlements = [grantedEntitlement()]
     #expect(superwall.subscriptionStatus.isActive)
@@ -218,34 +218,34 @@ final class GrantedEntitlementsTests {
   // MARK: - Idempotence
 
   @Test
-  func reassigningResolvedStatus_isStable() {
+  func reassigningPublishedStatus_isStable() {
     superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
     superwall.grantedEntitlements = [grantedEntitlement(id: "granted")]
 
     let resolved = superwall.subscriptionStatus
     superwall.subscriptionStatus = resolved
 
-    // resolve(resolve(x)) == resolve(x): re-resolving an already-merged
-    // value must settle, not loop or grow.
+    // merge(merge(x)) == merge(x): re-assigning an already-merged value
+    // must settle, not loop or grow.
     #expect(superwall.subscriptionStatus == resolved)
   }
 
   // MARK: - Persistence
 
   @Test
-  func persistedStatus_isUnresolvedBase() {
+  func persistedStatus_isAssignedValue() {
     superwall.grantedEntitlements = [grantedEntitlement()]
     superwall.subscriptionStatus = .inactive
 
     // The published status is merged, but the persisted one must be the
-    // unresolved base — otherwise granted entitlements are baked into the
+    // assigned value — otherwise granted entitlements are baked into the
     // restored value and can never be cleared after a relaunch.
     #expect(superwall.subscriptionStatus.isActive)
     #expect(dependencyContainer.storage.get(SubscriptionStatusKey.self) == .inactive)
   }
 
   @Test
-  func clearingGranted_afterRestore_restoresBaseStatus() {
+  func clearingGranted_afterRestore_restoresAssignedStatus() {
     superwall.grantedEntitlements = [grantedEntitlement()]
     superwall.subscriptionStatus = .inactive
     #expect(superwall.subscriptionStatus.isActive)
@@ -263,13 +263,13 @@ final class GrantedEntitlementsTests {
   }
 
   @Test
-  func concurrentAssignments_neverPersistGrantedIntoBase() async {
+  func concurrentAssignments_neverPersistGrantedIntoAssignedStatus() async {
     superwall.grantedEntitlements = [grantedEntitlement()]
 
     // Race external assignments from many threads. Without the lock
-    // covering the property store, a store landing mid-resolution captures
-    // another thread's resolved write-back as its base, persisting granted
-    // entitlements into SubscriptionStatusKey.
+    // covering the property store, a store landing mid-publish captures
+    // another thread's merged write-back as its assigned status, persisting
+    // granted entitlements into SubscriptionStatusKey.
     await withTaskGroup(of: Void.self) { group in
       for index in 0..<50 {
         group.addTask { [superwall, deviceEnt = deviceEntitlement(id: "premium")] in
@@ -280,15 +280,15 @@ final class GrantedEntitlementsTests {
       }
     }
 
-    // The persisted base must be exactly one of the assigned values —
-    // any merged base means a resolved write-back was captured.
-    let persistedBase = dependencyContainer.storage.get(SubscriptionStatusKey.self)
+    // The persisted status must be exactly one of the assigned values —
+    // any merged value means a write-back was captured as the assigned status.
+    let persistedStatus = dependencyContainer.storage.get(SubscriptionStatusKey.self)
     #expect(
-      persistedBase == .inactive
-        || persistedBase == .active([deviceEntitlement(id: "premium")])
+      persistedStatus == .inactive
+        || persistedStatus == .active([deviceEntitlement(id: "premium")])
     )
-    // The in-memory base must be clean too: clearing the grant must leave
-    // a status without it.
+    // The in-memory assigned status must be clean too: clearing the grant
+    // must leave a status without it.
     superwall.grantedEntitlements = []
     if case .active(let entitlements) = superwall.subscriptionStatus {
       #expect(entitlements.map(\.id) == ["premium"])
@@ -371,7 +371,7 @@ final class GrantedEntitlementsTests {
   // MARK: - Publishing
 
   @Test
-  func baseAssignment_publishesOnlyTheResolvedValue() {
+  func sdkAssignment_publishesOnlyTheMergedValue() {
     superwall.grantedEntitlements = [grantedEntitlement()]
 
     var published: [SubscriptionStatus] = []
@@ -380,9 +380,9 @@ final class GrantedEntitlementsTests {
       .sink { published.append($0) }
     defer { cancellable.cancel() }
 
-    superwall.setSubscriptionStatus(base: .active([deviceEntitlement(id: "premium")]))
+    superwall.setSubscriptionStatus(assigned: .active([deviceEntitlement(id: "premium")]))
 
-    // A single store of the merged value — never the raw base first.
+    // A single store of the merged value — never the raw assigned value first.
     #expect(published.count == 1)
     if case .active(let entitlements) = published.first {
       #expect(Set(entitlements.map(\.id)) == ["premium", "granted"])
@@ -402,10 +402,10 @@ final class GrantedEntitlementsTests {
     #expect(delegate.subscriptionStatusChanges.count == 1)
 
     // A device poll reporting no subscription, and a direct .inactive
-    // assignment, both resolve back to the granted status. The delegate
+    // assignment, both publish the granted status again. The delegate
     // must not hear about either — in particular it must never see the
-    // transient .inactive that the public setter stores before resolution.
-    superwall.setSubscriptionStatus(base: .inactive)
+    // transient .inactive that the public setter stores before merging.
+    superwall.setSubscriptionStatus(assigned: .inactive)
     superwall.subscriptionStatus = .inactive
     try? await Task.sleep(nanoseconds: 300_000_000)
     #expect(delegate.subscriptionStatusChanges.count == 1)

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -279,13 +279,19 @@ final class GrantedEntitlementsTests {
       }
     }
 
-    // The persisted base must never contain a granted entitlement.
-    if case .active(let entitlements) = dependencyContainer.storage.get(SubscriptionStatusKey.self) {
-      #expect(!entitlements.contains { $0.id == "granted" })
+    // The persisted base must be exactly one of the assigned values —
+    // any merged base means a resolved write-back was captured.
+    let persistedBase = dependencyContainer.storage.get(SubscriptionStatusKey.self)
+    #expect(
+      persistedBase == .inactive
+        || persistedBase == .active([deviceEntitlement(id: "premium")])
+    )
+    // The in-memory base must be clean too: clearing the grant must leave
+    // a status without it.
+    superwall.grantedEntitlements = []
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(entitlements.map(\.id) == ["premium"])
     }
-    // Whatever base won the race, the published status resolves active
-    // because of the grant.
-    #expect(superwall.subscriptionStatus.isActive)
   }
 
   @Test

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -106,7 +106,29 @@ final class GrantedEntitlementsTests {
     superwall.subscriptionStatus = .inactive
     superwall.grantedEntitlements = [grantedEntitlement(isActive: false)]
 
-    #expect(!superwall.subscriptionStatus.isActive)
+    // Inactive-only grants must not promote — the status stays .inactive,
+    // not an .active-cased status that's effectively inactive.
+    #expect(superwall.subscriptionStatus == .inactive)
+  }
+
+  @Test
+  func inactiveGrant_doesNotEnterActiveSet() {
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
+    superwall.grantedEntitlements = [grantedEntitlement(id: "extra", isActive: false)]
+
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(entitlements.map(\.id) == ["premium"])
+    } else {
+      Issue.record("Expected .active status")
+    }
+  }
+
+  @Test
+  func inactiveGrantedOnly_leavesUnknownStatusUnknown() {
+    superwall.subscriptionStatus = .unknown
+    superwall.grantedEntitlements = [grantedEntitlement(isActive: false)]
+
+    #expect(superwall.subscriptionStatus == .unknown)
   }
 
   @Test
@@ -260,6 +282,15 @@ final class GrantedEntitlementsTests {
     )
 
     #expect(customerInfo.entitlements.contains { $0.id == "granted" && $0.isActive })
+  }
+
+  @Test
+  func grantChange_refreshesCustomerInfoOnAutomaticPath() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    #expect(superwall.customerInfo.entitlements.contains { $0.id == "granted" && $0.isActive })
+
+    superwall.grantedEntitlements = []
+    #expect(!superwall.customerInfo.entitlements.contains { $0.id == "granted" })
   }
 
   @Test

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -262,6 +262,33 @@ final class GrantedEntitlementsTests {
   }
 
   @Test
+  func concurrentAssignments_neverPersistGrantedIntoBase() async {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    // Race external assignments from many threads. Without the lock
+    // covering the property store, a store landing mid-resolution captures
+    // another thread's resolved write-back as its base, persisting granted
+    // entitlements into SubscriptionStatusKey.
+    await withTaskGroup(of: Void.self) { group in
+      for index in 0..<50 {
+        group.addTask { [superwall, deviceEnt = deviceEntitlement(id: "premium")] in
+          superwall.subscriptionStatus = index.isMultiple(of: 2)
+            ? .inactive
+            : .active([deviceEnt])
+        }
+      }
+    }
+
+    // The persisted base must never contain a granted entitlement.
+    if case .active(let entitlements) = dependencyContainer.storage.get(SubscriptionStatusKey.self) {
+      #expect(!entitlements.contains { $0.id == "granted" })
+    }
+    // Whatever base won the race, the published status resolves active
+    // because of the grant.
+    #expect(superwall.subscriptionStatus.isActive)
+  }
+
+  @Test
   func granted_survivesStorageReset() {
     superwall.grantedEntitlements = [grantedEntitlement()]
 

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -380,6 +380,28 @@ final class GrantedEntitlementsTests {
   }
 
   @Test
+  func externalController_customerInfoFollowsStatusAndGrants() {
+    // The suite's own container uses the internal controller, so this is the
+    // only test that exercises the external-controller recompute wired into
+    // publishSubscriptionStatus.
+    let container = DependencyContainer(
+      purchaseController: MockPurchaseController(),
+      cache: CacheMock()
+    )
+    let superwall = Superwall(dependencyContainer: container)
+
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
+
+    #expect(Set(superwall.customerInfo.entitlements.map(\.id)) == ["premium", "granted"])
+
+    // Clearing recomputes too, even though the status stays active.
+    superwall.grantedEntitlements = []
+
+    #expect(superwall.customerInfo.entitlements.map(\.id) == ["premium"])
+  }
+
+  @Test
   func grantChange_refreshesCustomerInfoOnAutomaticPath() {
     superwall.grantedEntitlements = [grantedEntitlement()]
     #expect(superwall.customerInfo.entitlements.contains { $0.id == "granted" && $0.isActive })

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -198,6 +198,20 @@ final class GrantedEntitlementsTests {
     #expect(activeIds(superwall.subscriptionStatus) == ["premium"])
   }
 
+  @Test
+  func writingBackACollidingGrant_keepsItRevocable() {
+    // A lapsed subscription and a grant for the same ID: the grant wins the
+    // merge but comes back carrying the lapsed record's product IDs, so it
+    // no longer equals the grant it came from.
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium", isActive: false)])
+    superwall.grantedEntitlements = [grantedEntitlement(id: "premium")]
+
+    superwall.subscriptionStatus = superwall.subscriptionStatus
+    superwall.grantedEntitlements = []
+
+    #expect(!superwall.subscriptionStatus.isActive)
+  }
+
   // MARK: - Merge precedence
 
   @Test

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -17,20 +17,12 @@ final class GrantedEntitlementsTests {
   private let superwall: Superwall
 
   init() {
-    dependencyContainer = DependencyContainer()
+    // In-memory storage, so nothing this suite writes reaches the on-disk
+    // store shared with other suites. GrantedEntitlements is app-specific
+    // and read on every status publish, so a file left behind mid-test would
+    // leak into suites running in parallel.
+    dependencyContainer = DependencyContainer(cache: CacheMock())
     superwall = Superwall(dependencyContainer: dependencyContainer)
-    cleanStorage()
-  }
-
-  deinit {
-    cleanStorage()
-  }
-
-  private func cleanStorage() {
-    dependencyContainer.storage.delete(GrantedEntitlements.self)
-    dependencyContainer.storage.delete(SubscriptionStatusKey.self)
-    dependencyContainer.storage.delete(LatestRedeemResponse.self)
-    dependencyContainer.storage.delete(LatestDeviceCustomerInfo.self)
   }
 
   // MARK: - Helpers
@@ -38,12 +30,14 @@ final class GrantedEntitlementsTests {
   /// A bare developer-granted entitlement: no transaction history, no store.
   private func grantedEntitlement(
     id: String = "granted",
-    isActive: Bool = true
+    isActive: Bool = true,
+    expiresAt: Date? = nil
   ) -> Entitlement {
     return Entitlement(
       id: id,
       type: .serviceLevel,
-      isActive: isActive
+      isActive: isActive,
+      expiresAt: expiresAt
     )
   }
 
@@ -67,6 +61,13 @@ final class GrantedEntitlementsTests {
     )
   }
 
+  private func activeIds(_ status: SubscriptionStatus) -> Set<String>? {
+    if case .active(let entitlements) = status {
+      return Set(entitlements.map(\.id))
+    }
+    return nil
+  }
+
   // MARK: - Merging
 
   @Test
@@ -75,11 +76,7 @@ final class GrantedEntitlementsTests {
     superwall.grantedEntitlements = [grantedEntitlement()]
 
     #expect(superwall.subscriptionStatus.isActive)
-    if case .active(let entitlements) = superwall.subscriptionStatus {
-      #expect(entitlements.map(\.id) == ["granted"])
-    } else {
-      Issue.record("Expected .active status")
-    }
+    #expect(activeIds(superwall.subscriptionStatus) == ["granted"])
   }
 
   @Test
@@ -87,11 +84,7 @@ final class GrantedEntitlementsTests {
     superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
     superwall.grantedEntitlements = [grantedEntitlement(id: "granted")]
 
-    if case .active(let entitlements) = superwall.subscriptionStatus {
-      #expect(Set(entitlements.map(\.id)) == ["premium", "granted"])
-    } else {
-      Issue.record("Expected .active status")
-    }
+    #expect(activeIds(superwall.subscriptionStatus) == ["premium", "granted"])
   }
 
   @Test
@@ -117,11 +110,7 @@ final class GrantedEntitlementsTests {
     superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
     superwall.grantedEntitlements = [grantedEntitlement(id: "extra", isActive: false)]
 
-    if case .active(let entitlements) = superwall.subscriptionStatus {
-      #expect(entitlements.map(\.id) == ["premium"])
-    } else {
-      Issue.record("Expected .active status")
-    }
+    #expect(activeIds(superwall.subscriptionStatus) == ["premium"])
   }
 
   @Test
@@ -139,10 +128,7 @@ final class GrantedEntitlementsTests {
 
     superwall.subscriptionStatus = .inactive
 
-    #expect(superwall.subscriptionStatus.isActive)
-    if case .active(let entitlements) = superwall.subscriptionStatus {
-      #expect(entitlements.map(\.id) == ["granted"])
-    }
+    #expect(activeIds(superwall.subscriptionStatus) == ["granted"])
   }
 
   @Test
@@ -153,6 +139,23 @@ final class GrantedEntitlementsTests {
     superwall.subscriptionStatus = .active([])
 
     #expect(superwall.subscriptionStatus.isActive)
+  }
+
+  @Test
+  func grantsSharingAnId_publishOneRecord() {
+    superwall.subscriptionStatus = .inactive
+    superwall.grantedEntitlements = [
+      grantedEntitlement(id: "pro", expiresAt: Date(timeIntervalSince1970: 1_800_000_000)),
+      grantedEntitlement(id: "pro", expiresAt: Date(timeIntervalSince1970: 1_900_000_000))
+    ]
+
+    if case .active(let entitlements) = superwall.subscriptionStatus {
+      #expect(entitlements.count == 1)
+      // The later expiry wins the merge.
+      #expect(entitlements.first?.expiresAt == Date(timeIntervalSince1970: 1_900_000_000))
+    } else {
+      Issue.record("Expected .active status")
+    }
   }
 
   // MARK: - Clearing
@@ -174,11 +177,25 @@ final class GrantedEntitlementsTests {
     superwall.grantedEntitlements = [grantedEntitlement(id: "a")]
     superwall.grantedEntitlements = [grantedEntitlement(id: "b")]
 
-    if case .active(let entitlements) = superwall.subscriptionStatus {
-      #expect(entitlements.map(\.id) == ["b"])
-    } else {
-      Issue.record("Expected .active status")
-    }
+    #expect(activeIds(superwall.subscriptionStatus) == ["b"])
+  }
+
+  @Test
+  func writingBackThePublishedStatus_keepsGrantsRevocable() {
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    // A read-modify-write of the published, grant-merged status must not
+    // hand the grant back as the developer's own.
+    superwall.subscriptionStatus = superwall.subscriptionStatus
+    #expect(
+      dependencyContainer.storage.get(SubscriptionStatusKey.self)
+        == .active([deviceEntitlement(id: "premium")])
+    )
+
+    superwall.grantedEntitlements = []
+
+    #expect(activeIds(superwall.subscriptionStatus) == ["premium"])
   }
 
   // MARK: - Merge precedence
@@ -222,12 +239,12 @@ final class GrantedEntitlementsTests {
     superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
     superwall.grantedEntitlements = [grantedEntitlement(id: "granted")]
 
-    let resolved = superwall.subscriptionStatus
-    superwall.subscriptionStatus = resolved
+    let published = superwall.subscriptionStatus
+    superwall.subscriptionStatus = published
 
     // merge(merge(x)) == merge(x): re-assigning an already-merged value
     // must settle, not loop or grow.
-    #expect(superwall.subscriptionStatus == resolved)
+    #expect(superwall.subscriptionStatus == published)
   }
 
   // MARK: - Persistence
@@ -253,8 +270,9 @@ final class GrantedEntitlementsTests {
     // Simulate a relaunch: a fresh instance restores the persisted status,
     // exactly as Superwall's configure init does.
     let relaunched = Superwall(dependencyContainer: dependencyContainer)
-    relaunched.subscriptionStatus =
-      dependencyContainer.storage.get(SubscriptionStatusKey.self) ?? .unknown
+    relaunched.setSubscriptionStatus(
+      assigned: dependencyContainer.storage.get(SubscriptionStatusKey.self) ?? .unknown
+    )
     #expect(relaunched.subscriptionStatus.isActive)
 
     relaunched.grantedEntitlements = []
@@ -266,10 +284,10 @@ final class GrantedEntitlementsTests {
   func concurrentAssignments_neverPersistGrantedIntoAssignedStatus() async {
     superwall.grantedEntitlements = [grantedEntitlement()]
 
-    // Race external assignments from many threads. Without the lock
-    // covering the property store, a store landing mid-publish captures
-    // another thread's merged write-back as its assigned status, persisting
-    // granted entitlements into SubscriptionStatusKey.
+    // Race external assignments from many threads. Without the lock, a store
+    // landing mid-publish could capture another thread's merged write-back
+    // as its assigned status, persisting granted entitlements into
+    // SubscriptionStatusKey.
     await withTaskGroup(of: Void.self) { group in
       for index in 0..<50 {
         group.addTask { [superwall, deviceEnt = deviceEntitlement(id: "premium")] in
@@ -312,7 +330,8 @@ final class GrantedEntitlementsTests {
 
     let customerInfo = CustomerInfo.forExternalPurchaseController(
       storage: dependencyContainer.storage,
-      subscriptionStatus: .inactive
+      subscriptionStatus: .inactive,
+      granted: superwall.grantedEntitlements
     )
 
     #expect(customerInfo.entitlements.contains { $0.id == "granted" && $0.isActive })
@@ -356,6 +375,18 @@ final class GrantedEntitlementsTests {
   }
 
   @Test
+  func grantsBeforeTheDeviceSnapshot_keepCustomerInfoAsPlaceholder() {
+    #expect(superwall.customerInfo.isPlaceholder)
+
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    // Grants alone don't mean the device has been read, so consumers that
+    // wait for real data keep waiting.
+    #expect(superwall.customerInfo.isPlaceholder)
+    #expect(superwall.customerInfo.entitlements.map(\.id) == ["granted"])
+  }
+
+  @Test
   func merging_treatsGrantedAsASource() {
     let device = CustomerInfo(
       subscriptions: [],
@@ -366,6 +397,7 @@ final class GrantedEntitlementsTests {
     let merged = device.merging(with: .blank(), granting: [grantedEntitlement()])
 
     #expect(merged.entitlements.map(\.id) == ["granted", "premium"])
+    #expect(!merged.isPlaceholder)
   }
 
   // MARK: - Publishing
@@ -382,13 +414,46 @@ final class GrantedEntitlementsTests {
 
     superwall.setSubscriptionStatus(assigned: .active([deviceEntitlement(id: "premium")]))
 
-    // A single store of the merged value — never the raw assigned value first.
     #expect(published.count == 1)
-    if case .active(let entitlements) = published.first {
-      #expect(Set(entitlements.map(\.id)) == ["premium", "granted"])
-    } else {
-      Issue.record("Expected .active status")
-    }
+    #expect(published.first.flatMap(activeIds) == ["premium", "granted"])
+  }
+
+  @Test
+  func developerAssignment_publishesOnlyTheMergedValue() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    var published: [SubscriptionStatus] = []
+    let cancellable = superwall.$subscriptionStatus
+      .dropFirst()
+      .sink { published.append($0) }
+    defer { cancellable.cancel() }
+
+    // The public setter must never publish the raw assigned value first.
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
+
+    #expect(published.count == 1)
+    #expect(published.first.flatMap(activeIds) == ["premium", "granted"])
+  }
+
+  @Test
+  func assignmentFromASubscriber_isApplied() {
+    var didReassign = false
+    let cancellable = superwall.$subscriptionStatus
+      .dropFirst()
+      .sink { [superwall] status in
+        // A subscriber that reacts to the first change by assigning again,
+        // synchronously, from inside the emission.
+        if !didReassign, case .active = status {
+          didReassign = true
+          superwall.subscriptionStatus = .inactive
+        }
+      }
+    defer { cancellable.cancel() }
+
+    superwall.subscriptionStatus = .active([deviceEntitlement(id: "premium")])
+
+    #expect(superwall.subscriptionStatus == .inactive)
+    #expect(dependencyContainer.storage.get(SubscriptionStatusKey.self) == .inactive)
   }
 
   @Test
@@ -403,8 +468,7 @@ final class GrantedEntitlementsTests {
 
     // A device poll reporting no subscription, and a direct .inactive
     // assignment, both publish the granted status again. The delegate
-    // must not hear about either — in particular it must never see the
-    // transient .inactive that the public setter stores before merging.
+    // must not hear about either.
     superwall.setSubscriptionStatus(assigned: .inactive)
     superwall.subscriptionStatus = .inactive
     try? await Task.sleep(nanoseconds: 300_000_000)

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -7,6 +7,7 @@
 // swiftlint:disable all
 
 @testable import SuperwallKit
+import Combine
 import Testing
 import Foundation
 
@@ -327,17 +328,69 @@ final class GrantedEntitlementsTests {
   }
 
   @Test
-  func granted_mergesIntoAutomaticPathCustomerInfo() {
-    superwall.grantedEntitlements = [grantedEntitlement()]
-
-    let base = CustomerInfo(
+  func merging_treatsGrantedAsASource() {
+    let device = CustomerInfo(
       subscriptions: [],
       nonSubscriptions: [],
       entitlements: [deviceEntitlement(id: "premium")]
     )
-    let merged = base.mergingGrantedEntitlements(from: dependencyContainer.storage)
 
-    #expect(Set(merged.entitlements.map(\.id)) == ["premium", "granted"])
+    let merged = device.merging(with: .blank(), granting: [grantedEntitlement()])
+
+    #expect(merged.entitlements.map(\.id) == ["granted", "premium"])
+  }
+
+  // MARK: - Publishing
+
+  @Test
+  func baseAssignment_publishesOnlyTheResolvedValue() {
+    superwall.grantedEntitlements = [grantedEntitlement()]
+
+    var published: [SubscriptionStatus] = []
+    let cancellable = superwall.$subscriptionStatus
+      .dropFirst()
+      .sink { published.append($0) }
+    defer { cancellable.cancel() }
+
+    superwall.setSubscriptionStatus(base: .active([deviceEntitlement(id: "premium")]))
+
+    // A single store of the merged value — never the raw base first.
+    #expect(published.count == 1)
+    if case .active(let entitlements) = published.first {
+      #expect(Set(entitlements.map(\.id)) == ["premium", "granted"])
+    } else {
+      Issue.record("Expected .active status")
+    }
+  }
+
+  @Test
+  func inactiveWritesWithGrant_doNotNotifyDelegate() async {
+    let delegate = MockSuperwallDelegate()
+    dependencyContainer.delegateAdapter.swiftDelegate = delegate
+    superwall.listenToSubscriptionStatus()
+
+    superwall.grantedEntitlements = [grantedEntitlement()]
+    await waitUntil { delegate.subscriptionStatusChanges.count == 1 }
+    #expect(delegate.subscriptionStatusChanges.count == 1)
+
+    // A device poll reporting no subscription, and a direct .inactive
+    // assignment, both resolve back to the granted status. The delegate
+    // must not hear about either — in particular it must never see the
+    // transient .inactive that the public setter stores before resolution.
+    superwall.setSubscriptionStatus(base: .inactive)
+    superwall.subscriptionStatus = .inactive
+    try? await Task.sleep(nanoseconds: 300_000_000)
+    #expect(delegate.subscriptionStatusChanges.count == 1)
+  }
+
+  private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: @escaping () -> Bool
+  ) async {
+    let start = Date()
+    while !condition() && Date().timeIntervalSince(start) < timeout {
+      try? await Task.sleep(nanoseconds: 50_000_000)
+    }
   }
 
   // MARK: - Event parameters

--- a/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/GrantedEntitlementsTests.swift
@@ -319,6 +319,34 @@ final class GrantedEntitlementsTests {
   }
 
   @Test
+  func preservingExternalControllerEntitlements_keepsGrantCollidingWithExpiredDevice() {
+    let expiredDevice = CustomerInfo(
+      subscriptions: [],
+      nonSubscriptions: [],
+      entitlements: [deviceEntitlement(id: "premium", isActive: false)]
+    )
+    // The controller's current customer info also carries "premium", so
+    // the externalOnly filter drops it — the grant must survive as its own
+    // source rather than ride in through that filter.
+    let current = CustomerInfo(
+      subscriptions: [],
+      nonSubscriptions: [],
+      entitlements: [deviceEntitlement(id: "premium", isActive: false)]
+    )
+
+    let merged = CustomerInfo.preservingExternalControllerEntitlements(
+      device: expiredDevice,
+      web: nil,
+      current: current,
+      granted: [grantedEntitlement(id: "premium")]
+    )
+
+    #expect(merged.entitlements.count == 1)
+    #expect(merged.entitlements.first?.isActive == true)
+    #expect(merged.entitlements.first?.latestProductId == nil)
+  }
+
+  @Test
   func grantChange_refreshesCustomerInfoOnAutomaticPath() {
     superwall.grantedEntitlements = [grantedEntitlement()]
     #expect(superwall.customerInfo.entitlements.contains { $0.id == "granted" && $0.isActive })


### PR DESCRIPTION
Implements [SW-5794](https://linear.app/superwall/issue/SW-5794/ios-grantedentitlements-developer-supplied-entitlements-merged-into): a `grantedEntitlements` bucket for access granted by the developer's own backend that Superwall can't observe, merged into `subscriptionStatus` alongside device and web entitlements.

## API

```swift
public var grantedEntitlements: Set<Entitlement> { get set }
```

Deviates from the issue's original `SubscriptionStatus`-typed proposal, per design discussion:

- The status enum's three cases would have to be re-purposed as a tri-state input (`.unknown` = never written, `.inactive` = cleared, `.active` = payload) — `Optional<Set<Entitlement>>` in a costume.
- With a shared type, `grantedEntitlements = subscriptionStatus` type-checks and creates a feedback loop that re-grants already-merged web entitlements, resurrecting revoked ones. With `Set<Entitlement>` it doesn't compile.
- The "developers already construct a `SubscriptionStatus`" argument applies to purchase-controller users — exactly the audience documented as *not* the target for this feature.

Swift-only, no Obj-C surface. Clearing is `grantedEntitlements = []`. Each assignment replaces the previous set outright.

## Semantics

- **Merge:** active granted entitlements merge into every published status via the existing prioritized merge. An `.inactive` status with an active grant publishes as `.active(granted)`. An `.unknown` one stays `.unknown`, exactly like web entitlements: it means the status hasn't been determined and grants don't determine it, so reporting active would open the paywall presentation gate before a purchase controller had answered. Grants merge as soon as the status is known. Inactive-only grants never enter the active set.
- **Precedence:** granted loses to entitlements with real transaction history (`latestProductId != nil`) and wins against expired ones, winner-take-all — a grant never inherits a dead store subscription's metadata or masquerades as an App Store record.
- **Persistence:** survives app launches, `reset()`, and `identify()` — the developer owns the bucket's lifecycle. Doc comments state this imperatively and the reset path logs a warning when granted entitlements exist.

## Assigned vs. published status

The whole pipeline lives in `SubscriptionStatusPublishing.swift`, with one doc comment explaining the two values involved:

- The **assigned** status is what a writer handed the SDK — device + web on the automatic path, or the developer's own value with a purchase controller. It's kept in `assignedSubscriptionStatus` and is what gets **persisted**.
- The **published** status is the assigned status with granted entitlements merged in, any test-mode override applied, and an empty `.active` collapsed to `.inactive`. It's what `subscriptionStatus` holds.

The assigned value is kept because the published one can't be un-merged — clearing grants recomputes from it. Persisting the assigned value rather than the published one matters for the same reason: a persisted merged value would bake grants into the restored status and make them uncleanable after a relaunch (covered by a persist → restore → clear round-trip test). `ConfigManager`'s readers of the cached status check granted storage separately so subscribed-user fetch heuristics still hold for users active only via grants.

`subscriptionStatus` is backed by a small property wrapper, `PublishedSubscriptionStatus`, whose setter routes every assignment — the developer's included — through one `publishSubscriptionStatus(assigned:isDeveloperAssignment:)`. That's the single critical section under a recursive lock: it snapshots the grants, records the assigned value, stores the merged status and persists the assigned one, then releases the lock **before** emitting to `$subscriptionStatus` subscribers and recomputing `customerInfo` — both from a consistent snapshot, re-run if a concurrent write moved the inputs — so a subscriber that blocks can't deadlock a writer and a slower writer can't leave stale state behind a newer publish. Because the wrapper stores only merged values, `$subscriptionStatus` never emits a transient un-merged value on any path (its type is now `AnyPublisher<SubscriptionStatus, Never>` — source-compatible with `.sink`/`.receive(on:)`/`.eraseToAnyPublisher()`, but no longer a valid target for `assign(to:)`; the wrapper type is public only because the compiler requires it for a public property), and a subscriber that assigns the status from inside an emission simply re-enters the pipeline. Developer assignments get two extra treatments: records identical to a current grant (ignoring product IDs, which the merge rewrites) are stripped (a read-modify-write of the published status must not hand the grants back as the developer's own), and an `.inactive` write while active grants exist logs a one-time warning.

The granted set itself is held in memory by `EntitlementsInfo.granted` (loaded once, write-through on set) — the cache doesn't memoize storage misses, so reading through on every publish would have meant a synchronous disk probe for the majority of apps that never grant.

## CustomerInfo

Granted entitlements are a first-class source in every customer-info merge — one `mergePrioritized` and one sort per composition: `merging(with:granting:)` on the automatic path (`ReceiptManager`, `WebEntitlementRedeemer`, the grant-change refresh), folded into `forExternalPurchaseController`'s own merge (the `.appStore` filter is deliberately not widened — that would resurrect revoked web entitlements), and `CustomerInfo.preservingExternalControllerEntitlements` for the external-controller composition on receipt load, where the external-only ID filter would otherwise drop a grant colliding with an expired device entitlement. The automatic path now merges uniformly, so subscription order without web data follows the same purchase-date sort as with it.

## Observability

- `subscriptionStatus_didChange` gains a `granted_entitlement_ids` param listing which active entitlements are developer-granted (the merged set doesn't record where each entitlement came from).
- New `grantedEntitlements` log scope (declared after `.all` to keep existing raw values stable): info on set/clear, a one-time warning when `.inactive` is assigned through the public setter while granted is non-empty, and a warning on reset.

## Tests

30 tests in `GrantedEntitlementsTests` (running on an in-memory `CacheMock` so nothing leaks to the on-disk store shared with parallel suites) covering: merge with active/inactive/unknown assigned values, inactive-only grants, duplicate-ID grants, empty-`.active` collapse ordering, clearing restores the assigned status, replace-outright semantics, write-back of the published status staying revocable, merge precedence in both directions, re-assignment idempotence, assigned-value persistence, clear-after-relaunch round-trip, a concurrent-writers race on the persisted value, `reset()` survival, CustomerInfo propagation on both paths including the external-controller ID collision and placeholder preservation, single-emission publishing for both SDK and developer writers, re-entrant assignment from a subscriber, no delegate flicker on `.inactive` writes with grants, and the event param. Full suite green on iPhone 17 Pro (iOS 26.5).

Version bumped 4.16.4 → 4.17.0 (new public API in the staged release).

## Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs. (SDK doc comments updated; online docs still to do.)
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


