### PR TITLE
fix: send unknown entitlement details as null, not as missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Fixes subscribers with an unexpired subscription being reported as `inactive` on cold launch when the App Store has no purchases to report. Refunded and expired App Store subscriptions still deactivate immediately.
 - Fixes a data race during SDK configuration that Thread Sanitizer flagged on every launch.
 - Fixes issue where paying web users could end up having a temporary inactive subscription status if the server temporarily returns no entitlement data for them.
-- Fixes audiences matching users they shouldn't when you use a Purchase Controller. An entitlement's renewal details are unknown in that setup, and audience filters were reading the missing details as `false`, so an active subscriber could match an audience like "active and will not renew". Unknown details are now sent as null and no longer match.
+- Fixes audiences matching users they shouldn't when you use a Purchase Controller. An entitlement's renewal details are unknown in that setup, and audience filters were reading the missing details as `false`, so an active subscriber could match an audience like "active and will not renew". Audience filters now see those details as null and no longer match them. Only audience filters changed — the enrichment request, paywall template variables, session attributes and `getDeviceAttributes()` all keep the shape they had.
 
 ## 4.16.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Fixes subscribers with an unexpired subscription being reported as `inactive` on cold launch when the App Store has no purchases to report. Refunded and expired App Store subscriptions still deactivate immediately.
 - Fixes a data race during SDK configuration that Thread Sanitizer flagged on every launch.
 - Fixes issue where paying web users could end up having a temporary inactive subscription status if the server temporarily returns no entitlement data for them.
+- Fixes audiences matching users they shouldn't when you use a Purchase Controller. An entitlement's renewal details are unknown in that setup, and audience filters were reading the missing details as `false`, so an active subscriber could match an audience like "active and will not renew". Unknown details are now sent as null and no longer match.
 
 ## 4.16.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Fixes subscribers with an unexpired subscription being reported as `inactive` on cold launch when the App Store has no purchases to report. Refunded and expired App Store subscriptions still deactivate immediately.
 - Fixes a data race during SDK configuration that Thread Sanitizer flagged on every launch.
 - Fixes issue where paying web users could end up having a temporary inactive subscription status if the server temporarily returns no entitlement data for them.
-- Fixes audiences matching users they shouldn't when you use a Purchase Controller. An entitlement's renewal details are unknown in that setup, and audience filters were reading the missing details as `false`, so an active subscriber could match an audience like "active and will not renew". Audience filters now see those details as null and no longer match them. Only audience filters changed — the enrichment request, paywall template variables, session attributes and `getDeviceAttributes()` all keep the shape they had.
+- Fixes audiences matching users they shouldn't when you use a Purchase Controller.
 
 ## 4.16.3
 

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -470,7 +470,8 @@ extension DependencyContainer: AudienceFilterAttributesFactory {
 
     let deviceAttributes = await deviceHelper.getDeviceAttributes(
       since: placement,
-      computedPropertyRequests: computedPropertyRequests
+      computedPropertyRequests: computedPropertyRequests,
+      reportingUnknownFieldsAsNull: true
     )
     return [
       "user": userAttributes,

--- a/Sources/SuperwallKit/Misc/Extensions/Encoder+ReportsUnknownFieldsAsNull.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/Encoder+ReportsUnknownFieldsAsNull.swift
@@ -1,5 +1,5 @@
 //
-//  KeyedEncodingContainer+EncodeNilOrValue.swift
+//  Encoder+ReportsUnknownFieldsAsNull.swift
 //  SuperwallKit
 //
 //  Created by Yusuf Tör on 07/09/2026.

--- a/Sources/SuperwallKit/Misc/Extensions/KeyedEncodingContainer+EncodeNilOrValue.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/KeyedEncodingContainer+EncodeNilOrValue.swift
@@ -1,0 +1,27 @@
+//
+//  KeyedEncodingContainer+EncodeNilOrValue.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 07/09/2026.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encodes an optional, writing an explicit null when it's `nil`.
+  ///
+  /// `encodeIfPresent` leaves the key out entirely, which loses the difference
+  /// between a value we know to be absent and one we never learned. Audience
+  /// filters give a missing key the type default, so a dropped `Bool?` reads as
+  /// `false`. Use this for any field a filter might compare by equality.
+  mutating func encodeNilOrValue<T: Encodable>(
+    _ value: T?,
+    forKey key: Key
+  ) throws {
+    if let value = value {
+      try encode(value, forKey: key)
+    } else {
+      try encodeNil(forKey: key)
+    }
+  }
+}

--- a/Sources/SuperwallKit/Misc/Extensions/KeyedEncodingContainer+EncodeNilOrValue.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/KeyedEncodingContainer+EncodeNilOrValue.swift
@@ -14,6 +14,12 @@ extension KeyedEncodingContainer {
   /// between a value we know to be absent and one we never learned. Audience
   /// filters give a missing key the type default, so a dropped `Bool?` reads as
   /// `false`. Use this for any field a filter might compare by equality.
+  ///
+  /// Plain `encode(_:forKey:)` on an optional already writes a null, since
+  /// `Optional`'s own `Encodable` conformance calls `encodeNil()`. This spells
+  /// that out at the call site: the one-character difference between `encode`
+  /// and `encodeIfPresent` is easy to read as a typo and "tidy up" back into
+  /// the bug.
   mutating func encodeNilOrValue<T: Encodable>(
     _ value: T?,
     forKey key: Key

--- a/Sources/SuperwallKit/Misc/Extensions/KeyedEncodingContainer+EncodeNilOrValue.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/KeyedEncodingContainer+EncodeNilOrValue.swift
@@ -7,26 +7,51 @@
 
 import Foundation
 
-extension KeyedEncodingContainer {
-  /// Encodes an optional, writing an explicit null when it's `nil`.
+extension CodingUserInfoKey {
+  /// Set on an encoder to write a field we have no value for as an explicit
+  /// null instead of leaving the key out.
   ///
-  /// `encodeIfPresent` leaves the key out entirely, which loses the difference
-  /// between a value we know to be absent and one we never learned. Audience
-  /// filters give a missing key the type default, so a dropped `Bool?` reads as
-  /// `false`. Use this for any field a filter might compare by equality.
+  /// Only the audience filter attributes are encoded this way. A filter gives a
+  /// missing key the type default, so a dropped `Bool?` reads as `false` and a
+  /// bare Purchase Controller entitlement matched `willRenew == false`. Every
+  /// other consumer — the enrichment request, paywall template variables,
+  /// session attributes and `getDeviceAttributes()` — keeps the shape it has
+  /// always had.
+  // swiftlint:disable:next force_unwrapping
+  static let reportsUnknownFieldsAsNull = CodingUserInfoKey(rawValue: "reportsUnknownFieldsAsNull")!
+}
+
+extension Encoder {
+  /// Whether this encoder wants unknown fields written as explicit nulls.
+  var reportsUnknownFieldsAsNull: Bool {
+    userInfo[.reportsUnknownFieldsAsNull] as? Bool ?? false
+  }
+}
+
+extension JSONEncoder {
+  /// An encoder that writes unknown optional fields as explicit nulls.
+  static func reportingUnknownFieldsAsNull() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.userInfo[.reportsUnknownFieldsAsNull] = true
+    return encoder
+  }
+}
+
+extension KeyedEncodingContainer {
+  /// Encodes an optional, either leaving the key out when it's `nil` or writing
+  /// an explicit null, depending on what the encoder asked for.
   ///
   /// Plain `encode(_:forKey:)` on an optional already writes a null, since
-  /// `Optional`'s own `Encodable` conformance calls `encodeNil()`. This spells
-  /// that out at the call site: the one-character difference between `encode`
-  /// and `encodeIfPresent` is easy to read as a typo and "tidy up" back into
-  /// the bug.
-  mutating func encodeNilOrValue<T: Encodable>(
+  /// `Optional`'s own `Encodable` conformance calls `encodeNil()`. Spelling it
+  /// out keeps the two behaviours side by side at the call site.
+  mutating func encode<T: Encodable>(
     _ value: T?,
-    forKey key: Key
+    forKey key: Key,
+    nilAsNull: Bool
   ) throws {
     if let value = value {
       try encode(value, forKey: key)
-    } else {
+    } else if nilAsNull {
       try encodeNil(forKey: key)
     }
   }

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -794,11 +794,16 @@ class DeviceHelper {
     )
   }
 
+  /// - Parameter reportingUnknownFieldsAsNull: Only the audience filter
+  ///   attributes pass `true`. See ``CodingUserInfoKey/reportsUnknownFieldsAsNull``.
   func getDeviceAttributes(
     since placement: PlacementData?,
-    computedPropertyRequests: [ComputedPropertyRequest]
+    computedPropertyRequests: [ComputedPropertyRequest],
+    reportingUnknownFieldsAsNull: Bool = false
   ) async -> [String: Any] {
-    var dictionary = await getTemplateDevice()
+    var dictionary = await getTemplateDevice(
+      reportingUnknownFieldsAsNull: reportingUnknownFieldsAsNull
+    )
 
     let computedProperties = await getComputedDevicePropertiesSincePlacement(
       placement,
@@ -952,7 +957,7 @@ class DeviceHelper {
     }
   }
 
-  func getTemplateDevice() async -> [String: Any] {
+  func getTemplateDevice(reportingUnknownFieldsAsNull: Bool = false) async -> [String: Any] {
     let identityInfo = await factory.makeIdentityInfo()
     let aliases = [identityInfo.aliasId]
 
@@ -1028,7 +1033,11 @@ class DeviceHelper {
       deviceId: factory.makeDeviceId()
     )
 
-    var deviceDictionary = template.toDictionary()
+    var deviceDictionary = template.toDictionary(
+      encoder: reportingUnknownFieldsAsNull
+        ? .reportingUnknownFieldsAsNull()
+        : JSONEncoder()
+    )
 
     let enrichmentDict: [String: Any] = $enrichment.withSnapshot { enrichment in
       enrichment?.device.dictionaryObject ?? [:]

--- a/Sources/SuperwallKit/Paywall/Presentation/Audience Logic/Expression Evaluator/EvaluationContext.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Audience Logic/Expression Evaluator/EvaluationContext.swift
@@ -124,6 +124,11 @@ func toPassableValue(from anyValue: Any) -> PassableValue {
   }
 
   switch anyValue {
+  case is NSNull:
+    // A field the SDK explicitly reported as unknown. Without this it would fall
+    // through to the `default` case and come out as an empty map, which can't be
+    // compared to anything.
+    return .null
   case let value as Int:
     return .int(value)
   case let value as UInt64:

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/DeviceTemplate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/DeviceTemplate.swift
@@ -70,8 +70,8 @@ struct DeviceTemplate: Codable {
   var localResourceIds: String
   var deviceId: String
 
-  func toDictionary() -> [String: Any] {
-    guard let data = try? JSONEncoder().encode(self) else {
+  func toDictionary(encoder: JSONEncoder = JSONEncoder()) -> [String: Any] {
+    guard let data = try? encoder.encode(self) else {
       return [:]
     }
     let jsonObject = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift
@@ -247,20 +247,23 @@ public final class Entitlement: NSObject, Codable, Sendable {
     try container.encodeIfPresent(startsAt, forKey: .startsAt)
     try container.encodeIfPresent(renewedAt, forKey: .renewedAt)
     try container.encodeIfPresent(expiresAt, forKey: .expiresAt)
-    // Encoded as an explicit null rather than left out, so an audience filter can
-    // tell "we don't know" from "no". A Purchase Controller can't fill these in,
-    // and a missing key is given the type default during filter evaluation, which
-    // made a bare entitlement match `willRenew == false`.
+    // When the encoder asks for it, a detail we have no value for is written as
+    // an explicit null rather than left out, so an audience filter can tell "we
+    // don't know" from "no". A Purchase Controller can't fill these in, and a
+    // filter gives a missing key the type default, which made a bare entitlement
+    // match `willRenew == false`. Only the filter attributes are encoded that
+    // way; every other consumer sees the keys omitted as before.
     //
-    // The dates above stay `encodeIfPresent`: filters compare them with `<` and
-    // `>`, and a null on either side of an ordering comparison makes the whole
-    // filter evaluate to null, taking unrelated parts of the filter with it.
-    try container.encodeNilOrValue(latestProductId, forKey: .latestProductId)
-    try container.encodeNilOrValue(store, forKey: .store)
-    try container.encodeNilOrValue(isLifetime, forKey: .isLifetime)
-    try container.encodeNilOrValue(willRenew, forKey: .willRenew)
-    try container.encodeNilOrValue(state, forKey: .state)
-    try container.encodeNilOrValue(offerType, forKey: .offerType)
+    // The dates above are never nulled: filters compare them with `<` and `>`,
+    // and a null on either side of an ordering comparison makes the whole filter
+    // evaluate to null, taking unrelated parts of the filter with it.
+    let nilAsNull = encoder.reportsUnknownFieldsAsNull
+    try container.encode(latestProductId, forKey: .latestProductId, nilAsNull: nilAsNull)
+    try container.encode(store, forKey: .store, nilAsNull: nilAsNull)
+    try container.encode(isLifetime, forKey: .isLifetime, nilAsNull: nilAsNull)
+    try container.encode(willRenew, forKey: .willRenew, nilAsNull: nilAsNull)
+    try container.encode(state, forKey: .state, nilAsNull: nilAsNull)
+    try container.encode(offerType, forKey: .offerType, nilAsNull: nilAsNull)
   }
 
   // Deep equality across all fields. For detecting logical status changes,

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/Entitlement.swift
@@ -244,15 +244,23 @@ public final class Entitlement: NSObject, Codable, Sendable {
     try container.encode(type, forKey: .type)
     try container.encodeIfPresent(isActive, forKey: .isActive)
     try container.encodeIfPresent(productIds, forKey: .productIds)
-    try container.encodeIfPresent(latestProductId, forKey: .latestProductId)
-    try container.encodeIfPresent(store, forKey: .store)
     try container.encodeIfPresent(startsAt, forKey: .startsAt)
     try container.encodeIfPresent(renewedAt, forKey: .renewedAt)
     try container.encodeIfPresent(expiresAt, forKey: .expiresAt)
-    try container.encodeIfPresent(isLifetime, forKey: .isLifetime)
-    try container.encodeIfPresent(willRenew, forKey: .willRenew)
-    try container.encodeIfPresent(state, forKey: .state)
-    try container.encodeIfPresent(offerType, forKey: .offerType)
+    // Encoded as an explicit null rather than left out, so an audience filter can
+    // tell "we don't know" from "no". A Purchase Controller can't fill these in,
+    // and a missing key is given the type default during filter evaluation, which
+    // made a bare entitlement match `willRenew == false`.
+    //
+    // The dates above stay `encodeIfPresent`: filters compare them with `<` and
+    // `>`, and a null on either side of an ordering comparison makes the whole
+    // filter evaluate to null, taking unrelated parts of the filter with it.
+    try container.encodeNilOrValue(latestProductId, forKey: .latestProductId)
+    try container.encodeNilOrValue(store, forKey: .store)
+    try container.encodeNilOrValue(isLifetime, forKey: .isLifetime)
+    try container.encodeNilOrValue(willRenew, forKey: .willRenew)
+    try container.encodeNilOrValue(state, forKey: .state)
+    try container.encodeNilOrValue(offerType, forKey: .offerType)
   }
 
   // Deep equality across all fields. For detecting logical status changes,

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		1E0D00DF75A6779C78145750 /* SurveyPresentationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B66B5A624F8A2E225EACA69 /* SurveyPresentationResult.swift */; };
 		1E7EBE0C39AC302D9B5BFF27 /* PublicGameController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010F0F8FCE0A86D8F2823A47 /* PublicGameController.swift */; };
 		1E81A71ADE8A5EAD9E609E1D /* AppSessionManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B78FB9232236AF44369EA92 /* AppSessionManagerMock.swift */; };
+		1EA8A326074CB46980BA7C9C /* Encoder+ReportsUnknownFieldsAsNull.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47AA8B18B4570F0C24B7389 /* Encoder+ReportsUnknownFieldsAsNull.swift */; };
 		1F20D775BC035F8A75B79323 /* PaywallMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF61DCA9CF170E0AFC507BAE /* PaywallMessageHandler.swift */; };
 		1F9AE04458B942D070FC4832 /* FakeTrackingAuthorizationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE43B98D847BB6DE291F0B4 /* FakeTrackingAuthorizationStatusTests.swift */; };
 		1FB66F276E4FD5AEC37EC14A /* ContactStoreProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F35F68AF572F7CDF174320C /* ContactStoreProxy.swift */; };
@@ -126,7 +127,6 @@
 		342593FCA24FBEA77FE472C7 /* SK2ReceiptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050BC76657949DBB5F3D551C /* SK2ReceiptManager.swift */; };
 		3464196F9088F8A320FE24A4 /* PendingStripeCheckoutPollState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797EC0356AA1065ED11835BF /* PendingStripeCheckoutPollState.swift */; };
 		35597883CB038DBEE63E162B /* EventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86D76FB5809C3B8122778A9 /* EventData.swift */; };
-		3584214186291379380E6823 /* KeyedEncodingContainer+EncodeNilOrValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D326F60B14F6911B6BDFD96B /* KeyedEncodingContainer+EncodeNilOrValue.swift */; };
 		3652D5EE4C172D623BDEE7E4 /* PresentationIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F306D67A9F3A43D082DD83 /* PresentationIdTests.swift */; };
 		369677E9A6E8754CFD20714D /* TrackingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764012CF0C0972240A73E3CF /* TrackingParameters.swift */; };
 		36B598D26A38D50CC713FD73 /* ProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641BC3C3F8AC2D6E1EF44D55 /* ProductsManager.swift */; };
@@ -1115,13 +1115,13 @@
 		D1443B535E6E1D572A74733F /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriod.swift; sourceTree = "<group>"; };
 		D198C8645A213EEAD622C881 /* FakeLocationAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeLocationAuthorizationStatus.swift; sourceTree = "<group>"; };
 		D31BB6D0C57337C6E929D617 /* ASN1Decoder+UnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASN1Decoder+UnkeyedDecodingContainer.swift"; sourceTree = "<group>"; };
-		D326F60B14F6911B6BDFD96B /* KeyedEncodingContainer+EncodeNilOrValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedEncodingContainer+EncodeNilOrValue.swift"; sourceTree = "<group>"; };
 		D3479E4B3365290BC0C0A123 /* StripeProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeProduct.swift; sourceTree = "<group>"; };
 		D3506FCC35155DF104A1DFCA /* CustomURLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomURLSessionMock.swift; sourceTree = "<group>"; };
 		D36898353ABCE620BA7AEE59 /* SuperwallGraveyard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallGraveyard.swift; sourceTree = "<group>"; };
 		D38D3A69A26709BFB52C6A3A /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		D3E5C31CEEDC9C2853D91C50 /* DeviceTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTemplate.swift; sourceTree = "<group>"; };
 		D449672964023589DA5535E3 /* String+MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MD5.swift"; sourceTree = "<group>"; };
+		D47AA8B18B4570F0C24B7389 /* Encoder+ReportsUnknownFieldsAsNull.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encoder+ReportsUnknownFieldsAsNull.swift"; sourceTree = "<group>"; };
 		D4F676D3A0F5B540052D36B1 /* PublicGetPresentationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGetPresentationResult.swift; sourceTree = "<group>"; };
 		D561728FDB68F572D5E33223 /* PermissionsHandler+Contacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PermissionsHandler+Contacts.swift"; sourceTree = "<group>"; };
 		D570217FF965FF087585931C /* PaywallPreloadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPreloadingTests.swift; sourceTree = "<group>"; };
@@ -1678,11 +1678,11 @@
 				4B1DC32C4ABB60B8323E5D28 /* AsyncSequence+Extract.swift */,
 				51407421A3CBF7AF0FC76E60 /* Bundle+Helpers.swift */,
 				B2E6016BF483A4C47FF7A7C0 /* Encodable+Dictionary.swift */,
+				D47AA8B18B4570F0C24B7389 /* Encoder+ReportsUnknownFieldsAsNull.swift */,
 				9A7FFEA64AF7F4E09F052FCD /* Error+SafeLocalizedDescription.swift */,
 				8DE36D141F461F6E945823FA /* Future+Async.swift */,
 				E2243C6BF6BE477794F568ED /* GCControllerElement+buttonName.swift */,
 				FD778E66506BA51BEB5EE89C /* JSONEncoder+Superwall.swift */,
-				D326F60B14F6911B6BDFD96B /* KeyedEncodingContainer+EncodeNilOrValue.swift */,
 				F4B35EF62D8C986B504B052C /* NSManagedObjectContext+mergeChanges.swift */,
 				AF5A8FFFC23826AD113D525A /* Publisher+Async.swift */,
 				A524F7AAE90E48C3B8D7E99A /* PurchaseResult+Internal.swift */,
@@ -3526,6 +3526,7 @@
 				B89435087910E6B501471622 /* Email.swift in Sources */,
 				9EAE577E60052F5E1C7B9657 /* EmptyResponse.swift in Sources */,
 				CB1E11FB74879A29DD1C9EB1 /* Encodable+Dictionary.swift in Sources */,
+				1EA8A326074CB46980BA7C9C /* Encoder+ReportsUnknownFieldsAsNull.swift in Sources */,
 				11477D1EB60D1FDA32F5099A /* Endpoint.swift in Sources */,
 				AD26500C2B27829305F76859 /* EndpointKind.swift in Sources */,
 				14B9EC6E8BAE199C9349838C /* Enrichment.swift in Sources */,
@@ -3590,7 +3591,6 @@
 				CDFE4C9A23CB583CAC113F59 /* IntroOfferTokenManager.swift in Sources */,
 				E63A7174E3B98690B073C373 /* JSONEncoder+Superwall.swift in Sources */,
 				3F3774A066285BB0DFE61B61 /* JSONToDict.swift in Sources */,
-				3584214186291379380E6823 /* KeyedEncodingContainer+EncodeNilOrValue.swift in Sources */,
 				5621A2D2FEC048847E22BF6C /* KeypathWritable.swift in Sources */,
 				88A5CA6515126BD3D09E0563 /* LimitedQueue.swift in Sources */,
 				68AF64973AC860BE2A41B8D4 /* LoadingInfo.swift in Sources */,

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		342593FCA24FBEA77FE472C7 /* SK2ReceiptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050BC76657949DBB5F3D551C /* SK2ReceiptManager.swift */; };
 		3464196F9088F8A320FE24A4 /* PendingStripeCheckoutPollState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797EC0356AA1065ED11835BF /* PendingStripeCheckoutPollState.swift */; };
 		35597883CB038DBEE63E162B /* EventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86D76FB5809C3B8122778A9 /* EventData.swift */; };
+		3584214186291379380E6823 /* KeyedEncodingContainer+EncodeNilOrValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D326F60B14F6911B6BDFD96B /* KeyedEncodingContainer+EncodeNilOrValue.swift */; };
 		3652D5EE4C172D623BDEE7E4 /* PresentationIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F306D67A9F3A43D082DD83 /* PresentationIdTests.swift */; };
 		369677E9A6E8754CFD20714D /* TrackingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764012CF0C0972240A73E3CF /* TrackingParameters.swift */; };
 		36B598D26A38D50CC713FD73 /* ProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641BC3C3F8AC2D6E1EF44D55 /* ProductsManager.swift */; };
@@ -377,6 +378,7 @@
 		AEB9D461AF5103FB7257AD25 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F010DC597017F5BEAEDE86 /* SwiftyJSON.swift */; };
 		AECD80682E1909735CCDAA78 /* AdServicesAttributionAttempts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D538EA68425ECB218BA3CA /* AdServicesAttributionAttempts.swift */; };
 		AF4AD928FACF9056E00D5920 /* HandleTriggerResultOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27F0D55EF3480E2B65C8DFD /* HandleTriggerResultOperatorTests.swift */; };
+		B002C22F935F04DE75E56183 /* EntitlementUnknownFieldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6596655637A212AEE276585 /* EntitlementUnknownFieldsTests.swift */; };
 		B078481CA0ADD4B4F3BEFD15 /* LocalFileSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B0C49F4A92D8C5C05FA026 /* LocalFileSchemeHandler.swift */; };
 		B0AD4A89AD5101360F93652D /* SubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ACDC7427B6340E9D86F9B0F /* SubscriptionTransaction.swift */; };
 		B0B0AD9409CEFE7CA8225146 /* Array+SafeRemove.swift in Sources */ = {isa = PBXBuildFile; fileRef = C855DE8F5341D67C614E3AF5 /* Array+SafeRemove.swift */; };
@@ -1113,6 +1115,7 @@
 		D1443B535E6E1D572A74733F /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriod.swift; sourceTree = "<group>"; };
 		D198C8645A213EEAD622C881 /* FakeLocationAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeLocationAuthorizationStatus.swift; sourceTree = "<group>"; };
 		D31BB6D0C57337C6E929D617 /* ASN1Decoder+UnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASN1Decoder+UnkeyedDecodingContainer.swift"; sourceTree = "<group>"; };
+		D326F60B14F6911B6BDFD96B /* KeyedEncodingContainer+EncodeNilOrValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedEncodingContainer+EncodeNilOrValue.swift"; sourceTree = "<group>"; };
 		D3479E4B3365290BC0C0A123 /* StripeProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeProduct.swift; sourceTree = "<group>"; };
 		D3506FCC35155DF104A1DFCA /* CustomURLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomURLSessionMock.swift; sourceTree = "<group>"; };
 		D36898353ABCE620BA7AEE59 /* SuperwallGraveyard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallGraveyard.swift; sourceTree = "<group>"; };
@@ -1125,6 +1128,7 @@
 		D5BF66C3986E287B7B2F5E27 /* SKProductSubscriptionPeriodMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKProductSubscriptionPeriodMock.swift; sourceTree = "<group>"; };
 		D5E2D026C30691F11D4E839F /* SurveyShowCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyShowCondition.swift; sourceTree = "<group>"; };
 		D6340ACDA40937ACAC66FA3D /* EntitlementPriorityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementPriorityTests.swift; sourceTree = "<group>"; };
+		D6596655637A212AEE276585 /* EntitlementUnknownFieldsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementUnknownFieldsTests.swift; sourceTree = "<group>"; };
 		D69BCC259F5FBE15AB02D662 /* PermissionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionHandler.swift; sourceTree = "<group>"; };
 		D7434029CB9E4680C85D3FB6 /* PermissionHandler+Microphone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PermissionHandler+Microphone.swift"; sourceTree = "<group>"; };
 		D7B0C7BDA06D25D9D5A865A3 /* TestModeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModeManagerTests.swift; sourceTree = "<group>"; };
@@ -1678,6 +1682,7 @@
 				8DE36D141F461F6E945823FA /* Future+Async.swift */,
 				E2243C6BF6BE477794F568ED /* GCControllerElement+buttonName.swift */,
 				FD778E66506BA51BEB5EE89C /* JSONEncoder+Superwall.swift */,
+				D326F60B14F6911B6BDFD96B /* KeyedEncodingContainer+EncodeNilOrValue.swift */,
 				F4B35EF62D8C986B504B052C /* NSManagedObjectContext+mergeChanges.swift */,
 				AF5A8FFFC23826AD113D525A /* Publisher+Async.swift */,
 				A524F7AAE90E48C3B8D7E99A /* PurchaseResult+Internal.swift */,
@@ -2407,6 +2412,7 @@
 			isa = PBXGroup;
 			children = (
 				D6340ACDA40937ACAC66FA3D /* EntitlementPriorityTests.swift */,
+				D6596655637A212AEE276585 /* EntitlementUnknownFieldsTests.swift */,
 				BC580BF1CC720ECBC4E68A28 /* SK2PriceFormatRoundingTests.swift */,
 				F98E1C9554F6AFAECF9B3430 /* StoreProductBillingPlanTests.swift */,
 				2CF1F5EAC9C4E384EBBE5EA9 /* SubscriptionPeriodPriceTests.swift */,
@@ -3324,6 +3330,7 @@
 				49A7156A67C8BAB23F97EC39 /* EmailTests.swift in Sources */,
 				A03AC977AD8110290DABECBD /* EntitlementPriorityTests.swift in Sources */,
 				6BA614F410A95F36CBA42F93 /* EntitlementProcessorTests.swift in Sources */,
+				B002C22F935F04DE75E56183 /* EntitlementUnknownFieldsTests.swift in Sources */,
 				1225B991B40D16B7FB4EF1A5 /* EvaluateRulesOperatorTests.swift in Sources */,
 				158EBAAC2A96F73B93C48E15 /* ExpressionEvaluatorMock.swift in Sources */,
 				77ED3D92C176CC6D93D625B2 /* ExpressionLogicTests.swift in Sources */,
@@ -3583,6 +3590,7 @@
 				CDFE4C9A23CB583CAC113F59 /* IntroOfferTokenManager.swift in Sources */,
 				E63A7174E3B98690B073C373 /* JSONEncoder+Superwall.swift in Sources */,
 				3F3774A066285BB0DFE61B61 /* JSONToDict.swift in Sources */,
+				3584214186291379380E6823 /* KeyedEncodingContainer+EncodeNilOrValue.swift in Sources */,
 				5621A2D2FEC048847E22BF6C /* KeypathWritable.swift in Sources */,
 				88A5CA6515126BD3D09E0563 /* LimitedQueue.swift in Sources */,
 				68AF64973AC860BE2A41B8D4 /* LoadingInfo.swift in Sources */,

--- a/Tests/SuperwallKitTests/Network/DeviceHelperMock.swift
+++ b/Tests/SuperwallKitTests/Network/DeviceHelperMock.swift
@@ -24,7 +24,7 @@ final class DeviceHelperMock: DeviceHelper {
     // Don't actually fetch enrichment in tests - just return immediately
   }
 
-  override func getTemplateDevice() async -> [String: Any] {
+  override func getTemplateDevice(reportingUnknownFieldsAsNull: Bool = false) async -> [String: Any] {
     // Return mock device attributes without async calls
     return [
       "publicApiKey": "test_key",

--- a/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/EntitlementUnknownFieldsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/EntitlementUnknownFieldsTests.swift
@@ -1,0 +1,142 @@
+//
+//  EntitlementUnknownFieldsTests.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 07/09/2026.
+//
+// swiftlint:disable all
+
+import Foundation
+import Superscript
+import Testing
+@testable import SuperwallKit
+
+/// An entitlement that a Purchase Controller supplies carries no renewal
+/// metadata. These tests pin down that "we don't know" reaches an audience
+/// filter as null rather than as an absent key, because a filter gives an
+/// absent key the type default and so reads a dropped `Bool?` as `false`.
+@Suite(.serialized)
+struct EntitlementUnknownFieldsTests {
+  /// The same trip an entitlement makes on its way to a filter:
+  /// `JSONEncoder` -> `JSONSerialization` -> `[String: Any]`.
+  private func encodedDictionary(_ entitlement: Entitlement) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(entitlement)
+    let object = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+    return try #require(object as? [String: Any])
+  }
+
+  private func evaluate(_ expression: String, entitlement: Entitlement) throws -> String {
+    let attributes: [String: Any] = [
+      "device": [
+        "customerInfo": [
+          "entitlements": [try encodedDictionary(entitlement)]
+        ]
+      ]
+    ]
+
+    var variablesMap: [String: PassableValue] = [:]
+    if case let PassableValue.map(dictionary) = toPassableValue(from: attributes) {
+      variablesMap = dictionary
+    }
+
+    let executionContext = ExecutionContext(
+      variables: PassableMap(map: variablesMap),
+      computed: [:],
+      device: [:],
+      expression: expression
+    )
+    let jsonData = try JSONEncoder().encode(executionContext)
+    let jsonString = try #require(String(data: jsonData, encoding: .utf8))
+
+    let dependencyContainer = DependencyContainer()
+    return evaluateWithContext(
+      definition: jsonString,
+      context: EvaluationContext(storage: dependencyContainer.storage)
+    )
+  }
+
+  /// The audience from the incident: "active, and will not renew".
+  private let willNotRenewFilter = """
+    device.customerInfo.entitlements.exists(e, e.isActive == true && e.willRenew == false)
+    """
+
+  @Test func unknownWillRenewIsEncodedAsExplicitNull() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true)
+    let dictionary = try encodedDictionary(entitlement)
+
+    #expect(dictionary.keys.contains("willRenew"))
+    #expect(dictionary["willRenew"] is NSNull)
+  }
+
+  @Test func knownWillRenewIsEncodedAsItsValue() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true, willRenew: false)
+    let dictionary = try encodedDictionary(entitlement)
+
+    #expect(dictionary["willRenew"] as? Bool == false)
+  }
+
+  /// Dates are deliberately left out rather than nulled: filters compare them
+  /// with `<` and `>`, and null on either side of an ordering comparison makes
+  /// the whole filter evaluate to null.
+  @Test func unknownDatesAreLeftOut() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true)
+    let dictionary = try encodedDictionary(entitlement)
+
+    #expect(dictionary.keys.contains("expiresAt") == false)
+    #expect(dictionary.keys.contains("startsAt") == false)
+    #expect(dictionary.keys.contains("renewedAt") == false)
+  }
+
+  @Test func nsNullBecomesPassableNull() {
+    if case PassableValue.null = toPassableValue(from: NSNull()) {
+      return
+    }
+    Issue.record("Expected NSNull to become PassableValue.null")
+  }
+
+  @Test func nullSurvivesTheTripIntoTheFilterContext() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true)
+    let passableValue = toPassableValue(from: try encodedDictionary(entitlement))
+
+    guard case let PassableValue.map(dictionary) = passableValue else {
+      Issue.record("Expected a map")
+      return
+    }
+    if case PassableValue.null = try #require(dictionary["willRenew"]) {
+      return
+    }
+    Issue.record("Expected willRenew to be PassableValue.null")
+  }
+
+  @Test func bareEntitlementDoesNotMatchWillNotRenew() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true)
+    let result = try evaluate(willNotRenewFilter, entitlement: entitlement)
+
+    #expect(result == #"{"Ok":{"type":"bool","value":false}}"#)
+  }
+
+  @Test func explicitlyNotRenewingStillMatches() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true, willRenew: false)
+    let result = try evaluate(willNotRenewFilter, entitlement: entitlement)
+
+    #expect(result == #"{"Ok":{"type":"bool","value":true}}"#)
+  }
+
+  @Test func explicitlyRenewingDoesNotMatch() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true, willRenew: true)
+    let result = try evaluate(willNotRenewFilter, entitlement: entitlement)
+
+    #expect(result == #"{"Ok":{"type":"bool","value":false}}"#)
+  }
+
+  /// A filter can still ask whether the SDK knows the renewal state.
+  @Test func unknownWillRenewComparesEqualToNull() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true)
+    let result = try evaluate(
+      "device.customerInfo.entitlements.exists(e, e.willRenew == null)",
+      entitlement: entitlement
+    )
+
+    #expect(result == #"{"Ok":{"type":"bool","value":true}}"#)
+  }
+}

--- a/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/EntitlementUnknownFieldsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/EntitlementUnknownFieldsTests.swift
@@ -158,6 +158,45 @@ struct EntitlementUnknownFieldsTests {
     #expect(forEveryoneElse.present == false)
   }
 
+  /// Runs the real production call rather than a hand-built encoder, so that
+  /// removing `reportingUnknownFieldsAsNull: true` from
+  /// `makeAudienceFilterAttributes` fails a test instead of silently restoring
+  /// the incident. That one argument is the whole opt-in.
+  @Test func onlyTheAudienceFilterPathReportsUnknownFieldsAsNull() async throws {
+    let container = DependencyContainer()
+    let previous = Superwall.shared.customerInfo
+    defer { Superwall.shared.customerInfo = previous }
+
+    Superwall.shared.customerInfo = CustomerInfo(
+      subscriptions: [],
+      nonSubscriptions: [],
+      entitlements: [Entitlement(id: "unlimited_access", isActive: true)],
+      isPlaceholder: false
+    )
+
+    func willRenewEntry(in device: [String: Any]) throws -> (present: Bool, isNull: Bool) {
+      let customerInfo = try #require(device["customerInfo"] as? [String: Any])
+      let entitlements = try #require(customerInfo["entitlements"] as? [[String: Any]])
+      let entitlement = try #require(
+        entitlements.first { $0["identifier"] as? String == "unlimited_access" }
+      )
+      return (entitlement.keys.contains("willRenew"), entitlement["willRenew"] is NSNull)
+    }
+
+    let filterAttributes = await container.makeAudienceFilterAttributes(
+      forPlacement: nil,
+      withComputedProperties: []
+    )
+    let filterDevice = try #require(filterAttributes["device"] as? [String: Any])
+    let forFilters = try willRenewEntry(in: filterDevice)
+    #expect(forFilters.present)
+    #expect(forFilters.isNull)
+
+    // The same data on the way to every other consumer keeps its old shape.
+    let template = await container.deviceHelper.getTemplateDevice()
+    #expect(try willRenewEntry(in: template).present == false)
+  }
+
   @Test func nsNullBecomesPassableNull() {
     if case PassableValue.null = toPassableValue(from: NSNull()) {
       return

--- a/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/EntitlementUnknownFieldsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/EntitlementUnknownFieldsTests.swift
@@ -25,7 +25,16 @@ struct EntitlementUnknownFieldsTests {
     return try #require(object as? [String: Any])
   }
 
-  private func evaluate(_ expression: String, entitlement: Entitlement) throws -> String {
+  /// One container for the suite: building one spins up real storage and a
+  /// persistent container, which the sibling `CELEvaluatorTests` resets for the
+  /// same reason.
+  private static let dependencyContainer: DependencyContainer = {
+    let container = DependencyContainer()
+    container.storage.reset()
+    return container
+  }()
+
+  private func evaluate(_ expression: String, entitlement: Entitlement) throws -> Bool {
     let attributes: [String: Any] = [
       "device": [
         "customerInfo": [
@@ -39,20 +48,36 @@ struct EntitlementUnknownFieldsTests {
       variablesMap = dictionary
     }
 
+    // Mirrors what CELEvaluator passes in production.
+    let computedProperties = Dictionary(uniqueKeysWithValues:
+      ComputedPropertyRequestType.allCases.map {
+        ($0.description, [PassableValue.string("event_name")])
+      }
+    )
     let executionContext = ExecutionContext(
       variables: PassableMap(map: variablesMap),
-      computed: [:],
-      device: [:],
+      computed: computedProperties,
+      device: computedProperties,
       expression: expression
     )
     let jsonData = try JSONEncoder().encode(executionContext)
     let jsonString = try #require(String(data: jsonData, encoding: .utf8))
 
-    let dependencyContainer = DependencyContainer()
-    return evaluateWithContext(
+    let output = evaluateWithContext(
       definition: jsonString,
-      context: EvaluationContext(storage: dependencyContainer.storage)
+      context: EvaluationContext(storage: Self.dependencyContainer.storage)
     )
+
+    // Decoded rather than compared byte for byte, so a future Superscript bump
+    // that reshapes the wrapper doesn't read as a behaviour change.
+    let outputData = try #require(output.data(using: .utf8))
+    let result = try JSONDecoder().decode(EvaluationResult.self, from: outputData)
+    guard case let .success(value) = result,
+      case let .bool(matched) = value else {
+      Issue.record("Expected a boolean result, got \(output)")
+      return false
+    }
+    return matched
   }
 
   /// The audience from the incident: "active, and will not renew".
@@ -110,33 +135,55 @@ struct EntitlementUnknownFieldsTests {
 
   @Test func bareEntitlementDoesNotMatchWillNotRenew() throws {
     let entitlement = Entitlement(id: "unlimited_access", isActive: true)
-    let result = try evaluate(willNotRenewFilter, entitlement: entitlement)
-
-    #expect(result == #"{"Ok":{"type":"bool","value":false}}"#)
+    #expect(try evaluate(willNotRenewFilter, entitlement: entitlement) == false)
   }
 
   @Test func explicitlyNotRenewingStillMatches() throws {
     let entitlement = Entitlement(id: "unlimited_access", isActive: true, willRenew: false)
-    let result = try evaluate(willNotRenewFilter, entitlement: entitlement)
-
-    #expect(result == #"{"Ok":{"type":"bool","value":true}}"#)
+    #expect(try evaluate(willNotRenewFilter, entitlement: entitlement) == true)
   }
 
   @Test func explicitlyRenewingDoesNotMatch() throws {
     let entitlement = Entitlement(id: "unlimited_access", isActive: true, willRenew: true)
-    let result = try evaluate(willNotRenewFilter, entitlement: entitlement)
+    #expect(try evaluate(willNotRenewFilter, entitlement: entitlement) == false)
+  }
 
-    #expect(result == #"{"Ok":{"type":"bool","value":false}}"#)
+  /// The string-valued fields are nulled too, so equality against them has to
+  /// stay a plain no-match rather than becoming an error or a null that would
+  /// take the rest of the filter with it.
+  @Test(arguments: [
+    "device.customerInfo.entitlements.exists(e, e.store == \"APP_STORE\")",
+    "device.customerInfo.entitlements.exists(e, e.state == \"SUBSCRIBED\")",
+    "device.customerInfo.entitlements.exists(e, e.latestProductId == \"pro_yearly\")",
+    "device.customerInfo.entitlements.exists(e, e.isLifetime == true)"
+  ])
+  func unknownStringFieldsDoNotMatch(expression: String) throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true)
+
+    #expect(try evaluate(expression, entitlement: entitlement) == false)
+  }
+
+  /// The whole point of the change: the field is now present, so a filter can
+  /// tell that the SDK holds no opinion rather than reading a default.
+  @Test func unknownWillRenewIsReportedAsPresent() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true)
+
+    #expect(
+      try evaluate(
+        "device.customerInfo.entitlements.exists(e, has(e.willRenew))",
+        entitlement: entitlement
+      ) == true
+    )
   }
 
   /// A filter can still ask whether the SDK knows the renewal state.
   @Test func unknownWillRenewComparesEqualToNull() throws {
     let entitlement = Entitlement(id: "unlimited_access", isActive: true)
-    let result = try evaluate(
-      "device.customerInfo.entitlements.exists(e, e.willRenew == null)",
-      entitlement: entitlement
+    #expect(
+      try evaluate(
+        "device.customerInfo.entitlements.exists(e, e.willRenew == null)",
+        entitlement: entitlement
+      ) == true
     )
-
-    #expect(result == #"{"Ok":{"type":"bool","value":true}}"#)
   }
 }

--- a/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/EntitlementUnknownFieldsTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/EntitlementUnknownFieldsTests.swift
@@ -19,8 +19,14 @@ import Testing
 struct EntitlementUnknownFieldsTests {
   /// The same trip an entitlement makes on its way to a filter:
   /// `JSONEncoder` -> `JSONSerialization` -> `[String: Any]`.
-  private func encodedDictionary(_ entitlement: Entitlement) throws -> [String: Any] {
-    let data = try JSONEncoder().encode(entitlement)
+  private func encodedDictionary(
+    _ entitlement: Entitlement,
+    reportingUnknownFieldsAsNull: Bool = true
+  ) throws -> [String: Any] {
+    let encoder = reportingUnknownFieldsAsNull
+      ? JSONEncoder.reportingUnknownFieldsAsNull()
+      : JSONEncoder()
+    let data = try encoder.encode(entitlement)
     let object = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
     return try #require(object as? [String: Any])
   }
@@ -100,6 +106,18 @@ struct EntitlementUnknownFieldsTests {
     #expect(dictionary["willRenew"] as? Bool == false)
   }
 
+  /// Everything that isn't an audience filter keeps the shape it always had, so
+  /// the enrichment request, paywall variables, session attributes and
+  /// `getDeviceAttributes()` don't start carrying nulls.
+  @Test func unknownFieldsStayOmittedForEveryOtherConsumer() throws {
+    let entitlement = Entitlement(id: "unlimited_access", isActive: true)
+    let dictionary = try encodedDictionary(entitlement, reportingUnknownFieldsAsNull: false)
+
+    for key in ["willRenew", "isLifetime", "state", "offerType", "latestProductId", "store"] {
+      #expect(dictionary.keys.contains(key) == false, "\(key) should be omitted")
+    }
+  }
+
   /// Dates are deliberately left out rather than nulled: filters compare them
   /// with `<` and `>`, and null on either side of an ordering comparison makes
   /// the whole filter evaluate to null.
@@ -110,6 +128,34 @@ struct EntitlementUnknownFieldsTests {
     #expect(dictionary.keys.contains("expiresAt") == false)
     #expect(dictionary.keys.contains("startsAt") == false)
     #expect(dictionary.keys.contains("renewedAt") == false)
+  }
+
+  /// The flag is set on the encoder for the whole device template, and the
+  /// entitlements sit two levels down inside it. This pins that `userInfo`
+  /// reaches a nested encoder, which is what the wiring depends on.
+  @Test func theNullFlagReachesNestedEntitlements() throws {
+    let customerInfo = CustomerInfo(
+      subscriptions: [],
+      nonSubscriptions: [],
+      entitlements: [Entitlement(id: "unlimited_access", isActive: true)],
+      isPlaceholder: false
+    )
+
+    func willRenewEntry(using encoder: JSONEncoder) throws -> (present: Bool, isNull: Bool) {
+      let data = try encoder.encode(customerInfo)
+      let object = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+      let dictionary = try #require(object as? [String: Any])
+      let entitlements = try #require(dictionary["entitlements"] as? [[String: Any]])
+      let entitlement = try #require(entitlements.first)
+      return (entitlement.keys.contains("willRenew"), entitlement["willRenew"] is NSNull)
+    }
+
+    let forFilters = try willRenewEntry(using: .reportingUnknownFieldsAsNull())
+    #expect(forFilters.present)
+    #expect(forFilters.isNull)
+
+    let forEveryoneElse = try willRenewEntry(using: JSONEncoder())
+    #expect(forEveryoneElse.present == false)
   }
 
   @Test func nsNullBecomesPassableNull() {


### PR DESCRIPTION
## What

An entitlement supplied by a **Purchase Controller** carries no renewal metadata — `willRenew`, `isLifetime`, `state`, `offerType` are all `nil`. `Entitlement.encode(to:)` used `encodeIfPresent`, which drops those keys entirely.

Audience filters give a missing key the **type default**, so `willRenew` read as `false` and a bare active entitlement matched an audience like *"active and will not renew"*:

```json
{ "identifier": "unlimited_access", "isActive": true }
```

On app 4531 / campaign 37465 that was **all 181 matches** in a 24h window; only 10 of those users had actually turned off renewal, and 53 were explicitly renewing.

## How

Unknown detail fields are written as explicit nulls, which filters treat as unknown rather than as a value. Verified against the shipped Superscript 1.0.15 — no evaluator change needed:

| entitlement | `willRenew == false` |
|---|---|
| `willRenew` unknown | **no match** (was: match) |
| `willRenew: false` | match |
| `willRenew: true` | no match |

`willRenew == null` now answers "is this known?", which was previously impossible to ask.

**Two hops had to change**, and either alone is broken:

1. `Entitlement.encode(to:)` writes the null.
2. `toPassableValue(from:)` gained `case is NSNull: return .null`. Without it the null fell through `default:` → `JSON(NSNull())` → the trailing `reduce` → an **empty map**, which can't be compared to anything (`Map can not be compared to Int(10)`). `PassableValue.null` already existed but was only ever produced when *decoding* results coming back.

## Scoped to audience filters only

`Entitlement.encode(to:)` is the SDK's only entitlement encoder, so nulling unconditionally would also have changed the enrichment request body, the paywall template variables, the session attributes and the public `getDeviceAttributes()` — six new nulls per bare entitlement on surfaces that never needed them.

The nulls are now opt-in via a `reportsUnknownFieldsAsNull` userInfo key, threaded from exactly one call site:

```
makeAudienceFilterAttributes → getDeviceAttributes(reportingUnknownFieldsAsNull: true)
                             → getTemplateDevice → DeviceTemplate.toDictionary(encoder:)
                             → Entitlement.encode → encodeNil
```

Every other caller uses a default `JSONEncoder` and produces byte-identical output to `develop`. Two tests pin both halves, including that `userInfo` survives into *nested* entitlements — the flag is set on the whole template but consumed two levels down.

For the record, the enrichment endpoint would have accepted the nulls anyway: `apps/enrichment-api/src/server.ts` runs no validation on the device payload, and `prepareRequest` destructures eight named fields and never reads entitlement data. The scoping is about not changing shapes that didn't need to change.

## Deliberate exception: dates

`startsAt` / `renewedAt` / `expiresAt` are never nulled. Filters compare them with `<` and `>`, and a null on either side of an ordering comparison makes the whole filter evaluate to null — which then swallows unrelated clauses (`x < 10 || true` is `null`, not `true`). A test pins this so it isn't "tidied up" later.

## Verified, not assumed: the string-valued fields

Four of the six nulled fields encode as strings. Checked against Superscript 1.0.15, comparing present-null to the old absent-key behaviour:

- **Equality is identical either way** — `store == "APP_STORE"` is `false`, `!=` is `true`, `state in [...]` is `false`, and `|| true` short-circuits correctly.
- **String functions error identically either way.** `startsWith`, `matches` and `size` return `Err` for *both* null and absent, because the member rewrite already hands them `null` when the key is missing. So a filter calling a string function on an unknown `latestProductId` already kills the whole audience via the `.failure -> noMatch` path — this PR neither causes nor fixes that. Worth its own issue.

The one genuine flip is `has(e.willRenew)`, false → true. That's the mechanism of the fix rather than a side effect, and it's pinned as a test.

## Scope

Fixes the false-positive half of the issue. Not addressed here: a complete atomic entitlement snapshot from Purchase Controllers, the Expo/RN field preservation and RevenueCat mapping, audience diagnostics naming the evaluation source, and a server-authoritative entitlement option.

The Android side is [Superwall-Android#459](https://github.com/superwall/Superwall-Android/pull/459) — a different bug (a JSON null became the *string* `"null"`). The incident bug can't occur there because Android's `DeviceTemplate` exposes only entitlement ids and types, never the detail fields.

## Testing

- New `EntitlementUnknownFieldsTests` — 13 tests: both hops separately, the incident's exact filter end-to-end through the real Superscript binary (bare / explicit-false / explicit-true / `== null` / `has()`), the four string-valued fields, nested `userInfo` propagation, and that every non-filter consumer still omits the keys.
- Full suite: **989 tests, 0 failures.**
- `swiftlint`: clean on all changed files.

## Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)