### PR TITLE
Fix crash when register is called from more than one thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Fixes duplicate device attribute and subscription status change events being tracked when the subscription status is repeatedly set to the same logical state. As part of this, `subscriptionStatusDidChange` now fires only when the logical status changes — the status case, the set of entitlements, or an entitlement's `isActive` flag. Updates to transaction metadata such as expiry dates or renewal state no longer trigger it; use `customerInfoDidChange` for those.
 - Fixes subscribers with an unexpired subscription being reported as `inactive` on cold launch when the App Store has no purchases to report. Refunded and expired App Store subscriptions still deactivate immediately.
 - Fixes a data race during SDK configuration that Thread Sanitizer flagged on every launch.
+- Fixes a crash when `register` is called from more than one thread at a time.
 - Fixes issue where paying web users could end up having a temporary inactive subscription status if the server temporarily returns no entitlement data for them.
 - Fixes audiences matching users they shouldn't when you use a Purchase Controller.
 

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
@@ -90,8 +90,8 @@ extension Superwall {
     forPlacement placement: Trackable,
     withData placementData: PlacementData
   ) async {
-    // Wait until any register call already in flight is finished before
-    // continuing.
+    // Queue the work behind any register call already in flight and return,
+    // so implicit triggers and `register` calls don't present over each other.
     registerTaskCoordinator.enqueue { [weak self] in
       await self?.internallyHandleImplicitTrigger(
         forPlacement: placement,

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
@@ -90,11 +90,9 @@ extension Superwall {
     forPlacement placement: Trackable,
     withData placementData: PlacementData
   ) async {
-    // Assign the current register task while capturing the previous one.
-    previousRegisterTask = Task { [weak self, previousRegisterTask] in
-      // Wait until the previous register task is finished before continuing.
-      await previousRegisterTask?.value
-
+    // Wait until any register call already in flight is finished before
+    // continuing.
+    registerTaskCoordinator.enqueue { [weak self] in
       await self?.internallyHandleImplicitTrigger(
         forPlacement: placement,
         withData: placementData

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -565,9 +565,9 @@ class ConfigManager {
 
   /// Preloads paywalls referenced by triggers.
   func preloadAllPaywalls() async {
-    // Wait until any preload already in flight is finished before continuing.
-    // Preloading is kicked off from several places (config refresh, retry,
-    // reset, public API), so the queue has to be safe to add to from any thread.
+    // Queue the preload behind any that's already in flight and return. It's
+    // kicked off from several places (config refresh, retry, reset, public
+    // API), so the queue has to be safe to add to from any thread.
     preloadingCoordinator.enqueue { [weak self] in
       guard let self = self else {
         return

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -44,9 +44,9 @@ class ConfigManager {
   private unowned let webEntitlementRedeemer: WebEntitlementRedeemer
   let expressionEvaluator: CELEvaluator
 
-  /// Serializes preloading so concurrent callers can't race on the task
+  /// Runs preloads one at a time so concurrent callers can't race on the task
   /// reference. See ``preloadAllPaywalls()``.
-  private let preloadingCoordinator = PreloadingTaskCoordinator()
+  private let preloadingCoordinator = SerialTaskCoordinator()
 
   typealias Factory = RequestFactory
     & AudienceFilterAttributesFactory
@@ -565,13 +565,10 @@ class ConfigManager {
 
   /// Preloads paywalls referenced by triggers.
   func preloadAllPaywalls() async {
-    // Chain onto any in-flight preload through the coordinator. The coordinator
-    // is an actor, so swapping in the new task is serialized. Previously this was
-    // `self.currentPreloadingTask = Task { ... }` on a non-isolated class, so
-    // concurrent callers (config refresh, retry, reset, public API) raced on the
-    // task reference and over-released it, crashing in `swift_release` during
-    // task teardown.
-    await preloadingCoordinator.enqueue { [weak self] in
+    // Wait until any preload already in flight is finished before continuing.
+    // Preloading is kicked off from several places (config refresh, retry,
+    // reset, public API), so the queue has to be safe to add to from any thread.
+    preloadingCoordinator.enqueue { [weak self] in
       guard let self = self else {
         return
       }
@@ -609,23 +606,6 @@ class ConfigManager {
         paywallIds.remove(presentedPaywallId)
       }
       await self.preloadPaywalls(withIdentifiers: paywallIds)
-    }
-  }
-
-  /// Serializes the read-modify-write of the preloading task so it can't be
-  /// mutated from multiple tasks at once. Each enqueued operation runs only
-  /// after the previously enqueued one finishes, preserving the original
-  /// chaining behavior while making the swap data-race free.
-  private actor PreloadingTaskCoordinator {
-    private var currentTask: Task<Void, Never>?
-
-    /// Atomically chains `operation` after any in-flight preloading task.
-    func enqueue(_ operation: @escaping @Sendable () async -> Void) {
-      let previous = currentTask
-      currentTask = Task {
-        await previous?.value
-        await operation()
-      }
     }
   }
 

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -46,7 +46,7 @@ class ConfigManager {
 
   /// Runs preloads one at a time so concurrent callers can't race on the task
   /// reference. See ``preloadAllPaywalls()``.
-  private let preloadingCoordinator = SerialTaskCoordinator(label: "preloading")
+  private let preloadingCoordinator = SerialTaskCoordinator()
 
   typealias Factory = RequestFactory
     & AudienceFilterAttributesFactory

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -46,7 +46,7 @@ class ConfigManager {
 
   /// Runs preloads one at a time so concurrent callers can't race on the task
   /// reference. See ``preloadAllPaywalls()``.
-  private let preloadingCoordinator = SerialTaskCoordinator()
+  private let preloadingCoordinator = SerialTaskCoordinator(label: "preloading")
 
   typealias Factory = RequestFactory
     & AudienceFilterAttributesFactory

--- a/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
+++ b/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
@@ -60,10 +60,9 @@ final class SerialTaskCoordinator: Sendable {
   /// enqueued before it has finished.
   func enqueue(_ operation: @escaping Operation) {
     // Run the operation at the priority of whoever enqueued it. The task
-    // draining the stream takes its priority from the thread that made the
-    // coordinator, which is whoever called `configure()` — without this, an app
-    // configuring off the main thread would pin every later operation to that
-    // thread's priority for the rest of the process.
+    // draining the stream takes its priority from whatever made the
+    // coordinator — without this, one made on a low-priority thread would pin
+    // every later operation to that priority for as long as it lives.
     let priority = Task.currentPriority
     continuation.yield {
       await Task(priority: priority) {

--- a/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
+++ b/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
@@ -61,13 +61,4 @@ final class SerialTaskCoordinator {
   func enqueue(_ operation: @escaping Operation) {
     continuation.yield(operation)
   }
-
-  /// Waits for everything enqueued so far to finish.
-  func drain() async {
-    await withCheckedContinuation { continuation in
-      enqueue {
-        continuation.resume()
-      }
-    }
-  }
 }

--- a/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
+++ b/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
@@ -25,28 +25,33 @@ import Foundation
 /// it's torn down. It also loses one of the two new tasks, so the chaining the
 /// code is there to provide silently stops happening.
 ///
-/// Holding the swap behind a lock fixes both.
+/// Doing the swap on a serial queue fixes both. Only the swap runs on the
+/// queue — making a task doesn't start it — so a caller never waits on the
+/// work itself, only on another caller's swap.
 final class SerialTaskCoordinator: @unchecked Sendable {
-  private let lock = NSLock()
+  private let queue: DispatchQueue
   private var currentTask: Task<Void, Never>?
 
   /// The task at the end of the queue, if there is one.
   var lastTask: Task<Void, Never>? {
-    lock.lock()
-    defer { lock.unlock() }
-    return currentTask
+    queue.sync { currentTask }
+  }
+
+  /// - Parameter label: Names the queue so it can be told apart from other
+  /// coordinators in crash reports and Instruments.
+  init(label: String) {
+    queue = DispatchQueue(label: "com.superwall.\(label)")
   }
 
   /// Adds `operation` to the end of the queue. It starts only after everything
   /// enqueued before it has finished.
   func enqueue(_ operation: @escaping @Sendable () async -> Void) {
-    lock.lock()
-    defer { lock.unlock() }
-
-    let previous = currentTask
-    currentTask = Task {
-      await previous?.value
-      await operation()
+    queue.sync {
+      let previous = currentTask
+      currentTask = Task {
+        await previous?.value
+        await operation()
+      }
     }
   }
 }

--- a/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
+++ b/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
@@ -1,0 +1,52 @@
+//
+//  SerialTaskCoordinator.swift
+//
+//
+//  Created by Yusuf Tör on 11/09/2026.
+//
+
+import Foundation
+
+/// Runs enqueued operations one at a time, in the order they were enqueued.
+///
+/// The usual way of doing this is to keep the last task in a property and swap
+/// it for a new task that waits on the old one:
+///
+/// ```swift
+/// previousTask = Task { [previousTask] in
+///   await previousTask?.value
+///   ...
+/// }
+/// ```
+///
+/// That read and that write aren't a single step, so when callers arrive on
+/// different threads two of them can read the same previous task and both
+/// release it. That over-releases the task and crashes in `swift_release` when
+/// it's torn down. It also loses one of the two new tasks, so the chaining the
+/// code is there to provide silently stops happening.
+///
+/// Holding the swap behind a lock fixes both.
+final class SerialTaskCoordinator: @unchecked Sendable {
+  private let lock = NSLock()
+  private var currentTask: Task<Void, Never>?
+
+  /// The task at the end of the queue, if there is one.
+  var lastTask: Task<Void, Never>? {
+    lock.lock()
+    defer { lock.unlock() }
+    return currentTask
+  }
+
+  /// Adds `operation` to the end of the queue. It starts only after everything
+  /// enqueued before it has finished.
+  func enqueue(_ operation: @escaping @Sendable () async -> Void) {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let previous = currentTask
+    currentTask = Task {
+      await previous?.value
+      await operation()
+    }
+  }
+}

--- a/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
+++ b/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
@@ -25,32 +25,48 @@ import Foundation
 /// it's torn down. It also loses one of the two new tasks, so the chaining the
 /// code is there to provide silently stops happening.
 ///
-/// Doing the swap on a serial queue fixes both. Only the swap runs on the
-/// queue — making a task doesn't start it — so a caller never waits on the
-/// work itself, only on another caller's swap.
-final class SerialTaskCoordinator: @unchecked Sendable {
-  private let queue: DispatchQueue
-  private var currentTask: Task<Void, Never>?
+/// Handing operations to a single long-lived task through a stream avoids the
+/// problem rather than guarding it: there's no task reference to swap. The
+/// stream keeps them in the order they were handed over, and ``enqueue(_:)``
+/// only hands one over, so no caller ever waits — including callers already
+/// running on the concurrency pool.
+final class SerialTaskCoordinator {
+  typealias Operation = @Sendable () async -> Void
 
-  /// The task at the end of the queue, if there is one.
-  var lastTask: Task<Void, Never>? {
-    queue.sync { currentTask }
+  private let continuation: AsyncStream<Operation>.Continuation
+
+  init() {
+    // `AsyncStream` hands over the continuation before its initializer
+    // returns, so this is always set by the time it's read.
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    var continuation: AsyncStream<Operation>.Continuation!
+    let operations = AsyncStream<Operation>(bufferingPolicy: .unbounded) {
+      continuation = $0
+    }
+    self.continuation = continuation
+
+    Task {
+      for await operation in operations {
+        await operation()
+      }
+    }
   }
 
-  /// - Parameter label: Names the queue so it can be told apart from other
-  /// coordinators in crash reports and Instruments.
-  init(label: String) {
-    queue = DispatchQueue(label: "com.superwall.\(label)")
+  deinit {
+    continuation.finish()
   }
 
   /// Adds `operation` to the end of the queue. It starts only after everything
   /// enqueued before it has finished.
-  func enqueue(_ operation: @escaping @Sendable () async -> Void) {
-    queue.sync {
-      let previous = currentTask
-      currentTask = Task {
-        await previous?.value
-        await operation()
+  func enqueue(_ operation: @escaping Operation) {
+    continuation.yield(operation)
+  }
+
+  /// Waits for everything enqueued so far to finish.
+  func drain() async {
+    await withCheckedContinuation { continuation in
+      enqueue {
+        continuation.resume()
       }
     }
   }

--- a/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
+++ b/Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift
@@ -30,7 +30,7 @@ import Foundation
 /// stream keeps them in the order they were handed over, and ``enqueue(_:)``
 /// only hands one over, so no caller ever waits — including callers already
 /// running on the concurrency pool.
-final class SerialTaskCoordinator {
+final class SerialTaskCoordinator: Sendable {
   typealias Operation = @Sendable () async -> Void
 
   private let continuation: AsyncStream<Operation>.Continuation
@@ -59,6 +59,17 @@ final class SerialTaskCoordinator {
   /// Adds `operation` to the end of the queue. It starts only after everything
   /// enqueued before it has finished.
   func enqueue(_ operation: @escaping Operation) {
-    continuation.yield(operation)
+    // Run the operation at the priority of whoever enqueued it. The task
+    // draining the stream takes its priority from the thread that made the
+    // coordinator, which is whoever called `configure()` — without this, an app
+    // configuring off the main thread would pin every later operation to that
+    // thread's priority for the rest of the process.
+    let priority = Task.currentPriority
+    continuation.yield {
+      await Task(priority: priority) {
+        await operation()
+      }
+      .value
+    }
   }
 }

--- a/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
@@ -196,11 +196,9 @@ extension Superwall {
           }
         ))
 
-    // Assign the current register task while capturing the previous one.
-    previousRegisterTask = Task { [weak self, previousRegisterTask] in
-      // Wait until the previous task is finished before continuing.
-      await previousRegisterTask?.value
-
+    // Wait until any register call already in flight is finished before
+    // continuing.
+    registerTaskCoordinator.enqueue { [weak self] in
       await self?.trackAndPresentPaywall(
         forPlacement: placement,
         params: params,

--- a/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
@@ -196,8 +196,9 @@ extension Superwall {
           }
         ))
 
-    // Wait until any register call already in flight is finished before
-    // continuing.
+    // Queue the work behind any register call already in flight and return.
+    // `register` can be called from any thread, so the queue has to be safe to
+    // add to from any thread.
     registerTaskCoordinator.enqueue { [weak self] in
       await self?.trackAndPresentPaywall(
         forPlacement: placement,

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -119,7 +119,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   private var didReceiveStripeCheckoutAbandonMessage = false
 
   /// Ensures Stripe checkout callbacks are forwarded to WebEntitlementRedeemer in order.
-  private var previousStripeCheckoutTask: Task<Void, Never>?
+  private let stripeCheckoutCoordinator = SerialTaskCoordinator()
 
   /// Manages intro offer eligibility tokens for SK2 purchases on iOS 18.2+
   let introOfferTokenManager: IntroOfferTokenManager
@@ -1266,10 +1266,9 @@ extension PaywallViewController: PaywallMessageHandlerDelegate {
   private func enqueueStripeCheckoutTask(
     _ operation: @escaping (PaywallViewController) async -> Void
   ) {
-    // Assign the current Stripe task while capturing the previous one.
-    previousStripeCheckoutTask = Task { [weak self, previousStripeCheckoutTask] in
-      // Wait until the previous task is finished before continuing.
-      await previousStripeCheckoutTask?.value
+    // Queue the callback behind any already in flight and return. The closure
+    // stays on the main actor so the callbacks run where they always have.
+    stripeCheckoutCoordinator.enqueue { @MainActor [weak self] in
       guard let self else {
         return
       }

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -389,8 +389,11 @@ public final class Superwall: NSObject, ObservableObject {
   /// Handles all dependencies.
   let dependencyContainer: DependencyContainer
 
-  /// Used to serially execute register calls.
-  var previousRegisterTask: Task<Void, Never>?
+  /// Runs register calls one at a time, in the order they came in.
+  ///
+  /// `register(placement:)` can be called from any thread, so the queue of
+  /// register tasks has to be safe to add to from any thread.
+  let registerTaskCoordinator = SerialTaskCoordinator()
 
   /// The integration attributes to send to the server when `appTransactionId`
   /// is available. Protected by a queue for thread safety.

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -393,7 +393,7 @@ public final class Superwall: NSObject, ObservableObject {
   ///
   /// `register(placement:)` can be called from any thread, so the queue of
   /// register tasks has to be safe to add to from any thread.
-  let registerTaskCoordinator = SerialTaskCoordinator(label: "register")
+  let registerTaskCoordinator = SerialTaskCoordinator()
 
   /// The integration attributes to send to the server when `appTransactionId`
   /// is available. Protected by a queue for thread safety.

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -393,7 +393,7 @@ public final class Superwall: NSObject, ObservableObject {
   ///
   /// `register(placement:)` can be called from any thread, so the queue of
   /// register tasks has to be safe to add to from any thread.
-  let registerTaskCoordinator = SerialTaskCoordinator()
+  let registerTaskCoordinator = SerialTaskCoordinator(label: "register")
 
   /// The integration attributes to send to the server when `appTransactionId`
   /// is available. Protected by a queue for thread safety.

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		213E7FC262106BFBC44462AC /* SWLocalizationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE7D1E1AF61D199E17B5C05 /* SWLocalizationViewController.swift */; };
 		2205A0CC8F059B3D6231C603 /* PaywallLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7140A8B0B006F2080D8915 /* PaywallLogicTests.swift */; };
 		2231B31B4B9A25778069B20A /* PaddleProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F17CFCD6B3B96A609A5B870 /* PaddleProduct.swift */; };
+		223E12D4EDBF41D8F5515E53 /* SerialTaskCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D555619C0738B6016C62DF0E /* SerialTaskCoordinator.swift */; };
 		225D6F5363B1520744EABD86 /* RedeemResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C339E7D08CDD7B1808AD4069 /* RedeemResponseTests.swift */; };
 		22B3763157DF592D4E3B27A0 /* InAppReceipt+ASN1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E80C81546752BCF32016A27 /* InAppReceipt+ASN1.swift */; };
 		234C1753A4606242CA765CA7 /* ManagedTriggerRuleOccurrence.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFFBE357699F5CAAB803DA7 /* ManagedTriggerRuleOccurrence.swift */; };
@@ -144,6 +145,7 @@
 		3CB65E105ADED11AEE69DEAF /* InAppReceiptAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9553EC1E394EF7AE8788291 /* InAppReceiptAttribute.swift */; };
 		3CD2C23BAC2EA11174237785 /* AttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7CFAF4B3E32AE628A249C8 /* AttributionTests.swift */; };
 		3CF2307C2CB994D00A35FADD /* LoadingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866F99509EDFBE8BAE10E575 /* LoadingModel.swift */; };
+		3D5684BAF13C86ABED458EB9 /* SerialTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224B526C168B5DB83E1F50D2 /* SerialTaskCoordinatorTests.swift */; };
 		3DCE95BAC148CCC7E6E7F608 /* DeviceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E5C31CEEDC9C2853D91C50 /* DeviceTemplate.swift */; };
 		3EA92DE86764CBAC557F8522 /* Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E41300E7467F017BCD5E5C /* Capabilities.swift */; };
 		3EE4C1C4EC45718C2EED34E5 /* EventTrackingBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8033AAF5549E30ACDA3EA /* EventTrackingBehavior.swift */; };
@@ -677,6 +679,7 @@
 		21903EACCA9AA13BB10917EC /* PermissionHandler+Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PermissionHandler+Camera.swift"; sourceTree = "<group>"; };
 		21C52F36F0BFF59363EBB4C7 /* GameControllerEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerEvent.swift; sourceTree = "<group>"; };
 		22439CFFFC5166F34D0DA524 /* WebViewURLConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewURLConfig.swift; sourceTree = "<group>"; };
+		224B526C168B5DB83E1F50D2 /* SerialTaskCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialTaskCoordinatorTests.swift; sourceTree = "<group>"; };
 		22919EFD263425D38E7D9D38 /* WebEntitlementRedeemer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebEntitlementRedeemer.swift; sourceTree = "<group>"; };
 		22D96B4C9B546F7B0EC73397 /* PaywallViewControllerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerWrapper.swift; sourceTree = "<group>"; };
 		23307BBFD80385233DDD4C43 /* AssetResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetResource.swift; sourceTree = "<group>"; };
@@ -1123,6 +1126,7 @@
 		D449672964023589DA5535E3 /* String+MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MD5.swift"; sourceTree = "<group>"; };
 		D47AA8B18B4570F0C24B7389 /* Encoder+ReportsUnknownFieldsAsNull.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encoder+ReportsUnknownFieldsAsNull.swift"; sourceTree = "<group>"; };
 		D4F676D3A0F5B540052D36B1 /* PublicGetPresentationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGetPresentationResult.swift; sourceTree = "<group>"; };
+		D555619C0738B6016C62DF0E /* SerialTaskCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialTaskCoordinator.swift; sourceTree = "<group>"; };
 		D561728FDB68F572D5E33223 /* PermissionsHandler+Contacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PermissionsHandler+Contacts.swift"; sourceTree = "<group>"; };
 		D570217FF965FF087585931C /* PaywallPreloadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPreloadingTests.swift; sourceTree = "<group>"; };
 		D5BF66C3986E287B7B2F5E27 /* SKProductSubscriptionPeriodMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKProductSubscriptionPeriodMock.swift; sourceTree = "<group>"; };
@@ -1905,6 +1909,7 @@
 		4D7656D6A565958F58A644AF /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				224B526C168B5DB83E1F50D2 /* SerialTaskCoordinatorTests.swift */,
 				F2F75130AF54DFC4C7FA839A /* Extensions */,
 			);
 			path = Misc;
@@ -3037,6 +3042,7 @@
 				7ABC4A0048583B47040C498B /* DispatchQueueBacked.swift */,
 				E09C238ADC0B019047FAB1DF /* JSONToDict.swift */,
 				2E2027BFC214905CBE589AF2 /* KeypathWritable.swift */,
+				D555619C0738B6016C62DF0E /* SerialTaskCoordinator.swift */,
 				19F010DC597017F5BEAEDE86 /* SwiftyJSON.swift */,
 				62EC6A60945A85646E1230C1 /* ThrowableDecodable.swift */,
 				848592ACE8760E53F2163F01 /* Typealiases.swift */,
@@ -3401,6 +3407,7 @@
 				E1A838C9CE62C9479D0C68F4 /* SWDebugManagerLogicTests.swift in Sources */,
 				C77A626D379969A86B900488 /* SWWebViewLoadingHandlerTests.swift in Sources */,
 				EE5646D09161237C649731F4 /* SWWebViewLogicTests.swift in Sources */,
+				3D5684BAF13C86ABED458EB9 /* SerialTaskCoordinatorTests.swift in Sources */,
 				919A08D7F25BD2DF27A22697 /* StorageMock.swift in Sources */,
 				713A1F9D9861C6A1E5EB9174 /* StorageTests.swift in Sources */,
 				701B1B586B6C1E3F0B3AF560 /* StoreKitManagerTests.swift in Sources */,
@@ -3750,6 +3757,7 @@
 				CE411644469AB99AC9DBB492 /* SWWebViewLoadingHandler.swift in Sources */,
 				074EBBBF7E3B2B207B00A275 /* SWWebViewLogic.swift in Sources */,
 				1753820CBFBDD8FF70455D71 /* ScaleAnimation.swift in Sources */,
+				223E12D4EDBF41D8F5515E53 /* SerialTaskCoordinator.swift in Sources */,
 				AD5EBB6DBA919E3CBC5B85B7 /* SessionEventsRequest.swift in Sources */,
 				5A6D06700C4E4E2C6C9BC1B2 /* ShimmerView.swift in Sources */,
 				18B147198F2E19C69013BA4B /* Sk1StoreProduct.swift in Sources */,

--- a/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
+++ b/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
@@ -131,7 +131,9 @@ struct SerialTaskCoordinatorTests {
   @Test("Operations run at the priority of whoever enqueued them")
   func runsAtEnqueuersPriority() async {
     // The coordinator is made here, so the task draining its stream takes this
-    // context's priority — the stand-in for an app calling `configure()`.
+    // context's priority — the stand-in for an app calling `configure()`. If
+    // that's already `.high`, the assertion below can't tell the two apart.
+    #expect(Task.currentPriority < .high)
     let coordinator = SerialTaskCoordinator()
     let recorder = PriorityRecorder()
 

--- a/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
+++ b/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
@@ -23,6 +23,15 @@ extension SerialTaskCoordinator {
 
 @Suite("SerialTaskCoordinator Tests")
 struct SerialTaskCoordinatorTests {
+  /// Records the priority an operation ran at.
+  private actor PriorityRecorder {
+    private(set) var recorded: TaskPriority?
+
+    func record(_ priority: TaskPriority) {
+      recorded = priority
+    }
+  }
+
   /// Records the order operations ran in and how many ran at the same time.
   private actor Recorder {
     private(set) var order: [Int] = []
@@ -117,5 +126,24 @@ struct SerialTaskCoordinatorTests {
 
     let order = await recorder.order
     #expect(order == [0, 1])
+  }
+
+  @Test("Operations run at the priority of whoever enqueued them")
+  func runsAtEnqueuersPriority() async {
+    // The coordinator is made here, so the task draining its stream takes this
+    // context's priority — the stand-in for an app calling `configure()`.
+    let coordinator = SerialTaskCoordinator()
+    let recorder = PriorityRecorder()
+
+    await Task(priority: .high) {
+      coordinator.enqueue {
+        await recorder.record(Task.currentPriority)
+      }
+    }
+    .value
+    await coordinator.drain()
+
+    let recorded = await recorder.recorded
+    #expect(recorded == .high)
   }
 }

--- a/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
+++ b/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
@@ -10,6 +10,17 @@ import Testing
 
 @testable import SuperwallKit
 
+extension SerialTaskCoordinator {
+  /// Waits for everything enqueued so far to finish.
+  fileprivate func drain() async {
+    await withCheckedContinuation { continuation in
+      enqueue {
+        continuation.resume()
+      }
+    }
+  }
+}
+
 @Suite("SerialTaskCoordinator Tests")
 struct SerialTaskCoordinatorTests {
   /// Records the order operations ran in and how many ran at the same time.

--- a/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
+++ b/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
@@ -31,7 +31,7 @@ struct SerialTaskCoordinatorTests {
 
   @Test("Operations run in the order they were enqueued")
   func runsOperationsInOrder() async {
-    let coordinator = SerialTaskCoordinator()
+    let coordinator = SerialTaskCoordinator(label: "test")
     let recorder = Recorder()
 
     for id in 0..<20 {
@@ -51,7 +51,7 @@ struct SerialTaskCoordinatorTests {
 
   @Test("Only one operation runs at a time when enqueued from many threads")
   func runsOneOperationAtATimeAcrossThreads() async {
-    let coordinator = SerialTaskCoordinator()
+    let coordinator = SerialTaskCoordinator(label: "test")
     let recorder = Recorder()
     let operationCount = 200
 
@@ -89,7 +89,7 @@ struct SerialTaskCoordinatorTests {
 
   @Test("Operations enqueued after the queue has drained still run")
   func runsOperationsEnqueuedAfterDraining() async {
-    let coordinator = SerialTaskCoordinator()
+    let coordinator = SerialTaskCoordinator(label: "test")
     let recorder = Recorder()
 
     coordinator.enqueue {

--- a/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
+++ b/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
@@ -31,7 +31,7 @@ struct SerialTaskCoordinatorTests {
 
   @Test("Operations run in the order they were enqueued")
   func runsOperationsInOrder() async {
-    let coordinator = SerialTaskCoordinator(label: "test")
+    let coordinator = SerialTaskCoordinator()
     let recorder = Recorder()
 
     for id in 0..<20 {
@@ -41,7 +41,7 @@ struct SerialTaskCoordinatorTests {
         await recorder.didFinish()
       }
     }
-    await coordinator.lastTask?.value
+    await coordinator.drain()
 
     let order = await recorder.order
     let maxRunningAtOnce = await recorder.maxRunningAtOnce
@@ -51,7 +51,7 @@ struct SerialTaskCoordinatorTests {
 
   @Test("Only one operation runs at a time when enqueued from many threads")
   func runsOneOperationAtATimeAcrossThreads() async {
-    let coordinator = SerialTaskCoordinator(label: "test")
+    let coordinator = SerialTaskCoordinator()
     let recorder = Recorder()
     let operationCount = 200
 
@@ -75,7 +75,7 @@ struct SerialTaskCoordinatorTests {
         continuation.resume()
       }
     }
-    await coordinator.lastTask?.value
+    await coordinator.drain()
 
     let order = await recorder.order
     let maxRunningAtOnce = await recorder.maxRunningAtOnce
@@ -89,20 +89,20 @@ struct SerialTaskCoordinatorTests {
 
   @Test("Operations enqueued after the queue has drained still run")
   func runsOperationsEnqueuedAfterDraining() async {
-    let coordinator = SerialTaskCoordinator(label: "test")
+    let coordinator = SerialTaskCoordinator()
     let recorder = Recorder()
 
     coordinator.enqueue {
       await recorder.didStart(0)
       await recorder.didFinish()
     }
-    await coordinator.lastTask?.value
+    await coordinator.drain()
 
     coordinator.enqueue {
       await recorder.didStart(1)
       await recorder.didFinish()
     }
-    await coordinator.lastTask?.value
+    await coordinator.drain()
 
     let order = await recorder.order
     #expect(order == [0, 1])

--- a/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
+++ b/Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift
@@ -1,0 +1,110 @@
+//
+//  SerialTaskCoordinatorTests.swift
+//  SuperwallKitTests
+//
+//  Created by Yusuf Tör on 11/09/2026.
+//
+
+import Foundation
+import Testing
+
+@testable import SuperwallKit
+
+@Suite("SerialTaskCoordinator Tests")
+struct SerialTaskCoordinatorTests {
+  /// Records the order operations ran in and how many ran at the same time.
+  private actor Recorder {
+    private(set) var order: [Int] = []
+    private(set) var maxRunningAtOnce = 0
+    private var runningAtOnce = 0
+
+    func didStart(_ id: Int) {
+      order.append(id)
+      runningAtOnce += 1
+      maxRunningAtOnce = max(maxRunningAtOnce, runningAtOnce)
+    }
+
+    func didFinish() {
+      runningAtOnce -= 1
+    }
+  }
+
+  @Test("Operations run in the order they were enqueued")
+  func runsOperationsInOrder() async {
+    let coordinator = SerialTaskCoordinator()
+    let recorder = Recorder()
+
+    for id in 0..<20 {
+      coordinator.enqueue {
+        await recorder.didStart(id)
+        await Task.yield()
+        await recorder.didFinish()
+      }
+    }
+    await coordinator.lastTask?.value
+
+    let order = await recorder.order
+    let maxRunningAtOnce = await recorder.maxRunningAtOnce
+    #expect(order == Array(0..<20))
+    #expect(maxRunningAtOnce == 1)
+  }
+
+  @Test("Only one operation runs at a time when enqueued from many threads")
+  func runsOneOperationAtATimeAcrossThreads() async {
+    let coordinator = SerialTaskCoordinator()
+    let recorder = Recorder()
+    let operationCount = 200
+
+    await withCheckedContinuation { continuation in
+      let group = DispatchGroup()
+
+      for id in 0..<operationCount {
+        group.enter()
+        let queue = DispatchQueue.global(qos: id.isMultiple(of: 2) ? .userInitiated : .utility)
+        queue.async {
+          coordinator.enqueue {
+            await recorder.didStart(id)
+            await Task.yield()
+            await recorder.didFinish()
+          }
+          group.leave()
+        }
+      }
+
+      group.notify(queue: .global()) {
+        continuation.resume()
+      }
+    }
+    await coordinator.lastTask?.value
+
+    let order = await recorder.order
+    let maxRunningAtOnce = await recorder.maxRunningAtOnce
+    // Every operation runs exactly once, and never alongside another one. If the
+    // swap of the task reference weren't serialized, two operations enqueued at
+    // the same time would each wait on the same predecessor and then overlap.
+    #expect(order.count == operationCount)
+    #expect(Set(order).count == operationCount)
+    #expect(maxRunningAtOnce == 1)
+  }
+
+  @Test("Operations enqueued after the queue has drained still run")
+  func runsOperationsEnqueuedAfterDraining() async {
+    let coordinator = SerialTaskCoordinator()
+    let recorder = Recorder()
+
+    coordinator.enqueue {
+      await recorder.didStart(0)
+      await recorder.didFinish()
+    }
+    await coordinator.lastTask?.value
+
+    coordinator.enqueue {
+      await recorder.didStart(1)
+      await recorder.didFinish()
+    }
+    await coordinator.lastTask?.value
+
+    let order = await recorder.order
+    #expect(order == [0, 1])
+  }
+}


### PR DESCRIPTION
## The bug

`register(placement:)` can be called from any thread, but the task that serializes register calls was swapped with an unsynchronized read-modify-write on the non-isolated `Superwall` class:

```swift
previousRegisterTask = Task { [weak self, previousRegisterTask] in
  await previousRegisterTask?.value
  ...
}
```

The read (in the capture list) and the write (the assignment) aren't one step. Two callers on different threads read the same previous task and both release it, which over-releases it and crashes in `swift_release` while it's torn down. It also drops one of the two new tasks, so the serialization the property exists to provide silently stops happening.

Fixes #364. Very likely also fixes #476 — the frames blamed there (`_NativeSet.filter` at `ConfigManager.swift:622`, `closure #1 in Superwall.gamepadValueChanged`) sit between `_swift_release_dealloc` / `doDecrementSlow` pairs and carry nonsense offsets, so they're teardown helpers attributed to the nearest symbol rather than real call sites. `gamepadValueChanged` only runs `Task { @MainActor in … }` and the crashing thread is a cooperative pool worker, so that closure can't be what's executing. The crash itself is the release cascade above.

## The fix

Rather than guard the swap, remove it. `SerialTaskCoordinator` hands operations to a single long-lived consumer task through an `AsyncStream`:

```swift
Task {
  for await operation in operations {
    await operation()
  }
}

func enqueue(_ operation: @escaping Operation) {
  continuation.yield(operation)
}
```

There's no task reference to race on, so the crash stops being possible rather than being locked against. Nothing blocks, either — which matters because `ConfigManager.preloadAllPaywalls()` is `async` and runs on the cooperative pool, where a blocking primitive would be holding one of its threads.

The same coordinator now covers preloading, which had this exact bug (that half was fixed separately in 4.16.0).

The commits walk through a lock and a dispatch queue before landing here; both worked, both are measured below, and neither removes the swap itself.

## Verification

Reverting `enqueue` to the racy swap reproduces both faces of the bug in one run. Thread Sanitizer flags it:

```
WARNING: ThreadSanitizer: data race
  Write of size 8 by thread T8:   SerialTaskCoordinator.enqueue(...)
  Previous read of size 8 by thread T1: SerialTaskCoordinator.enqueue(...)
```

— structurally identical to the `internallyRegister` trace in #364 — and the runtime kills the test process outright:

```
swift::AsyncTask::~AsyncTask()
destroyTask(swift::HeapObject*)
_swift_release_dealloc
doDecrementSlow
```

With the fix: coordinator suite green across repeated runs, clean under Thread Sanitizer, full suite passes (997 tests), lint clean apart from one pre-existing violation in `SK1ReceiptManager.swift`.

Caller latency, 20k samples, against six threads hammering the same coordinator and in a 40-one-shot-caller burst shaped like the #364 repro:

| Scenario | | median | p99 | max |
|---|---|---|---|---|
| 6 competitors, equal priority | NSLock | 459 ns | 94 µs | 387 µs |
| | DispatchQueue | 35 µs | 69 µs | 161 µs |
| | AsyncStream | 625 ns | 30 µs | 154 µs |
| 40 one-shot callers | NSLock | 2.7 µs | 227 µs | 261 µs |
| | DispatchQueue | 6.6 µs | 65 µs | 72 µs |
| | AsyncStream | 2.0 µs | 41 µs | 71 µs |

(Re-measured against the shipped implementation, per-operation `Task` included.)

All three stay well under a millisecond, so this was a design call rather than a performance one.

## Notes for review

- **Deployment floor — what was verified, and what can't be.** `AsyncStream` is `@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)`, the same back-deployment annotation as `Task`, which the SDK already uses unguarded; `Continuation`, `init(_:bufferingPolicy:_:)`, `yield` and `finish` inherit it. Type-checked clean at `-target arm64-apple-ios13.0-simulator`.

  Running it against the back-deployed concurrency library is **not reachable on this toolchain**, and that's a recorded decision rather than an omission. Three constraints stack up:

  | Constraint | Floor |
  |---|---|
  | Xcode 27 simulator SDK (`MinimumDeploymentTarget = 15.0`) | can't **build** below iOS 15 |
  | `Testing.framework` links `libswiftRegexBuilder` (iOS 16+) | harness won't launch on iOS 15.4 |
  | Xcode 27 `XCTestCore` needs a `libswiftCore` symbol iOS 16.4 lacks | harness won't launch on iOS 16.4 |

  Back-deployment only engages *below* iOS 15, and that's exactly what can't be built — so no destination produces a binary using it. The suite was run on the oldest runtime that will host it: **iOS 18.6, 4/4 green**, alongside the usual iOS 27 run.

  Worth noting this gap isn't introduced here. `AsyncStream` is no more back-deployed than `Task` or `async`/`await`, which this SDK already ships hundreds of uses of on the same floor. Whether an iOS 13 floor nobody can build or test should stay is a separate call, not one for a crash fix.
- **Don't swap in `makeStream`.** It would collapse the continuation dance and its `swiftlint:disable`, and it's also marked iOS 13.0, but it needs Swift 5.9 while the package declares `swift-tools-version:5.5`.
- **Priority.** `enqueue` captures `Task.currentPriority` and runs the operation at it, so an operation takes its enqueuer's priority rather than the drain task's. One asymmetry to know about: because the drain awaits each operation, this reliably *raises* an operation to its caller's priority but can't hold one below the drain's own — awaiting escalates it back up. Order and isolation are unchanged; the work still hops to whatever actor it needs.

## Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces race-prone task-reference chaining with a reusable `AsyncStream`-backed serial coordinator.
- Serializes public registration and implicit-trigger handling without an unsynchronized task swap.
- Applies the same coordinator to paywall preloading and Stripe checkout callbacks.
- Preserves each enqueuer’s task priority while keeping operations FIFO and mutually exclusive.
- Adds concurrency, ordering, reuse-after-drain, and priority tests.
- Documents the crash fix in the changelog and adds the new source and tests to the Xcode project.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

The new coordinator removes the unsynchronized task-reference read-modify-write while preserving FIFO, single-operation execution and the prior fire-and-forget caller contract across registration, preloading, and Stripe callback paths.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Misc/SerialTaskCoordinator.swift | Introduces a Sendable FIFO coordinator backed by one AsyncStream consumer, removing the raced task-reference swap. |
| Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift | Routes public registration work through the shared serial coordinator. |
| Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift | Serializes implicit-trigger handling with public registration work. |
| Sources/SuperwallKit/Config/ConfigManager.swift | Replaces the preload-specific task coordinator with the shared nonblocking coordinator. |
| Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift | Serializes Stripe checkout callbacks while preserving main-actor execution. |
| Tests/SuperwallKitTests/Misc/SerialTaskCoordinatorTests.swift | Covers FIFO execution, cross-thread mutual exclusion, queue reuse, and caller-priority propagation. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Concurrent register, preload, or Stripe callers] --> B[SerialTaskCoordinator.enqueue]
  B --> C[AsyncStream continuation]
  C --> D[Single consumer task]
  D --> E[Operation at captured caller priority]
  E --> F{More queued work?}
  F -->|Yes| D
  F -->|No| G[Wait for next operation]
```

<sub>Reviews (2): Last reviewed commit: ["Guard the priority test, and correct a c..."](https://github.com/superwall/superwall-ios/commit/4ffdb41ca189b0d5cb744ea5d8d0a67f9193f983) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63094829)</sub>

<!-- /greptile_comment -->